### PR TITLE
Update alerts.yaml

### DIFF
--- a/charts/cnpg-sandbox/alerts.yaml
+++ b/charts/cnpg-sandbox/alerts.yaml
@@ -33,7 +33,7 @@ groups:
       description: Standby is lagging behind by over 300 seconds (5 minutes)
       summary: The standby is lagging behind the primary
     expr: |-
-      cnpg_pg_database_xid_age > 150000000
+      cnpg_pg_replication_lag > 300
     for: 1m
     labels:
       severity: warning


### PR DESCRIPTION
The default Replication Lag alerts is using the expression for transaction id age rather cnpg_replication_lag.

Current on main:

  - alert: PGReplication
    annotations:
      description: Standby is lagging behind by over 300 seconds (5 minutes)
      summary: The standby is lagging behind the primary
    expr: |-
      cnpg_pg_database_xid_age > 150000000
    for: 1m
    labels:
      severity: warning 

Should be:

- alert: PGReplication
    annotations:
      description: Standby is lagging behind by over 300 seconds (5 minutes)
      summary: The standby is lagging behind the primary
    expr: |-
      cnpg_replication_lag > 300
    for: 1m
    labels:
      severity: warning


Signed-off-by: theadamwright <theadamwright@gmail.com>