### PR TITLE
Updates sandbox monitoring configmap to cnpg-default-monitoring

### DIFF
--- a/charts/cnpg-sandbox/values.yaml
+++ b/charts/cnpg-sandbox/values.yaml
@@ -74,7 +74,7 @@ cloudnative-pg:
   config:
     create: true
     data:
-      MONITORING_QUERIES_CONFIGMAP: default-monitoring-queries
+      MONITORING_QUERIES_CONFIGMAP: cnpg-default-monitoring
 
 defaultAlerts: true
 defaultDashboard: true


### PR DESCRIPTION
As described here: https://github.com/cloudnative-pg/cloudnative-pg/issues/811 I ran into an issue with deploying an example cluster with the sandbox. The cluster could not find the 'cnpg-default-monitoring' config map since it wasn't copied to the custom namespace. This might be due to a misconfiguration of the sandbox default values.
