### PR TITLE
fix(cnpg-sandbox): removing explicit reference to monitoring queries

### DIFF
--- a/charts/cnpg-sandbox/README.md
+++ b/charts/cnpg-sandbox/README.md
@@ -27,7 +27,7 @@ A sandbox for CloudNativePG
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| cloudnative-pg | object | `{"config":{"create":true,"data":{"MONITORING_QUERIES_CONFIGMAP":"default-monitoring-queries"}},"enabled":true}` | here you can pass the whole values directly to the cloudnative-pg chart |
+| cloudnative-pg | object | `{"enabled":true}` | here you can pass the whole values directly to the cloudnative-pg chart |
 | defaultAlerts | bool | `true` |  |
 | defaultDashboard | bool | `true` |  |
 | kube-prometheus-stack | object | `{"alertmanager":{"enabled":true},"defaultRules":{"create":true,"rules":{"alertmanager":false,"configReloaders":false,"etcd":false,"general":false,"k8s":true,"kubeApiserver":false,"kubeApiserverAvailability":false,"kubeApiserverSlos":false,"kubePrometheusGeneral":false,"kubePrometheusNodeRecording":false,"kubeProxy":false,"kubeScheduler":false,"kubeStateMetrics":false,"kubelet":true,"kubernetesApps":false,"kubernetesResources":false,"kubernetesStorage":false,"kubernetesSystem":false,"network":false,"node":true,"nodeExporterAlerting":false,"nodeExporterRecording":true,"prometheus":false,"prometheusOperator":false}},"enabled":true,"grafana":{"adminPassword":"prom-operator","defaultDashboardsEnabled":false,"enabled":true},"kubeControllerManager":{"enabled":false},"nodeExporter":{"enabled":false},"prometheus":{"prometheusSpec":{"podMonitorSelectorNilUsesHelmValues":false,"probeSelectorNilUsesHelmValues":false,"ruleSelectorNilUsesHelmValues":false,"serviceMonitorSelectorNilUsesHelmValues":false}}}` | here you can pass the whole values directly to the kube-prometheus-stack chart |

--- a/charts/cnpg-sandbox/values.schema.json
+++ b/charts/cnpg-sandbox/values.schema.json
@@ -5,22 +5,6 @@
         "cloudnative-pg": {
             "type": "object",
             "properties": {
-                "config": {
-                    "type": "object",
-                    "properties": {
-                        "create": {
-                            "type": "boolean"
-                        },
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "MONITORING_QUERIES_CONFIGMAP": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                },
                 "enabled": {
                     "type": "boolean"
                 }

--- a/charts/cnpg-sandbox/values.yaml
+++ b/charts/cnpg-sandbox/values.yaml
@@ -71,10 +71,6 @@ kube-prometheus-stack:
 # -- here you can pass the whole values directly to the cloudnative-pg chart
 cloudnative-pg:
   enabled: true
-  config:
-    create: true
-    data:
-      MONITORING_QUERIES_CONFIGMAP: default-monitoring-queries
 
 defaultAlerts: true
 defaultDashboard: true


### PR DESCRIPTION
The chart cnpg-sandbox was still setting monitoring queries via environment variables, which is not required anymore given that now the source `cloudnative-pg` chart is shipping that configmap by default. Moreover, the current setting was wrong as the name was not the actual name of the now default configmap.

Closes #51