### PR TITLE
fix(cloudnative-pg): helm test using configurable image, default to b…

### DIFF
--- a/charts/cloudnative-pg/README.md
+++ b/charts/cloudnative-pg/README.md
@@ -47,6 +47,7 @@ CloudNativePG Helm Chart
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.create | bool | `true` | Specifies whether the service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| test | object | `{"image":{"pullPolicy":"IfNotPresent","repository":"busybox","tag":"latest"}}` | Test related configurations |
 | tolerations | list | `[]` | Tolerations for the operator to be installed |
 | webhook.mutating.create | bool | `true` |  |
 | webhook.mutating.failurePolicy | string | `"Fail"` |  |

--- a/charts/cloudnative-pg/templates/tests/test-connection.yaml
+++ b/charts/cloudnative-pg/templates/tests/test-connection.yaml
@@ -28,7 +28,7 @@ spec:
   {{- end }}
   containers:
     - name: wget
-      image: "{{ .Values.test.image.repository }}:{{ .Values.test.image.tag | default latest }}"
+      image: '{{ .Values.test.image.repository }}:{{ .Values.test.image.tag | default "latest" }}'
       imagePullPolicy: {{ .Values.test.image.pullPolicy }}
       command: ['curl']
       args: ['-ki','https://{{ .Values.service.name }}:{{ .Values.service.port }}']

--- a/charts/cloudnative-pg/templates/tests/test-connection.yaml
+++ b/charts/cloudnative-pg/templates/tests/test-connection.yaml
@@ -22,9 +22,14 @@ metadata:
   annotations:
     "helm.sh/hook": test
 spec:
+  {{- with .Values.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
   containers:
     - name: wget
-      image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+      image: "{{ .Values.test.image.repository }}:{{ .Values.test.image.tag | default 'latest' }}"
+      imagePullPolicy: {{ .Values.test.image.pullPolicy }}
       command: ['curl']
       args: ['-ki','https://{{ .Values.service.name }}:{{ .Values.service.port }}']
   restartPolicy: Never

--- a/charts/cloudnative-pg/templates/tests/test-connection.yaml
+++ b/charts/cloudnative-pg/templates/tests/test-connection.yaml
@@ -28,7 +28,7 @@ spec:
   {{- end }}
   containers:
     - name: wget
-      image: "{{ .Values.test.image.repository }}:{{ .Values.test.image.tag | default 'latest' }}"
+      image: "{{ .Values.test.image.repository }}:{{ .Values.test.image.tag | default latest }}"
       imagePullPolicy: {{ .Values.test.image.pullPolicy }}
       command: ['curl']
       args: ['-ki','https://{{ .Values.service.name }}:{{ .Values.service.port }}']

--- a/charts/cloudnative-pg/values.schema.json
+++ b/charts/cloudnative-pg/values.schema.json
@@ -131,6 +131,25 @@
                 }
             }
         },
+        "test": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "pullPolicy": {
+                            "type": "string"
+                        },
+                        "repository": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "tolerations": {
             "type": "array"
         },

--- a/charts/cloudnative-pg/values.yaml
+++ b/charts/cloudnative-pg/values.yaml
@@ -107,6 +107,13 @@ tolerations: []
 # -- Affinity for the operator to be installed
 affinity: {}
 
+# -- Test related configurations
+test:
+  image:
+    repository: busybox
+    pullPolicy: IfNotPresent
+    tag: "latest"
+
 # Default monitoring queries
 monitoringQueriesConfigMap:
   # -- The name of the default monitoring configmap


### PR DESCRIPTION
…usybox

Due to the recent switch to distroless, the test run by helm upon installation wasn't properly working due to the missing `curl` 
binary. With this patch we switch to a configurable image, defaulting to `busybox:latest`.

Closes #53 

Signed-off-by: Philippe Scorsolini <p.scorsolini@gmail.com>