### PR TITLE
ci: remove cnpg-sandbox from lint pipeline

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,7 +37,4 @@ jobs:
 
       - name: Run chart-testing (lint)
         run: |
-          helm dependency update charts/cnpg-sandbox
-          helm repo add cnpg https://cloudnative-pg.github.io/charts
-          helm repo add prometheus https://prometheus-community.github.io/helm-charts
           ct lint --target-branch=main --check-version-increment=false


### PR DESCRIPTION
Given that we removed cnpg-sanbox chart from this repo, we also need to remove related steps from the pipelines.

Signed-off-by: Philippe Scorsolini <p.scorsolini@gmail.com>