### PR TITLE
Add PriorityClassName to the CNPG Controller

### DIFF
--- a/charts/cloudnative-pg/README.md
+++ b/charts/cloudnative-pg/README.md
@@ -42,6 +42,7 @@ CloudNativePG Helm Chart
 | rbac.create | bool | `true` | Specifies whether ClusterRole and ClusterRoleBinding should be created |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
+| priorityClassName | string | `""` | PriorityClassName refers to ProrityClass and ensures that mission-critical workloads have allocated resources over non-critical |
 | service.name | string | `"cnpg-webhook-service"` | DO NOT CHANGE THE SERVICE NAME as it is currently used to generate the certificate and can not be configured |
 | service.port | int | `443` |  |
 | service.type | string | `"ClusterIP"` |  |

--- a/charts/cloudnative-pg/templates/deployment.yaml
+++ b/charts/cloudnative-pg/templates/deployment.yaml
@@ -100,6 +100,9 @@ spec:
           name: scratch-data
         - mountPath: /run/secrets/cnpg.io/webhook
           name: webhook-certificates
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ include "cloudnative-pg.serviceAccountName" . }}

--- a/charts/cloudnative-pg/values.schema.json
+++ b/charts/cloudnative-pg/values.schema.json
@@ -106,6 +106,9 @@
         "resources": {
             "type": "object"
         },
+        "priorityClassName": {
+            "type": "string"
+        },
         "service": {
             "type": "object",
             "properties": {

--- a/charts/cloudnative-pg/values.yaml
+++ b/charts/cloudnative-pg/values.yaml
@@ -80,6 +80,9 @@ podSecurityContext:
     type: RuntimeDefault
   # fsGroup: 2000
 
+# -- Priority indicates the importance of a Pod relative to other Pods.
+priorityClassName: ""
+
 service:
   type: ClusterIP
   # -- DO NOT CHANGE THE SERVICE NAME as it is currently used to generate the certificate


### PR DESCRIPTION
Fix: #64 

This PR adds the capability to define a `priorityClassName` in the CNPG deployment. Since the controller is mission critical workload by defining a priorityClassName we can ensure that controller gets enough resources defined in the `priortiyClass`.