### PR TITLE
fix: use wget to check service availability

### DIFF
--- a/charts/cloudnative-pg/templates/tests/test-connection.yaml
+++ b/charts/cloudnative-pg/templates/tests/test-connection.yaml
@@ -30,6 +30,6 @@ spec:
     - name: wget
       image: '{{ .Values.test.image.repository }}:{{ .Values.test.image.tag | default "latest" }}'
       imagePullPolicy: {{ .Values.test.image.pullPolicy }}
-      command: ['curl']
-      args: ['-ki','https://{{ .Values.service.name }}:{{ .Values.service.port }}']
+      command: ['wget']
+      args: ['--quiet','--spider','--no-check-certificate','https://{{ .Values.service.name }}:{{ .Values.service.port }}']
   restartPolicy: Never


### PR DESCRIPTION
The busybox image does not contain the `curl` command to perform tests. Thus, the pod failed to start with the following error message:

```sh
unable to start container process: exec: "curl": executable file not found in $PATH: unknown
```
This PR replaces the curl command with `wget` and updates the argument to test the service availability. 