### PR TITLE
Generate correct Secret when using custom ConfigMap

### DIFF
--- a/charts/cloudnative-pg/templates/config.yaml
+++ b/charts/cloudnative-pg/templates/config.yaml
@@ -28,7 +28,7 @@ metadata:
 data:
   {{- toYaml .Values.config.data | nindent 2 }}
 {{- end }}
-{{- else -}}
+{{- else }}
 apiVersion: v1
 kind: Secret
 type: Opaque


### PR DESCRIPTION
Using a custom ConfigMap with the helm chart by providing the following values:
```
  config:
    create: false
```

The template that generates the Secret(cnpg-controller-manager-config) will not include `apiVersion` in the rendered output.

Attempting to deploy without a specified api version will give the following error message:
```
groupVersion shouldn't be empty
```