### PR TITLE
Drop obsolete test pod values

### DIFF
--- a/charts/cloudnative-pg/values.yaml
+++ b/charts/cloudnative-pg/values.yaml
@@ -126,13 +126,6 @@ tolerations: []
 # -- Affinity for the operator to be installed
 affinity: {}
 
-# -- Test related configurations
-test:
-  image:
-    repository: busybox
-    pullPolicy: IfNotPresent
-    tag: "latest"
-
 # Default monitoring queries
 monitoringQueriesConfigMap:
   # -- The name of the default monitoring configmap


### PR DESCRIPTION
My auditors want fully qualified container images, I figured others would probably benefit from this as well.