### PR TITLE
feat(cloudnative-pg): clusterrole aggregated to user facing roles

### DIFF
--- a/charts/cloudnative-pg/templates/rbac.yaml
+++ b/charts/cloudnative-pg/templates/rbac.yaml
@@ -389,8 +389,6 @@ metadata:
     {{- include "cloudnative-pg.labels" . | nindent 4 }}
     {{- if .Values.rbac.aggregateClusterRoles }}
     rbac.authorization.k8s.io/aggregate-to-view: "true"
-    rbac.authorization.k8s.io/aggregate-to-edit: "true"
-    rbac.authorization.k8s.io/aggregate-to-admin: "true"
     {{- end }}
 rules:
 - apiGroups:
@@ -413,7 +411,6 @@ metadata:
     {{- include "cloudnative-pg.labels" . | nindent 4 }}
     {{- if .Values.rbac.aggregateClusterRoles }}
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
-    rbac.authorization.k8s.io/aggregate-to-admin: "true"
     {{- end }}
 rules:
 - apiGroups:


### PR DESCRIPTION
create rbac to view/edit cnpg crds and aggregate to [user facing roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles)

view/edit/admin clusterroles are bound to a user & namespace, to manage said namespace, and now allow to create a cluster/backup/etc  with this change.
