### PR TITLE
fix: readded check for primary to prevent providing erroneous metrix …

### DIFF
--- a/charts/cloudnative-pg/values.yaml
+++ b/charts/cloudnative-pg/values.yaml
@@ -244,6 +244,7 @@ monitoringQueriesConfigMap:
             description: "Time at which postgres started (based on epoch)"
 
     pg_replication:
+      primary: true
       query: "SELECT CASE WHEN NOT pg_catalog.pg_is_in_recovery()
               THEN 0
               ELSE GREATEST (0,


### PR DESCRIPTION
…for replicas. see #1814

See the issue [here](https://github.com/cloudnative-pg/cloudnative-pg/issues/1814)

For some reason in this commit [here](https://github.com/cloudnative-pg/charts/commit/6eeb80eb59dfdec14318e1d20d783a74a04ead9f#diff-a551a220ad6f272352960c48fdc0558ea801fe2f3c551c91e5aa1c97c86963cdR239) a check for primary was removed in one place, and left in the remainder.

The result is that the metrics query replicas for their replication lag, however replicas should not be providing this answer, only the primary. This resulted in replicas returning erroneous data and subsequent Prometheus rules failing despite the fact that replication was occuring correctly.

Re adding the primary check resolves the solution with the correct stats returned. 