### PR TITLE
added missing RBAC for version 1.21.0

### DIFF
--- a/charts/cloudnative-pg/templates/rbac.yaml
+++ b/charts/cloudnative-pg/templates/rbac.yaml
@@ -361,6 +361,15 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  verbs:
+  - get
+  - list
+  - update
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
When we try to install cloudnative-pg with latest version 1.21.0, it through the error about "can not get volume snapshot" in this one i have added missing RBAC entry.