### PR TITLE
fix: avoid setting configmap name with config.secret=true

### DIFF
--- a/charts/cloudnative-pg/templates/config.yaml
+++ b/charts/cloudnative-pg/templates/config.yaml
@@ -27,7 +27,6 @@ metadata:
   {{- end }}
 data:
   {{- toYaml .Values.config.data | nindent 2 }}
-{{- end }}
 {{- else }}
 apiVersion: v1
 kind: Secret
@@ -42,4 +41,5 @@ metadata:
   {{- end }}
 stringData:
   {{- toYaml .Values.config.data | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/cloudnative-pg/templates/deployment.yaml
+++ b/charts/cloudnative-pg/templates/deployment.yaml
@@ -49,9 +49,12 @@ spec:
       - args:
         - controller
         - --leader-elect
-        {{- with .Values.config.name }}
-        - --config-map-name={{ . }}
-        - --secret-name={{ . }}
+        {{- if .Values.config.name }}
+        {{- if not .Values.config.secret }}
+        - --config-map-name={{ .Values.config.name }}
+        {{- else }}
+        - --secret-name={{ .Values.config.name }}
+        {{- end }}
         {{- end }}
         - --webhook-port={{ .Values.webhook.port }}
         {{- range .Values.additionalArgs }}


### PR DESCRIPTION
Fixes https://github.com/cloudnative-pg/charts/issues/156

with `config.secret=false`:
```shell
$ helm template test --set config.secret=false charts/cloudnative-pg | grep cnpg-controller-manager-config -C 5
# limitations under the License.
#
apiVersion: v1
kind: ConfigMap
metadata:
  name: cnpg-controller-manager-config
  labels:
    helm.sh/chart: cloudnative-pg-0.19.0
    app.kubernetes.io/name: cloudnative-pg
    app.kubernetes.io/instance: test
    app.kubernetes.io/version: "1.21.0"
--
    spec:
      containers:
      - args:
        - controller
        - --leader-elect
        - --config-map-name=cnpg-controller-manager-config
        - --webhook-port=9443
        command:
        - /manager
        env:
        - name: OPERATOR_IMAGE_NAME
```

with `config.secret=true`:
```shell
$ helm template test --set config.secret=true charts/cloudnative-pg | grep cnpg-controller-manager-config -C 5
#
apiVersion: v1
kind: Secret
type: Opaque
metadata:
  name: cnpg-controller-manager-config
  labels:
    helm.sh/chart: cloudnative-pg-0.19.0
    app.kubernetes.io/name: cloudnative-pg
    app.kubernetes.io/instance: test
    app.kubernetes.io/version: "1.21.0"
--
    spec:
      containers:
      - args:
        - controller
        - --leader-elect
        - --secret-name=cnpg-controller-manager-config
        - --webhook-port=9443
        command:
        - /manager
        env:
        - name: OPERATOR_IMAGE_NAME
```