### PR TITLE
feat(cloudnative-pg): add hostNetwork configuration parameter 

### DIFF
--- a/charts/cloudnative-pg/templates/deployment.yaml
+++ b/charts/cloudnative-pg/templates/deployment.yaml
@@ -46,6 +46,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      hostNetwork: {{ .Values.hostNetwork }}
       containers:
       - args:
         - controller

--- a/charts/cloudnative-pg/values.schema.json
+++ b/charts/cloudnative-pg/values.schema.json
@@ -75,6 +75,9 @@
         "fullnameOverride": {
             "type": "string"
         },
+        "hostNetwork": {
+            "type": "boolean"
+        },
         "image": {
             "type": "object",
             "properties": {

--- a/charts/cloudnative-pg/values.yaml
+++ b/charts/cloudnative-pg/values.yaml
@@ -29,6 +29,8 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+hostNetwork: false
+
 crds:
   # -- Specifies whether the CRDs should be created when installing the chart.
   create: true


### PR DESCRIPTION
Related to: #177 

This PR adds a feature to configure `spec.hostNetwork` in the operator deployment manifest. 