### PR TITLE
Bug Fix: cosign step not correctly extracting tag version

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -66,6 +66,6 @@ jobs:
             file=${pkg##*/}
             name=${file%-*}
             version=${file%.*}
-            version=${version#*-}
+            version=${version##*-}
             cosign sign ghcr.io/"${GITHUB_REPOSITORY_OWNER}"/charts/"${name}":"${version}"
           done


### PR DESCRIPTION
This fixes a typo causing tags to not be correctly extracted when the name of the chart contains `-`.