### PR TITLE
feat: allow using existing secret for backup and restore

### DIFF
--- a/charts/cluster/templates/_backup.tpl
+++ b/charts/cluster/templates/_backup.tpl
@@ -12,7 +12,7 @@ backup:
       encryption: AES256
       jobs: 2
 
-    {{- $d := dict "chartFullname" (include "cluster.fullname" .) "scope" .Values.backups }}
+    {{- $d := dict "chartFullname" (include "cluster.fullname" .) "scope" .Values.backups "secretSuffix" "" }}
     {{- include "cluster.barmanObjectStoreConfig" $d | nindent 2 }}
 {{- end }}
 {{- end }}

--- a/charts/cluster/templates/_barman_object_store.tpl
+++ b/charts/cluster/templates/_barman_object_store.tpl
@@ -15,33 +15,35 @@
   {{- if empty .scope.destinationPath }}
   destinationPath: "s3://{{ required "You need to specify S3 bucket if destinationPath is not specified." .scope.s3.bucket }}{{ .scope.s3.path }}"
   {{- end }}
+  {{ $secretName := coalesce .scope.secret.name (printf "%s-backup-s3%s-creds" .chartFullname .secretSuffix) }}
   s3Credentials:
     accessKeyId:
-      name: {{ .chartFullname }}-backup-s3{{ .secretSuffix }}-creds
+      name: {{ $secretName }}
       key: ACCESS_KEY_ID
     secretAccessKey:
-      name: {{ .chartFullname }}-backup-s3{{ .secretSuffix }}-creds
+      name: {{ $secretName }}
       key: ACCESS_SECRET_KEY
 {{- else if eq .scope.provider "azure" }}
   {{- if empty .scope.destinationPath }}
   destinationPath: "https://{{ required "You need to specify Azure storageAccount if destinationPath is not specified." .scope.azure.storageAccount }}.{{ .scope.azure.serviceName }}.core.windows.net/{{ .scope.azure.containerName }}{{ .scope.azure.path }}"
   {{- end }}
   azureCredentials:
+  {{ $secretName := coalesce .scope.secret.name (printf "%s-backup-azure%s-creds" .chartFullname .secretSuffix) }}
   {{- if .scope.azure.connectionString }}
     connectionString:
-      name: {{ .chartFullname }}-backup-azure{{ .secretSuffix }}-creds
+      name: {{ $secretName }}
       key: AZURE_CONNECTION_STRING
   {{- else }}
     storageAccount:
-      name: {{ .chartFullname }}-backup-azure{{ .secretSuffix }}-creds
+      name: {{ $secretName }}
       key: AZURE_STORAGE_ACCOUNT
     {{- if .scope.azure.storageKey }}
     storageKey:
-      name: {{ .chartFullname }}-backup-azure{{ .secretSuffix }}-creds
+      name: {{ $secretName }}
       key: AZURE_STORAGE_KEY
     {{- else }}
     storageSasToken:
-      name: {{ .chartFullname }}-backup-azure{{ .secretSuffix }}-creds
+      name: {{ $secretName }}
       key: AZURE_STORAGE_SAS_TOKEN
     {{- end }}
   {{- end }}
@@ -49,10 +51,11 @@
   {{- if empty .scope.destinationPath }}
   destinationPath: "gs://{{ required "You need to specify Google storage bucket if destinationPath is not specified." .scope.google.bucket }}{{ .scope.google.path }}"
   {{- end }}
+  {{ $secretName := coalesce .scope.secret.name (printf "%s-backup-google%s-creds" .chartFullname .secretSuffix) }}
   googleCredentials:
     gkeEnvironment: {{ .scope.google.gkeEnvironment }}
     applicationCredentials:
-      name: {{ .chartFullname }}-backup-google{{ .secretSuffix }}-creds
+      name: {{ $secretName }}
       key: APPLICATION_CREDENTIALS
 {{- end -}}
 {{- end -}}

--- a/charts/cluster/templates/backup-azure-creds.yaml
+++ b/charts/cluster/templates/backup-azure-creds.yaml
@@ -1,8 +1,12 @@
-{{- if and .Values.backups.enabled (eq .Values.backups.provider "azure") }}
+{{- if and .Values.backups.enabled (eq .Values.backups.provider "azure") .Values.backups.secret.create }}
 apiVersion: v1
 kind: Secret
 metadata:
+  {{- if empty .Values.backups.secret.name }}
   name: {{ include "cluster.fullname" . }}-backup-azure-creds
+  {{- else }}
+  name: {{ .Values.backups.secret.name }}
+  {{- end }}
 data:
   AZURE_CONNECTION_STRING: {{ .Values.backups.azure.connectionString | b64enc | quote }}
   AZURE_STORAGE_ACCOUNT: {{ .Values.backups.azure.storageAccount | b64enc | quote }}

--- a/charts/cluster/templates/backup-azure-recovery-creds.yaml
+++ b/charts/cluster/templates/backup-azure-recovery-creds.yaml
@@ -1,8 +1,12 @@
-{{- if and (eq .Values.mode "recovery" ) (eq .Values.recovery.method "object_store") (eq .Values.recovery.provider "azure") }}
+{{- if and (eq .Values.mode "recovery" ) (eq .Values.recovery.method "object_store") (eq .Values.recovery.provider "azure") .Values.recovery.secret.create }}
 apiVersion: v1
 kind: Secret
 metadata:
+  {{- if empty .Values.recovery.secret.name }}
   name: {{ include "cluster.fullname" . }}-backup-azure-recovery-creds
+  {{- else }}
+  name: {{ .Values.recovery.secret.name }}
+  {{- end }}
 data:
   AZURE_CONNECTION_STRING: {{ .Values.recovery.azure.connectionString | b64enc | quote }}
   AZURE_STORAGE_ACCOUNT: {{ .Values.recovery.azure.storageAccount | b64enc | quote }}

--- a/charts/cluster/templates/backup-google-creds.yaml
+++ b/charts/cluster/templates/backup-google-creds.yaml
@@ -1,8 +1,12 @@
-{{- if and .Values.backups.enabled (eq .Values.backups.provider "google") }}
+{{- if and .Values.backups.enabled (eq .Values.backups.provider "google") .Values.backups.secret.create }}
 apiVersion: v1
 kind: Secret
 metadata:
+  {{- if empty .Values.backups.secret.name }}
   name: {{ include "cluster.fullname" . }}-backup-google-creds
+  {{- else }}
+  name: {{ .Values.backups.secret.name }}
+  {{- end }}
 data:
   APPLICATION_CREDENTIALS: {{ .Values.backups.google.applicationCredentials | b64enc | quote }}
 {{- end }}

--- a/charts/cluster/templates/backup-google-recovery-creds.yaml
+++ b/charts/cluster/templates/backup-google-recovery-creds.yaml
@@ -1,8 +1,12 @@
-{{- if and (eq .Values.mode "recovery" ) (eq .Values.recovery.method "object_store") (eq .Values.recovery.provider "google") }}
+{{- if and (eq .Values.mode "recovery" ) (eq .Values.recovery.method "object_store") (eq .Values.recovery.provider "google") .Values.recovery.secret.create }}
 apiVersion: v1
 kind: Secret
 metadata:
+  {{- if empty .Values.recovery.secret.name }}
   name: {{ include "cluster.fullname" . }}-backup-google-recovery-creds
+  {{- else }}
+  name: {{ .Values.recovery.secret.name }}
+  {{- end }}
 data:
   APPLICATION_CREDENTIALS: {{ .Values.recovery.google.applicationCredentials | b64enc | quote }}
 {{- end }}

--- a/charts/cluster/templates/backup-s3-creds.yaml
+++ b/charts/cluster/templates/backup-s3-creds.yaml
@@ -1,8 +1,12 @@
-{{- if and .Values.backups.enabled (eq .Values.backups.provider "s3") }}
+{{- if and .Values.backups.enabled (eq .Values.backups.provider "s3") .Values.backups.secret.create }}
 apiVersion: v1
 kind: Secret
 metadata:
+  {{- if empty .Values.backups.secret.name }}
   name: {{ include "cluster.fullname" . }}-backup-s3-creds
+  {{- else }}
+  name: {{ .Values.backups.secret.name }}
+  {{- end }}
 data:
   ACCESS_KEY_ID: {{ required ".Values.backups.s3.accessKey is required, but not specified." .Values.backups.s3.accessKey | b64enc | quote }}
   ACCESS_SECRET_KEY: {{ required ".Values.backups.s3.secretKey is required, but not specified." .Values.backups.s3.secretKey | b64enc | quote }}

--- a/charts/cluster/templates/backup-s3-recovery-creds.yaml
+++ b/charts/cluster/templates/backup-s3-recovery-creds.yaml
@@ -1,8 +1,12 @@
-{{- if and (eq .Values.mode "recovery" ) (eq .Values.recovery.method "object_store") (eq .Values.recovery.provider "s3") }}
+{{- if and (eq .Values.mode "recovery" ) (eq .Values.recovery.method "object_store") (eq .Values.recovery.provider "s3") .Values.recovery.secret.create }}
 apiVersion: v1
 kind: Secret
 metadata:
+  {{- if empty .Values.recovery.secret.name }}
   name: {{ include "cluster.fullname" . }}-backup-s3-recovery-creds
+  {{- else }}
+  name: {{ .Values.recovery.secret.name }}
+  {{- end }}
 data:
   ACCESS_KEY_ID: {{ required ".Values.recovery.s3.accessKey is required, but not specified." .Values.recovery.s3.accessKey | b64enc | quote }}
   ACCESS_SECRET_KEY: {{ required ".Values.recovery.s3.secretKey is required, but not specified." .Values.recovery.s3.secretKey | b64enc | quote }}

--- a/charts/cluster/values.yaml
+++ b/charts/cluster/values.yaml
@@ -48,6 +48,9 @@ recovery:
   destinationPath: ""
   # -- One of `s3`, `azure` or `google`
   provider: s3
+  secret:
+    create: true
+    name: ""
   s3:
     region: ""
     bucket: ""
@@ -182,6 +185,9 @@ backups:
   destinationPath: ""
   # -- One of `s3`, `azure` or `google`
   provider: s3
+  secret:
+    create: true
+    name: ""
   s3:
     region: ""
     bucket: ""


### PR DESCRIPTION
This PR allows to specify S3 credentials through an existing secret instead of having to commit the secrets with custom helm chart values.

Closes #197