### PR TITLE
Grafana dashboard label to "1"

### DIFF
--- a/charts/cloudnative-pg/values.yaml
+++ b/charts/cloudnative-pg/values.yaml
@@ -148,7 +148,7 @@ monitoring:
     # -- Label that ConfigMaps should have to be loaded as dashboards.
     sidecarLabel: "grafana_dashboard"
     # -- Label value that ConfigMaps should have to be loaded as dashboards.
-    sidecarLabelValue: ""
+    sidecarLabelValue: "1"
 
 # Default monitoring queries
 monitoringQueriesConfigMap:


### PR DESCRIPTION
According to most used monitoring stack dashboard label value should be "1" to be automatically loaded by Grafana. While it's not very hard to find it took me some time to figure out why dashboard wasn't loaded.

https://github.com/prometheus-community/helm-charts/blob/e7b492f14f217bfa5616e36bf1eb031cae2721b1/charts/kube-prometheus-stack/values.yaml#L1032