### PR TITLE
Added support for the specific user UID & GID

### DIFF
--- a/charts/cluster/README.md
+++ b/charts/cluster/README.md
@@ -152,6 +152,8 @@ refer to  the [CloudNativePG Documentation](https://cloudnative-pg.io/documentat
 | cluster.monitoring.enabled | bool | `false` |  |
 | cluster.monitoring.podMonitor.enabled | bool | `true` |  |
 | cluster.monitoring.prometheusRule.enabled | bool | `true` |  |
+| cluster.postgresGID | int | `26` | The GID of the postgres user inside the image, defaults to 26 |
+| cluster.postgresUID | int | `26` | The UID of the postgres user inside the image, defaults to 26 |
 | cluster.postgresql | object | `{}` | Configuration of the PostgreSQL server See: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-PostgresConfiguration |
 | cluster.primaryUpdateMethod | string | `"switchover"` | Method to follow to upgrade the primary server during a rolling update procedure, after all replicas have been successfully updated. It can be switchover (default) or in-place (restart). |
 | cluster.primaryUpdateStrategy | string | `"unsupervised"` | Strategy to follow to upgrade the primary server during a rolling update procedure, after all replicas have been successfully updated: it can be automated (unsupervised - default) or manual (supervised) |

--- a/charts/cluster/templates/cluster.yaml
+++ b/charts/cluster/templates/cluster.yaml
@@ -19,6 +19,8 @@ spec:
   imagePullSecrets:
     {{- . | toYaml | nindent 4 }}
   {{- end }}
+  postgresUID: {{ .Values.cluster.postgresUID }}
+  postgresGID: {{ .Values.cluster.postgresGID }}
   storage:
     size: {{ .Values.cluster.storage.size }}
     storageClass: {{ .Values.cluster.storage.storageClass }}

--- a/charts/cluster/values.schema.json
+++ b/charts/cluster/values.schema.json
@@ -176,6 +176,12 @@
                 "postgresql": {
                     "type": "object"
                 },
+                "postgresUID": {
+                    "type": "integer"
+                },
+                "postgresGID": {
+                    "type": "integer"
+                },
                 "primaryUpdateMethod": {
                     "type": "string"
                 },

--- a/charts/cluster/values.yaml
+++ b/charts/cluster/values.yaml
@@ -90,6 +90,12 @@ cluster:
     size: 8Gi
     storageClass: ""
 
+  # -- The UID of the postgres user inside the image, defaults to 26
+  postgresUID: 26
+  
+  # -- The GID of the postgres user inside the image, defaults to 26
+  postgresGID: 26
+
   # -- Resources requirements of every generated Pod.
   # Please refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ for more information.
   # We strongly advise you use the same setting for limits and requests so that your cluster pods are given a Guaranteed QoS.


### PR DESCRIPTION
Closes #206 

Added the postgresUID & GID from the [Clusterspec](https://cloudnative-pg.io/documentation/1.22/cloudnative-pg.v1/#postgresql-cnpg-io-v1-ClusterSpec) to the helm template. 