### PR TITLE
Fix cluster resources value type

### DIFF
--- a/charts/cluster/README.md
+++ b/charts/cluster/README.md
@@ -110,22 +110,22 @@ refer to  the [CloudNativePG Documentation](https://cloudnative-pg.io/documentat
 
 ## Values
 
-| Key | Type   | Default | Description |
-|-----|--------|---------|-------------|
+| Key | Type | Default | Description |
+|-----|-----|---------|-------------|
 | backups.azure.connectionString | string | `""` |  |
 | backups.azure.containerName | string | `""` |  |
-| backups.azure.inheritFromAzureAD | bool   | `false` |  |
+| backups.azure.inheritFromAzureAD | bool | `false` |  |
 | backups.azure.path | string | `"/"` |  |
 | backups.azure.serviceName | string | `"blob"` |  |
 | backups.azure.storageAccount | string | `""` |  |
 | backups.azure.storageKey | string | `""` |  |
 | backups.azure.storageSasToken | string | `""` |  |
 | backups.destinationPath | string | `""` | Overrides the provider specific default path. Defaults to: S3: s3://<bucket><path> Azure: https://<storageAccount>.<serviceName>.core.windows.net/<clusterName><path> Google: gs://<bucket><path> |
-| backups.enabled | bool   | `false` | You need to configure backups manually, so backups are disabled by default. |
+| backups.enabled | bool | `false` | You need to configure backups manually, so backups are disabled by default. |
 | backups.endpointURL | string | `""` | Overrides the provider specific default endpoint. Defaults to: S3: https://s3.<region>.amazonaws.com" |
 | backups.google.applicationCredentials | string | `""` |  |
 | backups.google.bucket | string | `""` |  |
-| backups.google.gkeEnvironment | bool   | `false` |  |
+| backups.google.gkeEnvironment | bool | `false` |  |
 | backups.google.path | string | `"/"` |  |
 | backups.provider | string | `"s3"` | One of `s3`, `azure` or `google` |
 | backups.retentionPolicy | string | `"30d"` | Retention policy for backups |
@@ -141,19 +141,19 @@ refer to  the [CloudNativePG Documentation](https://cloudnative-pg.io/documentat
 | cluster.affinity | object | `{"topologyKey":"topology.kubernetes.io/zone"}` | Affinity/Anti-affinity rules for Pods See: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-AffinityConfiguration |
 | cluster.annotations | object | `{}` |  |
 | cluster.certificates | string | `nil` | The configuration for the CA and related certificates See: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-CertificatesConfiguration |
-| cluster.enableSuperuserAccess | bool   | `true` | When this option is enabled, the operator will use the SuperuserSecret to update the postgres user password. If the secret is not present, the operator will automatically create one. When this option is disabled, the operator will ignore the SuperuserSecret content, delete it when automatically created, and then blank the password of the postgres user by setting it to NULL. |
+| cluster.enableSuperuserAccess | bool | `true` | When this option is enabled, the operator will use the SuperuserSecret to update the postgres user password. If the secret is not present, the operator will automatically create one. When this option is disabled, the operator will ignore the SuperuserSecret content, delete it when automatically created, and then blank the password of the postgres user by setting it to NULL. |
 | cluster.imageName | string | `""` | Name of the container image, supporting both tags (<image>:<tag>) and digests for deterministic and repeatable deployments: <image>:<tag>@sha256:<digestValue> |
 | cluster.imagePullPolicy | string | `"IfNotPresent"` | Image pull policy. One of Always, Never or IfNotPresent. If not defined, it defaults to IfNotPresent. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images |
-| cluster.imagePullSecrets | list   | `[]` | The list of pull secrets to be used to pull the images See: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-LocalObjectReference |
+| cluster.imagePullSecrets | list | `[]` | The list of pull secrets to be used to pull the images See: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-LocalObjectReference |
 | cluster.initdb | object | `{}` | BootstrapInitDB is the configuration of the bootstrap process when initdb is used See: https://cloudnative-pg.io/documentation/current/bootstrap/ See: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-bootstrapinitdb |
-| cluster.instances | int    | `3` | Number of instances |
+| cluster.instances | int | `3` | Number of instances |
 | cluster.logLevel | string | `"info"` | The instances' log level, one of the following values: error, warning, info (default), debug, trace |
-| cluster.monitoring.customQueries | list   | `[]` |  |
-| cluster.monitoring.enabled | bool   | `false` |  |
-| cluster.monitoring.podMonitor.enabled | bool   | `true` |  |
-| cluster.monitoring.prometheusRule.enabled | bool   | `true` |  |
-| cluster.postgresGID | int    | `26` | The GID of the postgres user inside the image, defaults to 26 |
-| cluster.postgresUID | int    | `26` | The UID of the postgres user inside the image, defaults to 26 |
+| cluster.monitoring.customQueries | list | `[]` |  |
+| cluster.monitoring.enabled | bool | `false` |  |
+| cluster.monitoring.podMonitor.enabled | bool | `true` |  |
+| cluster.monitoring.prometheusRule.enabled | bool | `true` |  |
+| cluster.postgresGID | int | `26` | The GID of the postgres user inside the image, defaults to 26 |
+| cluster.postgresUID | int | `26` | The UID of the postgres user inside the image, defaults to 26 |
 | cluster.postgresql | object | `{}` | Configuration of the PostgreSQL server See: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-PostgresConfiguration |
 | cluster.primaryUpdateMethod | string | `"switchover"` | Method to follow to upgrade the primary server during a rolling update procedure, after all replicas have been successfully updated. It can be switchover (default) or in-place (restart). |
 | cluster.primaryUpdateStrategy | string | `"unsupervised"` | Strategy to follow to upgrade the primary server during a rolling update procedure, after all replicas have been successfully updated: it can be automated (unsupervised - default) or manual (supervised) |
@@ -165,13 +165,13 @@ refer to  the [CloudNativePG Documentation](https://cloudnative-pg.io/documentat
 | fullnameOverride | string | `""` | Override the full name of the chart |
 | mode | string | `"standalone"` | Cluster mode of operation. Available modes: * `standalone` - default mode. Creates new or updates an existing CNPG cluster. * `replica` - Creates a replica cluster from an existing CNPG cluster. # TODO * `recovery` - Same as standalone but creates a cluster from a backup, object store or via pg_basebackup. |
 | nameOverride | string | `""` | Override the name of the chart |
-| pooler.enabled | bool   | `false` | Whether to enable PgBouncer |
-| pooler.instances | int    | `3` | Number of PgBouncer instances |
+| pooler.enabled | bool | `false` | Whether to enable PgBouncer |
+| pooler.instances | int | `3` | Number of PgBouncer instances |
 | pooler.parameters | object | `{"default_pool_size":"25","max_client_conn":"1000"}` | PgBouncer configuration parameters |
 | pooler.poolMode | string | `"transaction"` | PgBouncer pooling mode |
 | recovery.azure.connectionString | string | `""` |  |
 | recovery.azure.containerName | string | `""` |  |
-| recovery.azure.inheritFromAzureAD | bool   | `false` |  |
+| recovery.azure.inheritFromAzureAD | bool | `false` |  |
 | recovery.azure.path | string | `"/"` |  |
 | recovery.azure.serviceName | string | `"blob"` |  |
 | recovery.azure.storageAccount | string | `""` |  |
@@ -183,7 +183,7 @@ refer to  the [CloudNativePG Documentation](https://cloudnative-pg.io/documentat
 | recovery.endpointURL | string | `""` | Overrides the provider specific default endpoint. Defaults to: S3: https://s3.<region>.amazonaws.com" Leave empty if using the default S3 endpoint |
 | recovery.google.applicationCredentials | string | `""` |  |
 | recovery.google.bucket | string | `""` |  |
-| recovery.google.gkeEnvironment | bool   | `false` |  |
+| recovery.google.gkeEnvironment | bool | `false` |  |
 | recovery.google.path | string | `"/"` |  |
 | recovery.method | string | `"backup"` | Available recovery methods: * `backup` - Recovers a CNPG cluster from a CNPG backup (PITR supported) Needs to be on the same cluster in the same namespace. * `object_store` - Recovers a CNPG cluster from a barman object store (PITR supported). * `pg_basebackup` - Recovers a CNPG cluster viaa streaming replication protocol. Useful if you want to        migrate databases to CloudNativePG, even from outside Kubernetes. # TODO |
 | recovery.pitrTarget.time | string | `""` | Time in RFC3339 format |

--- a/charts/cluster/README.md
+++ b/charts/cluster/README.md
@@ -110,22 +110,22 @@ refer to  the [CloudNativePG Documentation](https://cloudnative-pg.io/documentat
 
 ## Values
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
+| Key | Type   | Default | Description |
+|-----|--------|---------|-------------|
 | backups.azure.connectionString | string | `""` |  |
 | backups.azure.containerName | string | `""` |  |
-| backups.azure.inheritFromAzureAD | bool | `false` |  |
+| backups.azure.inheritFromAzureAD | bool   | `false` |  |
 | backups.azure.path | string | `"/"` |  |
 | backups.azure.serviceName | string | `"blob"` |  |
 | backups.azure.storageAccount | string | `""` |  |
 | backups.azure.storageKey | string | `""` |  |
 | backups.azure.storageSasToken | string | `""` |  |
 | backups.destinationPath | string | `""` | Overrides the provider specific default path. Defaults to: S3: s3://<bucket><path> Azure: https://<storageAccount>.<serviceName>.core.windows.net/<clusterName><path> Google: gs://<bucket><path> |
-| backups.enabled | bool | `false` | You need to configure backups manually, so backups are disabled by default. |
+| backups.enabled | bool   | `false` | You need to configure backups manually, so backups are disabled by default. |
 | backups.endpointURL | string | `""` | Overrides the provider specific default endpoint. Defaults to: S3: https://s3.<region>.amazonaws.com" |
 | backups.google.applicationCredentials | string | `""` |  |
 | backups.google.bucket | string | `""` |  |
-| backups.google.gkeEnvironment | bool | `false` |  |
+| backups.google.gkeEnvironment | bool   | `false` |  |
 | backups.google.path | string | `"/"` |  |
 | backups.provider | string | `"s3"` | One of `s3`, `azure` or `google` |
 | backups.retentionPolicy | string | `"30d"` | Retention policy for backups |
@@ -141,37 +141,37 @@ refer to  the [CloudNativePG Documentation](https://cloudnative-pg.io/documentat
 | cluster.affinity | object | `{"topologyKey":"topology.kubernetes.io/zone"}` | Affinity/Anti-affinity rules for Pods See: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-AffinityConfiguration |
 | cluster.annotations | object | `{}` |  |
 | cluster.certificates | string | `nil` | The configuration for the CA and related certificates See: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-CertificatesConfiguration |
-| cluster.enableSuperuserAccess | bool | `true` | When this option is enabled, the operator will use the SuperuserSecret to update the postgres user password. If the secret is not present, the operator will automatically create one. When this option is disabled, the operator will ignore the SuperuserSecret content, delete it when automatically created, and then blank the password of the postgres user by setting it to NULL. |
+| cluster.enableSuperuserAccess | bool   | `true` | When this option is enabled, the operator will use the SuperuserSecret to update the postgres user password. If the secret is not present, the operator will automatically create one. When this option is disabled, the operator will ignore the SuperuserSecret content, delete it when automatically created, and then blank the password of the postgres user by setting it to NULL. |
 | cluster.imageName | string | `""` | Name of the container image, supporting both tags (<image>:<tag>) and digests for deterministic and repeatable deployments: <image>:<tag>@sha256:<digestValue> |
 | cluster.imagePullPolicy | string | `"IfNotPresent"` | Image pull policy. One of Always, Never or IfNotPresent. If not defined, it defaults to IfNotPresent. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images |
-| cluster.imagePullSecrets | list | `[]` | The list of pull secrets to be used to pull the images See: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-LocalObjectReference |
+| cluster.imagePullSecrets | list   | `[]` | The list of pull secrets to be used to pull the images See: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-LocalObjectReference |
 | cluster.initdb | object | `{}` | BootstrapInitDB is the configuration of the bootstrap process when initdb is used See: https://cloudnative-pg.io/documentation/current/bootstrap/ See: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-bootstrapinitdb |
-| cluster.instances | int | `3` | Number of instances |
+| cluster.instances | int    | `3` | Number of instances |
 | cluster.logLevel | string | `"info"` | The instances' log level, one of the following values: error, warning, info (default), debug, trace |
-| cluster.monitoring.customQueries | list | `[]` |  |
-| cluster.monitoring.enabled | bool | `false` |  |
-| cluster.monitoring.podMonitor.enabled | bool | `true` |  |
-| cluster.monitoring.prometheusRule.enabled | bool | `true` |  |
-| cluster.postgresGID | int | `26` | The GID of the postgres user inside the image, defaults to 26 |
-| cluster.postgresUID | int | `26` | The UID of the postgres user inside the image, defaults to 26 |
+| cluster.monitoring.customQueries | list   | `[]` |  |
+| cluster.monitoring.enabled | bool   | `false` |  |
+| cluster.monitoring.podMonitor.enabled | bool   | `true` |  |
+| cluster.monitoring.prometheusRule.enabled | bool   | `true` |  |
+| cluster.postgresGID | int    | `26` | The GID of the postgres user inside the image, defaults to 26 |
+| cluster.postgresUID | int    | `26` | The UID of the postgres user inside the image, defaults to 26 |
 | cluster.postgresql | object | `{}` | Configuration of the PostgreSQL server See: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-PostgresConfiguration |
 | cluster.primaryUpdateMethod | string | `"switchover"` | Method to follow to upgrade the primary server during a rolling update procedure, after all replicas have been successfully updated. It can be switchover (default) or in-place (restart). |
 | cluster.primaryUpdateStrategy | string | `"unsupervised"` | Strategy to follow to upgrade the primary server during a rolling update procedure, after all replicas have been successfully updated: it can be automated (unsupervised - default) or manual (supervised) |
 | cluster.priorityClassName | string | `""` |  |
-| cluster.resources | string | `nil` | Resources requirements of every generated Pod. Please refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ for more information. We strongly advise you use the same setting for limits and requests so that your cluster pods are given a Guaranteed QoS. See: https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/ |
+| cluster.resources | object | `nil` | Resources requirements of every generated Pod. Please refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ for more information. We strongly advise you use the same setting for limits and requests so that your cluster pods are given a Guaranteed QoS. See: https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/ |
 | cluster.storage.size | string | `"8Gi"` |  |
 | cluster.storage.storageClass | string | `""` |  |
 | cluster.superuserSecret | string | `""` |  |
 | fullnameOverride | string | `""` | Override the full name of the chart |
 | mode | string | `"standalone"` | Cluster mode of operation. Available modes: * `standalone` - default mode. Creates new or updates an existing CNPG cluster. * `replica` - Creates a replica cluster from an existing CNPG cluster. # TODO * `recovery` - Same as standalone but creates a cluster from a backup, object store or via pg_basebackup. |
 | nameOverride | string | `""` | Override the name of the chart |
-| pooler.enabled | bool | `false` | Whether to enable PgBouncer |
-| pooler.instances | int | `3` | Number of PgBouncer instances |
+| pooler.enabled | bool   | `false` | Whether to enable PgBouncer |
+| pooler.instances | int    | `3` | Number of PgBouncer instances |
 | pooler.parameters | object | `{"default_pool_size":"25","max_client_conn":"1000"}` | PgBouncer configuration parameters |
 | pooler.poolMode | string | `"transaction"` | PgBouncer pooling mode |
 | recovery.azure.connectionString | string | `""` |  |
 | recovery.azure.containerName | string | `""` |  |
-| recovery.azure.inheritFromAzureAD | bool | `false` |  |
+| recovery.azure.inheritFromAzureAD | bool   | `false` |  |
 | recovery.azure.path | string | `"/"` |  |
 | recovery.azure.serviceName | string | `"blob"` |  |
 | recovery.azure.storageAccount | string | `""` |  |
@@ -183,7 +183,7 @@ refer to  the [CloudNativePG Documentation](https://cloudnative-pg.io/documentat
 | recovery.endpointURL | string | `""` | Overrides the provider specific default endpoint. Defaults to: S3: https://s3.<region>.amazonaws.com" Leave empty if using the default S3 endpoint |
 | recovery.google.applicationCredentials | string | `""` |  |
 | recovery.google.bucket | string | `""` |  |
-| recovery.google.gkeEnvironment | bool | `false` |  |
+| recovery.google.gkeEnvironment | bool   | `false` |  |
 | recovery.google.path | string | `"/"` |  |
 | recovery.method | string | `"backup"` | Available recovery methods: * `backup` - Recovers a CNPG cluster from a CNPG backup (PITR supported) Needs to be on the same cluster in the same namespace. * `object_store` - Recovers a CNPG cluster from a barman object store (PITR supported). * `pg_basebackup` - Recovers a CNPG cluster viaa streaming replication protocol. Useful if you want to        migrate databases to CloudNativePG, even from outside Kubernetes. # TODO |
 | recovery.pitrTarget.time | string | `""` | Time in RFC3339 format |

--- a/charts/cluster/README.md
+++ b/charts/cluster/README.md
@@ -111,7 +111,7 @@ refer to  the [CloudNativePG Documentation](https://cloudnative-pg.io/documentat
 ## Values
 
 | Key | Type | Default | Description |
-|-----|-----|---------|-------------|
+|-----|------|---------|-------------|
 | backups.azure.connectionString | string | `""` |  |
 | backups.azure.containerName | string | `""` |  |
 | backups.azure.inheritFromAzureAD | bool | `false` |  |

--- a/charts/cluster/examples/cluster-resources.yaml
+++ b/charts/cluster/examples/cluster-resources.yaml
@@ -1,0 +1,12 @@
+mode: standalone
+
+cluster:
+  instances: 1
+
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "1"
+    limits:
+      memory: "1Gi"
+      cpu: "2"

--- a/charts/cluster/values.schema.json
+++ b/charts/cluster/values.schema.json
@@ -192,7 +192,7 @@
                     "type": "string"
                 },
                 "resources": {
-                    "type": "null"
+                    "type": "object"
                 },
                 "storage": {
                     "type": "object",


### PR DESCRIPTION
Hi,
I was trying to configure the cluster resources for the pods, and I got this error:

```
cluster:
    - cluster.resources: Invalid type. Expected: null, given: object
```

This error seems to be related only to the wrong mapping in `value.schema.json`, which is fixed in this PR.

I added an example that is the same one I was trying to apply in my cluster.

