### PR TITLE
feat: add annotation to grafana dashboard

### DIFF
--- a/charts/cloudnative-pg/templates/grafana-dashboard.yaml
+++ b/charts/cloudnative-pg/templates/grafana-dashboard.yaml
@@ -2,6 +2,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  annotations:
+    grafana_folder: {{ .Values.monitoring.grafanaDashboard.sidecarAnnotationValue | quote }}
   name: {{ .Values.monitoring.grafanaDashboard.configMapName }}
   namespace: {{ default .Release.Namespace .Values.monitoring.grafanaDashboard.namespace }}
   labels:

--- a/charts/cloudnative-pg/values.yaml
+++ b/charts/cloudnative-pg/values.yaml
@@ -149,6 +149,8 @@ monitoring:
     sidecarLabel: "grafana_dashboard"
     # -- Label value that ConfigMaps should have to be loaded as dashboards.
     sidecarLabelValue: "1"
+    # -- Annotation for ConfigMaps describing the grafana folder
+    sidecarAnnotationValue: ""
 
 # Default monitoring queries
 monitoringQueriesConfigMap:


### PR DESCRIPTION
Add grafana_folder annotation to the dashboard which allows it to be automagically placed in a folder