### PR TITLE
feat(cluster): Exposed backup.barmanObjectStore.wal and backup.barmanObjectStore.data

### DIFF
--- a/charts/cluster/README.md
+++ b/charts/cluster/README.md
@@ -120,6 +120,9 @@ refer to  the [CloudNativePG Documentation](https://cloudnative-pg.io/documentat
 | backups.azure.storageAccount | string | `""` |  |
 | backups.azure.storageKey | string | `""` |  |
 | backups.azure.storageSasToken | string | `""` |  |
+| backups.data.compression | string | `"gzip"` | Data compression method. One of `` (for no compression), `gzip`, `bzip2` or `snappy`. |
+| backups.data.encryption | string | `"AES256"` | Whether to instruct the storage provider to encrypt data files. One of `` (use the storage container default), `AES256` or `aws:kms`. |
+| backups.data.jobs | int | `2` | Number of data files to be archived or restored in parallel. |
 | backups.destinationPath | string | `""` | Overrides the provider specific default path. Defaults to: S3: s3://<bucket><path> Azure: https://<storageAccount>.<serviceName>.core.windows.net/<clusterName><path> Google: gs://<bucket><path> |
 | backups.enabled | bool | `false` | You need to configure backups manually, so backups are disabled by default. |
 | backups.endpointURL | string | `""` | Overrides the provider specific default endpoint. Defaults to: S3: https://s3.<region>.amazonaws.com" |
@@ -137,6 +140,9 @@ refer to  the [CloudNativePG Documentation](https://cloudnative-pg.io/documentat
 | backups.scheduledBackups[0].backupOwnerReference | string | `"self"` | Backup owner reference |
 | backups.scheduledBackups[0].name | string | `"daily-backup"` | Scheduled backup name |
 | backups.scheduledBackups[0].schedule | string | `"0 0 0 * * *"` | Schedule in cron format |
+| backups.wal.compression | string | `"gzip"` | WAL compression method. One of `` (for no compression), `gzip`, `bzip2` or `snappy`. |
+| backups.wal.encryption | string | `"AES256"` | Whether to instruct the storage provider to encrypt WAL files. One of `` (use the storage container default), `AES256` or `aws:kms`. |
+| backups.wal.maxParallel | int | `1` | Number of WAL files to be archived or restored in parallel. |
 | cluster.additionalLabels | object | `{}` |  |
 | cluster.affinity | object | `{"topologyKey":"topology.kubernetes.io/zone"}` | Affinity/Anti-affinity rules for Pods See: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-AffinityConfiguration |
 | cluster.annotations | object | `{}` |  |

--- a/charts/cluster/templates/_backup.tpl
+++ b/charts/cluster/templates/_backup.tpl
@@ -5,12 +5,13 @@ backup:
   retentionPolicy: {{ .Values.backups.retentionPolicy }}
   barmanObjectStore:
     wal:
-      compression: gzip
-      encryption: AES256
+      compression: {{ .Values.backups.wal.compression }}
+      encryption: {{ .Values.backups.wal.encryption }}
+      maxParallel: {{ .Values.backups.wal.maxParallel }}
     data:
-      compression: gzip
-      encryption: AES256
-      jobs: 2
+      compression: {{ .Values.backups.data.compression }}
+      encryption: {{ .Values.backups.data.encryption }}
+      jobs: {{ .Values.backups.data.jobs }}
 
     {{- $d := dict "chartFullname" (include "cluster.fullname" .) "scope" .Values.backups }}
     {{- include "cluster.barmanObjectStoreConfig" $d | nindent 2 }}

--- a/charts/cluster/values.schema.json
+++ b/charts/cluster/values.schema.json
@@ -34,6 +34,20 @@
                         }
                     }
                 },
+                "data": {
+                    "type": "object",
+                    "properties": {
+                        "compression": {
+                            "type": "string"
+                        },
+                        "encryption": {
+                            "type": "string"
+                        },
+                        "jobs": {
+                            "type": "integer"
+                        }
+                    }
+                },
                 "destinationPath": {
                     "type": "string"
                 },
@@ -100,6 +114,20 @@
                             "schedule": {
                                 "type": "string"
                             }
+                        }
+                    }
+                },
+                "wal": {
+                    "type": "object",
+                    "properties": {
+                        "compression": {
+                            "type": "string"
+                        },
+                        "encryption": {
+                            "type": "string"
+                        },
+                        "maxParallel": {
+                            "type": "integer"
                         }
                     }
                 }

--- a/charts/cluster/values.yaml
+++ b/charts/cluster/values.yaml
@@ -209,6 +209,21 @@ backups:
     gkeEnvironment: false
     applicationCredentials: ""
 
+  wal:
+    # -- WAL compression method. One of `` (for no compression), `gzip`, `bzip2` or `snappy`.
+    compression: gzip
+    # -- Whether to instruct the storage provider to encrypt WAL files. One of `` (use the storage container default), `AES256` or `aws:kms`.
+    encryption: AES256
+    # -- Number of WAL files to be archived or restored in parallel.
+    maxParallel: 1
+  data:
+    # -- Data compression method. One of `` (for no compression), `gzip`, `bzip2` or `snappy`.
+    compression: gzip
+    # -- Whether to instruct the storage provider to encrypt data files. One of `` (use the storage container default), `AES256` or `aws:kms`.
+    encryption: AES256
+    # -- Number of data files to be archived or restored in parallel.
+    jobs: 2
+
   scheduledBackups:
     -
       # -- Scheduled backup name
@@ -220,6 +235,7 @@ backups:
 
   # -- Retention policy for backups
   retentionPolicy: "30d"
+
 
 pooler:
   # -- Whether to enable PgBouncer


### PR DESCRIPTION
This PR exposed the `backup.barmanObjectStore.wal` and `backup.barmanObjectStore.data` properties so that the encryption can be disabled.

This is needed in the case where you are using MinIO without encryption enabled. The defaults for encryption are still: `AES256`.

In addition the compression and parallelism properties are exposed for fine-tuning the storage space and performance of your cluster.

Closes: #198