### PR TITLE
Bug Fix Attempt: Cosign confirmation prompt

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -80,5 +80,5 @@ jobs:
             name=${file%-*}
             version=${file%.*}
             version=${version##*-}
-            cosign sign ghcr.io/"${GITHUB_REPOSITORY_OWNER}"/charts/"${name}":"${version}"
+            cosign sign --yes ghcr.io/"${GITHUB_REPOSITORY_OWNER}"/charts/"${name}":"${version}"
           done


### PR DESCRIPTION
Hopefully this simple change in the `release-publish` workflow would resolve the following issue:

```
By typing 'y', you attest that (1) you are not submitting the personal data of any other person; and (2) you understand and agree to the statement and the Agreement terms at the URLs listed above.
Are you sure you would like to continue? [y/N] Error: signing [ghcr.io/cloudnative-pg/charts/cluster:0.0.3]: recursively signing: signing digest: should upload to tlog: user declined the prompt
main.go:74: error during command execution: signing [ghcr.io/cloudnative-pg/charts/cluster:0.0.3]: recursively signing: signing digest: should upload to tlog: user declined the prompt
Error: Process completed with exit code 1.
```