### PR TITLE
ci: properly add dependency before chart-releaser

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -37,6 +37,10 @@ jobs:
         with:
           version: v3.14.1
 
+      - name: Add chart dependencies
+        run: |
+          helm repo add cnpg-grafana-dashboard https://cloudnative-pg.github.io/grafana-dashboards
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@a917fd15b20e8b64b94d9158ad54cd6345335584 # v1.6.0
         env:


### PR DESCRIPTION
We need to add dependencies before running chart-releaser, see https://github.com/helm/chart-releaser/issues/135#issuecomment-915850640.