### PR TITLE
Add config value endpointCA for private S3 such as MinIO

### DIFF
--- a/charts/cluster/README.md
+++ b/charts/cluster/README.md
@@ -125,6 +125,8 @@ refer to  the [CloudNativePG Documentation](https://cloudnative-pg.io/documentat
 | backups.data.jobs | int | `2` | Number of data files to be archived or restored in parallel. |
 | backups.destinationPath | string | `""` | Overrides the provider specific default path. Defaults to: S3: s3://<bucket><path> Azure: https://<storageAccount>.<serviceName>.core.windows.net/<clusterName><path> Google: gs://<bucket><path> |
 | backups.enabled | bool | `false` | You need to configure backups manually, so backups are disabled by default. |
+| backups.endpointCA | object | `{"create":false,"key":"","name":"","value":""}` | Specifies a CA bundle to validate a privately signed certificate. |
+| backups.endpointCA.create | bool | `false` | Creates a secret with the given value if true, otherwise uses an existing secret. |
 | backups.endpointURL | string | `""` | Overrides the provider specific default endpoint. Defaults to: S3: https://s3.<region>.amazonaws.com" |
 | backups.google.applicationCredentials | string | `""` |  |
 | backups.google.bucket | string | `""` |  |
@@ -190,6 +192,8 @@ refer to  the [CloudNativePG Documentation](https://cloudnative-pg.io/documentat
 | recovery.backupName | string | `""` | Backup Recovery Method |
 | recovery.clusterName | string | `""` | Object Store Recovery Method |
 | recovery.destinationPath | string | `""` | Overrides the provider specific default path. Defaults to: S3: s3://<bucket><path> Azure: https://<storageAccount>.<serviceName>.core.windows.net/<clusterName><path> Google: gs://<bucket><path> |
+| recovery.endpointCA | object | `{"create":false,"key":"","name":"","value":""}` | Specifies a CA bundle to validate a privately signed certificate. |
+| recovery.endpointCA.create | bool | `false` | Creates a secret with the given value if true, otherwise uses an existing secret. |
 | recovery.endpointURL | string | `""` | Overrides the provider specific default endpoint. Defaults to: S3: https://s3.<region>.amazonaws.com" Leave empty if using the default S3 endpoint |
 | recovery.google.applicationCredentials | string | `""` |  |
 | recovery.google.bucket | string | `""` |  |

--- a/charts/cluster/templates/_barman_object_store.tpl
+++ b/charts/cluster/templates/_barman_object_store.tpl
@@ -4,6 +4,12 @@
   endpointURL: {{ .scope.endpointURL }}
 {{- end }}
 
+{{- if or (.scope.endpointCA.create) (.scope.endpointCA.name) }}
+  endpointCA:
+    name: {{ .chartFullname }}-ca-bundle
+    key: ca-bundle.crt
+{{- end }}
+
 {{- if .scope.destinationPath }}
   destinationPath: {{ .scope.destinationPath }}
 {{- end }}

--- a/charts/cluster/templates/ca-bundle.yaml
+++ b/charts/cluster/templates/ca-bundle.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.backups.endpointCA.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.backups.endpointCA.name | default (printf "%s-ca-bundle" (include "cluster.fullname" .)) | quote }}
+data:
+  {{ .Values.backups.endpointCA.key | default "ca-bundle.crt" | quote }}: {{ .Values.backups.endpointCA.value }}
+  
+{{- end }}

--- a/charts/cluster/values.schema.json
+++ b/charts/cluster/values.schema.json
@@ -54,25 +54,25 @@
                 "enabled": {
                     "type": "boolean"
                 },
-                "endpointURL": {
-                    "type": "string"
-                },
                 "endpointCA": {
                     "type": "object",
                     "properties": {
-                        "createSecret": {
+                        "create": {
                             "type": "boolean"
                         },
-                        "name": {
+                        "key": {
                             "type": "string"
                         },
-                        "key": {
+                        "name": {
                             "type": "string"
                         },
                         "value": {
                             "type": "string"
                         }
                     }
+                },
+                "endpointURL": {
+                    "type": "string"
                 },
                 "google": {
                     "type": "object",
@@ -352,25 +352,25 @@
                 "destinationPath": {
                     "type": "string"
                 },
-                "endpointURL": {
-                    "type": "string"
-                },
                 "endpointCA": {
                     "type": "object",
                     "properties": {
-                        "createSecret": {
+                        "create": {
                             "type": "boolean"
                         },
-                        "name": {
+                        "key": {
                             "type": "string"
                         },
-                        "key": {
+                        "name": {
                             "type": "string"
                         },
                         "value": {
                             "type": "string"
                         }
                     }
+                },
+                "endpointURL": {
+                    "type": "string"
                 },
                 "google": {
                     "type": "object",

--- a/charts/cluster/values.schema.json
+++ b/charts/cluster/values.schema.json
@@ -57,6 +57,23 @@
                 "endpointURL": {
                     "type": "string"
                 },
+                "endpointCA": {
+                    "type": "object",
+                    "properties": {
+                        "createSecret": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "key": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "type": "string"
+                        }
+                    }
+                },
                 "google": {
                     "type": "object",
                     "properties": {
@@ -337,6 +354,23 @@
                 },
                 "endpointURL": {
                     "type": "string"
+                },
+                "endpointCA": {
+                    "type": "object",
+                    "properties": {
+                        "createSecret": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "key": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "type": "string"
+                        }
+                    }
                 },
                 "google": {
                     "type": "object",

--- a/charts/cluster/values.yaml
+++ b/charts/cluster/values.yaml
@@ -41,6 +41,13 @@ recovery:
   # S3: https://s3.<region>.amazonaws.com"
   # Leave empty if using the default S3 endpoint
   endpointURL: ""
+  # -- Specifies a CA bundle to validate a privately signed certificate.
+  endpointCA:
+    # -- Creates a secret with the given value if true, otherwise uses an existing secret.
+    create: false
+    name: ""
+    key: ""
+    value: ""
   # -- Overrides the provider specific default path. Defaults to:
   # S3: s3://<bucket><path>
   # Azure: https://<storageAccount>.<serviceName>.core.windows.net/<clusterName><path>
@@ -184,6 +191,13 @@ backups:
   # -- Overrides the provider specific default endpoint. Defaults to:
   # S3: https://s3.<region>.amazonaws.com"
   endpointURL: ""  # Leave empty if using the default S3 endpoint
+  # -- Specifies a CA bundle to validate a privately signed certificate.
+  endpointCA:
+    # -- Creates a secret with the given value if true, otherwise uses an existing secret.
+    create: false
+    name: ""
+    key: ""
+    value: ""
 
   # -- Overrides the provider specific default path. Defaults to:
   # S3: s3://<bucket><path>


### PR DESCRIPTION
This PR adds a chart values to `endpointCA` in both the backup and recovery sections, allowing a user to specify a private CA. The value is stored in a secret, which can either be created manually, or will be created automatically if the `create` option is true.

Resolves #229 