### PR TITLE
Added the ability to exclude specific PrometheusRules

### DIFF
--- a/charts/cluster/README.md
+++ b/charts/cluster/README.md
@@ -158,6 +158,7 @@ refer to  the [CloudNativePG Documentation](https://cloudnative-pg.io/documentat
 | cluster.monitoring.enabled | bool | `false` | Whether to enable monitoring |
 | cluster.monitoring.podMonitor.enabled | bool | `true` | Whether to enable the PodMonitor |
 | cluster.monitoring.prometheusRule.enabled | bool | `true` | Whether to enable the PrometheusRule automated alerts |
+| cluster.monitoring.prometheusRule.excludeRules | list | `[]` | Exclude specified rules |
 | cluster.postgresGID | int | `26` | The GID of the postgres user inside the image, defaults to 26 |
 | cluster.postgresUID | int | `26` | The UID of the postgres user inside the image, defaults to 26 |
 | cluster.postgresql | object | `{}` | Configuration of the PostgreSQL server. See: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-PostgresConfiguration |

--- a/charts/cluster/prometheus_rules/cluster-ha-critical.yaml
+++ b/charts/cluster/prometheus_rules/cluster-ha-critical.yaml
@@ -1,0 +1,23 @@
+{{- if not (has "CNPGClusterHACritical" .excludeRules) -}}
+alert: CNPGClusterHACritical
+annotations:
+  summary: CNPG Cluster has no standby replicas!
+  description: |-
+    CloudNativePG Cluster "{{ .labels.job }}" has no ready standby replicas. Your cluster at a severe
+    risk of data loss and downtime if the primary instance fails.
+
+    The primary instance is still online and able to serve queries, although connections to the `-ro` endpoint
+    will fail. The `-r` endpoint os operating at reduced capacity and all traffic is being served by the main.
+
+    This can happen during a normal fail-over or automated minor version upgrades in a cluster with 2 or less
+    instances. The replaced instance may need some time to catch-up with the cluster primary instance.
+
+    This alarm will be always trigger if your cluster is configured to run with only 1 instance. In this
+    case you may want to silence it.
+  runbook_url: https://github.com/cloudnative-pg/charts/blob/main/charts/cluster/docs/runbooks/CNPGClusterHACritical.md
+expr: |
+  max by (job) (cnpg_pg_replication_streaming_replicas{namespace="{{ .namespace }}"} - cnpg_pg_replication_is_wal_receiver_up{namespace="{{ .namespace }}"}) < 1
+for: 5m
+labels:
+  severity: critical
+{{- end -}}

--- a/charts/cluster/prometheus_rules/cluster-ha-critical.yaml
+++ b/charts/cluster/prometheus_rules/cluster-ha-critical.yaml
@@ -1,5 +1,6 @@
-{{- if not (has "CNPGClusterHACritical" .excludeRules) -}}
-alert: CNPGClusterHACritical
+{{- $alert := "CNPGClusterHACritical" -}}
+{{- if not (has $alert .excludeRules) -}}
+alert: {{ $alert }}
 annotations:
   summary: CNPG Cluster has no standby replicas!
   description: |-

--- a/charts/cluster/prometheus_rules/cluster-ha-warning.yaml
+++ b/charts/cluster/prometheus_rules/cluster-ha-warning.yaml
@@ -1,5 +1,6 @@
-{{- if not (has "CNPGClusterHAWarning" .excludeRules) -}}
-alert: CNPGClusterHAWarning
+{{- $alert := "CNPGClusterHAWarning" -}}
+{{- if not (has $alert .excludeRules) -}}
+alert: {{ $alert }}
 annotations:
   summary: CNPG Cluster less than 2 standby replicas.
   description: |-

--- a/charts/cluster/prometheus_rules/cluster-ha-warning.yaml
+++ b/charts/cluster/prometheus_rules/cluster-ha-warning.yaml
@@ -1,0 +1,21 @@
+{{- if not (has "CNPGClusterHAWarning" .excludeRules) -}}
+alert: CNPGClusterHAWarning
+annotations:
+  summary: CNPG Cluster less than 2 standby replicas.
+  description: |-
+    CloudNativePG Cluster "{{ .labels.job }}" has only {{ .value }} standby replicas, putting
+    your cluster at risk if another instance fails. The cluster is still able to operate normally, although
+    the `-ro` and `-r` endpoints operate at reduced capacity.
+
+    This can happen during a normal fail-over or automated minor version upgrades. The replaced instance may
+    need some time to catch-up with the cluster primary instance.
+
+    This alarm will be constantly triggered if your cluster is configured to run with less than 3 instances.
+    In this case you may want to silence it.
+  runbook_url: https://github.com/cloudnative-pg/charts/blob/main/charts/cluster/docs/runbooks/CNPGClusterHAWarning.md
+expr: |
+  max by (job) (cnpg_pg_replication_streaming_replicas{namespace="{{ .namespace }}"} - cnpg_pg_replication_is_wal_receiver_up{namespace="{{ .namespace }}"}) < 2
+for: 5m
+labels:
+  severity: warning
+{{- end -}}

--- a/charts/cluster/prometheus_rules/cluster-high_connection-critical.yaml
+++ b/charts/cluster/prometheus_rules/cluster-high_connection-critical.yaml
@@ -1,5 +1,6 @@
-{{- if not (has "CNPGClusterHighConnectionsCritical" .excludeRules) -}}
-alert: CNPGClusterHighConnectionsCritical
+{{- $alert := "CNPGClusterHighConnectionsCritical" -}}
+{{- if not (has $alert .excludeRules) -}}
+alert: {{ $alert }}
 annotations:
   summary: CNPG Instance maximum number of connections critical!
   description: |-

--- a/charts/cluster/prometheus_rules/cluster-high_connection-critical.yaml
+++ b/charts/cluster/prometheus_rules/cluster-high_connection-critical.yaml
@@ -1,0 +1,14 @@
+{{- if not (has "CNPGClusterHighConnectionsCritical" .excludeRules) -}}
+alert: CNPGClusterHighConnectionsCritical
+annotations:
+  summary: CNPG Instance maximum number of connections critical!
+  description: |-
+    CloudNativePG Cluster "{{ .cluster }}" instance {{ .labels.pod }} is using {{ .value }}% of
+    the maximum number of connections.
+  runbook_url: https://github.com/cloudnative-pg/charts/blob/main/charts/cluster/docs/runbooks/CNPGClusterHighConnectionsCritical.md
+expr: |
+  sum by (pod) (cnpg_backends_total{namespace=~"{{ .namespace }}", pod=~"{{ .podSelector }}"}) / max by (pod) (cnpg_pg_settings_setting{name="max_connections", namespace=~"{{ .namespace }}", pod=~"{{ .podSelector }}"}) * 100 > 95
+for: 5m
+labels:
+  severity: critical
+{{- end -}}

--- a/charts/cluster/prometheus_rules/cluster-high_connection-warning.yaml
+++ b/charts/cluster/prometheus_rules/cluster-high_connection-warning.yaml
@@ -1,5 +1,6 @@
-{{- if not (has "CNPGClusterHighConnectionsWarning" .excludeRules) -}}
-alert: CNPGClusterHighConnectionsWarning
+{{- $alert := "CNPGClusterHighConnectionsWarning" -}}
+{{- if not (has $alert .excludeRules) -}}
+alert: {{ $alert }}
 annotations:
   summary: CNPG Instance is approaching the maximum number of connections.
   description: |-

--- a/charts/cluster/prometheus_rules/cluster-high_connection-warning.yaml
+++ b/charts/cluster/prometheus_rules/cluster-high_connection-warning.yaml
@@ -1,0 +1,14 @@
+{{- if not (has "CNPGClusterHighConnectionsWarning" .excludeRules) -}}
+alert: CNPGClusterHighConnectionsWarning
+annotations:
+  summary: CNPG Instance is approaching the maximum number of connections.
+  description: |-
+    CloudNativePG Cluster "{{ .cluster }}" instance {{ .labels.pod }} is using {{ .value }}% of
+    the maximum number of connections.
+  runbook_url: https://github.com/cloudnative-pg/charts/blob/main/charts/cluster/docs/runbooks/CNPGClusterHighConnectionsWarning.md
+expr: |
+  sum by (pod) (cnpg_backends_total{namespace=~"{{ .namespace }}", pod=~"{{ .podSelector }}"}) / max by (pod) (cnpg_pg_settings_setting{name="max_connections", namespace=~"{{ .namespace }}", pod=~"{{ .podSelector }}"}) * 100 > 80
+for: 5m
+labels:
+  severity: warning
+{{- end -}}

--- a/charts/cluster/prometheus_rules/cluster-high_replication_lag.yaml
+++ b/charts/cluster/prometheus_rules/cluster-high_replication_lag.yaml
@@ -1,5 +1,6 @@
-{{- if not (has "CNPGClusterHighReplicationLag" .excludeRules) -}}
-alert: CNPGClusterHighReplicationLag
+{{- $alert := "CNPGClusterHighReplicationLag" -}}
+{{- if not (has $alert .excludeRules) -}}
+alert: {{ $alert }}
 annotations:
   summary: CNPG Cluster high replication lag
   description: |-

--- a/charts/cluster/prometheus_rules/cluster-high_replication_lag.yaml
+++ b/charts/cluster/prometheus_rules/cluster-high_replication_lag.yaml
@@ -1,0 +1,16 @@
+{{- if not (has "CNPGClusterHighReplicationLag" .excludeRules) -}}
+alert: CNPGClusterHighReplicationLag
+annotations:
+  summary: CNPG Cluster high replication lag
+  description: |-
+    CloudNativePG Cluster "{{ .cluster }}" is experiencing a high replication lag of
+    {{ .value }}ms.
+
+    High replication lag indicates network issues, busy instances, slow queries or suboptimal configuration.
+  runbook_url: https://github.com/cloudnative-pg/charts/blob/main/charts/cluster/docs/runbooks/CNPGClusterHighReplicationLag.md
+expr: |
+  max(cnpg_pg_replication_lag{namespace=~"{{ .namespace }}",pod=~"{{ .podSelector }}"}) * 1000 > 1000
+for: 5m
+labels:
+  severity: warning
+{{- end -}}

--- a/charts/cluster/prometheus_rules/cluster-instances_on_same_node.yaml
+++ b/charts/cluster/prometheus_rules/cluster-instances_on_same_node.yaml
@@ -1,0 +1,16 @@
+{{- if not (has "CNPGClusterInstancesOnSameNode" .excludeRules) -}}
+alert: CNPGClusterInstancesOnSameNode
+annotations:
+  summary: CNPG Cluster instances are located on the same node.
+  description: |-
+    CloudNativePG Cluster "{{ .cluster }}" has {{ .value }}
+    instances on the same node {{ .labels.node }}.
+
+    A failure or scheduled downtime of a single node will lead to a potential service disruption and/or data loss.
+  runbook_url: https://github.com/cloudnative-pg/charts/blob/main/charts/cluster/docs/runbooks/CNPGClusterInstancesOnSameNode.md
+expr: |
+  count by (node) (kube_pod_info{namespace=~"{{ .namespace }}", pod=~"{{ .podSelector }}"}) > 1
+for: 5m
+labels:
+  severity: warning
+{{- end -}}

--- a/charts/cluster/prometheus_rules/cluster-instances_on_same_node.yaml
+++ b/charts/cluster/prometheus_rules/cluster-instances_on_same_node.yaml
@@ -1,5 +1,6 @@
-{{- if not (has "CNPGClusterInstancesOnSameNode" .excludeRules) -}}
-alert: CNPGClusterInstancesOnSameNode
+{{- $alert := "CNPGClusterInstancesOnSameNode" -}}
+{{- if not (has $alert .excludeRules) -}}
+alert: {{ $alert }}
 annotations:
   summary: CNPG Cluster instances are located on the same node.
   description: |-

--- a/charts/cluster/prometheus_rules/cluster-low_disk_space-critical.yaml
+++ b/charts/cluster/prometheus_rules/cluster-low_disk_space-critical.yaml
@@ -1,5 +1,6 @@
-{{- if not (has "CNPGClusterLowDiskSpaceCritical" .excludeRules) -}}
-alert: CNPGClusterLowDiskSpaceCritical
+{{- $alert := "CNPGClusterLowDiskSpaceCritical" -}}
+{{- if not (has $alert .excludeRules) -}}
+alert: {{ $alert }}
 annotations:
   summary: CNPG Instance is running out of disk space!
   description: |-

--- a/charts/cluster/prometheus_rules/cluster-low_disk_space-critical.yaml
+++ b/charts/cluster/prometheus_rules/cluster-low_disk_space-critical.yaml
@@ -1,0 +1,21 @@
+{{- if not (has "CNPGClusterLowDiskSpaceCritical" .excludeRules) -}}
+alert: CNPGClusterLowDiskSpaceCritical
+annotations:
+  summary: CNPG Instance is running out of disk space!
+  description: |-
+    CloudNativePG Cluster "{{ .cluster }}" is running extremely low on disk space. Check attached PVCs!
+  runbook_url: https://github.com/cloudnative-pg/charts/blob/main/charts/cluster/docs/runbooks/CNPGClusterLowDiskSpaceCritical.md
+expr: |
+  max(max by(persistentvolumeclaim) (1 - kubelet_volume_stats_available_bytes{namespace="{{ .namespace }}", persistentvolumeclaim=~"{{ .podSelector }}"} / kubelet_volume_stats_capacity_bytes{namespace="{{ .namespace }}", persistentvolumeclaim=~"{{ .podSelector }}"})) > 0.9 OR
+  max(max by(persistentvolumeclaim) (1 - kubelet_volume_stats_available_bytes{namespace="{{ .namespace }}", persistentvolumeclaim=~"{{ .podSelector }}-wal"} / kubelet_volume_stats_capacity_bytes{namespace="{{ .namespace }}", persistentvolumeclaim=~"{{ .podSelector }}-wal"})) > 0.9 OR
+  max(sum by (namespace,persistentvolumeclaim) (kubelet_volume_stats_used_bytes{namespace="{{ .namespace }}", persistentvolumeclaim=~"{{ .podSelector }}-tbs.*"})
+      /
+      sum by (namespace,persistentvolumeclaim) (kubelet_volume_stats_capacity_bytes{namespace="{{ .namespace }}", persistentvolumeclaim=~"{{ .podSelector }}-tbs.*"})
+      *
+      on(namespace, persistentvolumeclaim) group_left(volume)
+      kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~"{{ .podSelector }}"}
+  ) > 0.9
+for: 5m
+labels:
+  severity: critical
+{{- end -}}

--- a/charts/cluster/prometheus_rules/cluster-low_disk_space-warning.yaml
+++ b/charts/cluster/prometheus_rules/cluster-low_disk_space-warning.yaml
@@ -1,0 +1,21 @@
+{{- if not (has "CNPGClusterLowDiskSpaceWarning" .excludeRules) -}}
+alert: CNPGClusterLowDiskSpaceWarning
+annotations:
+  summary: CNPG Instance is running out of disk space.
+  description: |-
+    CloudNativePG Cluster "{{ .cluster }}" is running low on disk space. Check attached PVCs.
+  runbook_url: https://github.com/cloudnative-pg/charts/blob/main/charts/cluster/docs/runbooks/CNPGClusterLowDiskSpaceWarning.md
+expr: |
+  max(max by(persistentvolumeclaim) (1 - kubelet_volume_stats_available_bytes{namespace="{{ .namespace }}", persistentvolumeclaim=~"{{ .podSelector }}"} / kubelet_volume_stats_capacity_bytes{namespace="{{ .namespace }}", persistentvolumeclaim=~"{{ .podSelector }}"})) > 0.7 OR
+  max(max by(persistentvolumeclaim) (1 - kubelet_volume_stats_available_bytes{namespace="{{ .namespace }}", persistentvolumeclaim=~"{{ .podSelector }}-wal"} / kubelet_volume_stats_capacity_bytes{namespace="{{ .namespace }}", persistentvolumeclaim=~"{{ .podSelector }}-wal"})) > 0.7 OR
+  max(sum by (namespace,persistentvolumeclaim) (kubelet_volume_stats_used_bytes{namespace="{{ .namespace }}", persistentvolumeclaim=~"{{ .podSelector }}-tbs.*"})
+      /
+      sum by (namespace,persistentvolumeclaim) (kubelet_volume_stats_capacity_bytes{namespace="{{ .namespace }}", persistentvolumeclaim=~"{{ .podSelector }}-tbs.*"})
+      *
+      on(namespace, persistentvolumeclaim) group_left(volume)
+      kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~"{{ .podSelector }}"}
+  ) > 0.7
+for: 5m
+labels:
+  severity: warning
+{{- end -}}

--- a/charts/cluster/prometheus_rules/cluster-low_disk_space-warning.yaml
+++ b/charts/cluster/prometheus_rules/cluster-low_disk_space-warning.yaml
@@ -1,5 +1,6 @@
-{{- if not (has "CNPGClusterLowDiskSpaceWarning" .excludeRules) -}}
-alert: CNPGClusterLowDiskSpaceWarning
+{{- $alert := "CNPGClusterLowDiskSpaceWarning" -}}
+{{- if not (has $alert .excludeRules) -}}
+alert: {{ $alert }}
 annotations:
   summary: CNPG Instance is running out of disk space.
   description: |-

--- a/charts/cluster/prometheus_rules/cluster-offline.yaml
+++ b/charts/cluster/prometheus_rules/cluster-offline.yaml
@@ -1,5 +1,6 @@
-{{- if not (has "CNPGClusterOffline" .excludeRules) -}}
-alert: CNPGClusterOffline
+{{- $alert := "CNPGClusterOffline" -}}
+{{- if not (has $alert .excludeRules) -}}
+alert: {{ $alert }}
 annotations:
   summary: CNPG Cluster has no running instances!
   description: |-

--- a/charts/cluster/prometheus_rules/cluster-offline.yaml
+++ b/charts/cluster/prometheus_rules/cluster-offline.yaml
@@ -1,0 +1,16 @@
+{{- if not (has "CNPGClusterOffline" .excludeRules) -}}
+alert: CNPGClusterOffline
+annotations:
+  summary: CNPG Cluster has no running instances!
+  description: |-
+    CloudNativePG Cluster "{{ .labels.job }}" has no ready instances.
+
+    Having an offline cluster means your applications will not be able to access the database, leading to
+    potential service disruption and/or data loss.
+  runbook_url: https://github.com/cloudnative-pg/charts/blob/main/charts/cluster/docs/runbooks/CNPGClusterOffline.md
+expr: |
+  ({{ .Values.cluster.instances }} - count(cnpg_collector_up{namespace=~"{{ .namespace }}",pod=~"{{ .podSelector }}"}) OR vector(0)) > 0
+for: 5m
+labels:
+  severity: critical
+{{- end -}}

--- a/charts/cluster/prometheus_rules/cluster-zone_spread-warning.yaml
+++ b/charts/cluster/prometheus_rules/cluster-zone_spread-warning.yaml
@@ -1,0 +1,15 @@
+{{- if not (has "CNPGClusterZoneSpreadWarning" .excludeRules) -}}
+alert: CNPGClusterZoneSpreadWarning
+annotations:
+  summary: CNPG Cluster instances in the same zone.
+  description: |-
+    CloudNativePG Cluster "{{ .cluster }}" has instances in the same availability zone.
+
+    A disaster in one availability zone will lead to a potential service disruption and/or data loss.
+  runbook_url: https://github.com/cloudnative-pg/charts/blob/main/charts/cluster/docs/runbooks/CNPGClusterZoneSpreadWarning.md
+expr: |
+  {{ .Values.cluster.instances }} > count(count by (label_topology_kubernetes_io_zone) (kube_pod_info{namespace=~"{{ .namespace }}", pod=~"{{ .podSelector }}"} * on(node,instance) group_left(label_topology_kubernetes_io_zone) kube_node_labels)) < 3
+for: 5m
+labels:
+  severity: warning
+{{- end -}}

--- a/charts/cluster/prometheus_rules/cluster-zone_spread-warning.yaml
+++ b/charts/cluster/prometheus_rules/cluster-zone_spread-warning.yaml
@@ -1,5 +1,6 @@
-{{- if not (has "CNPGClusterZoneSpreadWarning" .excludeRules) -}}
-alert: CNPGClusterZoneSpreadWarning
+{{- $alert := "CNPGClusterZoneSpreadWarning" -}}
+{{- if not (has $alert .excludeRules) -}}
+alert: {{ $alert }}
 annotations:
   summary: CNPG Cluster instances in the same zone.
   description: |-

--- a/charts/cluster/templates/prometheus-rule.yaml
+++ b/charts/cluster/templates/prometheus-rule.yaml
@@ -1,9 +1,4 @@
 {{- if and .Values.cluster.monitoring.enabled .Values.cluster.monitoring.prometheusRule.enabled -}}
-{{- $value := "{{ $value }}" -}}
-{{- $namespace := .Release.Namespace -}}
-{{- $cluster := printf "%s/%s" $namespace (include "cluster.fullname" .)}}
-{{- $labels := dict "job" "{{ $labels.job }}" "node" "{{ $labels.node }}" "pod" "{{ $labels.pod }}" -}}
-{{- $podSelector := printf "%s-([1-9][0-9]*)$" (include "cluster.fullname" .) -}}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -16,162 +11,15 @@ metadata:
 spec:
   groups:
     - name: cloudnative-pg/{{ include "cluster.fullname" . }}
-      rules:
-        - alert: CNPGClusterHAWarning
-          annotations:
-            summary: CNPG Cluster less than 2 standby replicas.
-            description: |-
-              CloudNativePG Cluster "{{ $labels.job }}" has only {{ $value }} standby replicas, putting
-              your cluster at risk if another instance fails. The cluster is still able to operate normally, although
-              the `-ro` and `-r` endpoints operate at reduced capacity.
-
-              This can happen during a normal fail-over or automated minor version upgrades. The replaced instance may
-              need some time to catch-up with the cluster primary instance.
-
-              This alarm will be constantly triggered if your cluster is configured to run with less than 3 instances.
-              In this case you may want to silence it.
-            runbook_url: https://github.com/cloudnative-pg/charts/blob/main/charts/cluster/docs/runbooks/CNPGClusterHAWarning.md
-          expr: |
-            max by (job) (cnpg_pg_replication_streaming_replicas{namespace="{{ $namespace }}"} - cnpg_pg_replication_is_wal_receiver_up{namespace="{{ $namespace }}"}) < 2
-          for: 5m
-          labels:
-            severity: warning
-        - alert: CNPGClusterHACritical
-          annotations:
-            summary: CNPG Cluster has no standby replicas!
-            description: |-
-              CloudNativePG Cluster "{{ $labels.job }}" has no ready standby replicas. Your cluster at a severe
-              risk of data loss and downtime if the primary instance fails.
-
-              The primary instance is still online and able to serve queries, although connections to the `-ro` endpoint
-              will fail. The `-r` endpoint os operating at reduced capacity and all traffic is being served by the main.
-
-              This can happen during a normal fail-over or automated minor version upgrades in a cluster with 2 or less
-              instances. The replaced instance may need some time to catch-up with the cluster primary instance.
-
-              This alarm will be always trigger if your cluster is configured to run with only 1 instance. In this
-              case you may want to silence it.
-            runbook_url: https://github.com/cloudnative-pg/charts/blob/main/charts/cluster/docs/runbooks/CNPGClusterHACritical.md
-          expr: |
-            max by (job) (cnpg_pg_replication_streaming_replicas{namespace="{{ $namespace }}"} - cnpg_pg_replication_is_wal_receiver_up{namespace="{{ $namespace }}"}) < 1
-          for: 5m
-          labels:
-            severity: critical
-        - alert: CNPGClusterOffline
-          annotations:
-            summary: CNPG Cluster has no running instances!
-            description: |-
-              CloudNativePG Cluster "{{ $labels.job }}" has no ready instances.
-
-              Having an offline cluster means your applications will not be able to access the database, leading to
-              potential service disruption and/or data loss.
-            runbook_url: https://github.com/cloudnative-pg/charts/blob/main/charts/cluster/docs/runbooks/CNPGClusterOffline.md
-          expr: |
-            ({{ .Values.cluster.instances }} - count(cnpg_collector_up{namespace=~"{{ $namespace }}",pod=~"{{ $podSelector }}"}) OR vector(0)) > 0
-          for: 5m
-          labels:
-            severity: critical
-        - alert: CNPGClusterZoneSpreadWarning
-          annotations:
-            summary: CNPG Cluster instances in the same zone.
-            description: |-
-              CloudNativePG Cluster "{{ $cluster }}" has instances in the same availability zone.
-
-              A disaster in one availability zone will lead to a potential service disruption and/or data loss.
-            runbook_url: https://github.com/cloudnative-pg/charts/blob/main/charts/cluster/docs/runbooks/CNPGClusterZoneSpreadWarning.md
-          expr: |
-            {{ .Values.cluster.instances }} > count(count by (label_topology_kubernetes_io_zone) (kube_pod_info{namespace=~"{{ $namespace }}", pod=~"{{ $podSelector }}"} * on(node,instance) group_left(label_topology_kubernetes_io_zone) kube_node_labels)) < 3
-          for: 5m
-          labels:
-            severity: warning
-        - alert: CNPGClusterInstancesOnSameNode
-          annotations:
-            summary: CNPG Cluster instances are located on the same node.
-            description: |-
-              CloudNativePG Cluster "{{ $cluster }}" has {{ $value }}
-              instances on the same node {{ $labels.node }}.
-
-              A failure or scheduled downtime of a single node will lead to a potential service disruption and/or data loss.
-            runbook_url: https://github.com/cloudnative-pg/charts/blob/main/charts/cluster/docs/runbooks/CNPGClusterInstancesOnSameNode.md
-          expr: |
-            count by (node) (kube_pod_info{namespace=~"{{ $namespace }}", pod=~"{{ $podSelector }}"}) > 1
-          for: 5m
-          labels:
-            severity: warning
-        - alert: CNPGClusterHighReplicationLag
-          annotations:
-            summary: CNPG Cluster high replication lag
-            description: |-
-              CloudNativePG Cluster "{{ $cluster }}" is experiencing a high replication lag of
-              {{ "{{ $value }}" }}ms.
-
-              High replication lag indicates network issues, busy instances, slow queries or suboptimal configuration.
-            runbook_url: https://github.com/cloudnative-pg/charts/blob/main/charts/cluster/docs/runbooks/CNPGClusterHighReplicationLag.md
-          expr: |
-            max(cnpg_pg_replication_lag{namespace=~"{{ $namespace }}",pod=~"{{ $podSelector }}"}) * 1000 > 1000
-          for: 5m
-          labels:
-            severity: warning
-        - alert: CNPGClusterHighConnectionsWarning
-          annotations:
-            summary: CNPG Instance is approaching the maximum number of connections.
-            description: |-
-              CloudNativePG Cluster "{{ $cluster }}" instance {{ $labels.pod }} is using {{ "{{ $value }}" }}% of
-              the maximum number of connections.
-            runbook_url: https://github.com/cloudnative-pg/charts/blob/main/charts/cluster/docs/runbooks/CNPGClusterHighConnectionsWarning.md
-          expr: |
-            sum by (pod) (cnpg_backends_total{namespace=~"{{ $namespace }}", pod=~"{{ $podSelector }}"}) / max by (pod) (cnpg_pg_settings_setting{name="max_connections", namespace=~"{{ $namespace }}", pod=~"{{ $podSelector }}"}) * 100 > 80
-          for: 5m
-          labels:
-            severity: warning
-        - alert: CNPGClusterHighConnectionsCritical
-          annotations:
-            summary: CNPG Instance maximum number of connections critical!
-            description: |-
-              CloudNativePG Cluster "{{ $cluster }}" instance {{ $labels.pod }} is using {{ "{{ $value }}" }}% of
-              the maximum number of connections.
-            runbook_url: https://github.com/cloudnative-pg/charts/blob/main/charts/cluster/docs/runbooks/CNPGClusterHighConnectionsCritical.md
-          expr: |
-            sum by (pod) (cnpg_backends_total{namespace=~"{{ $namespace }}", pod=~"{{ $podSelector }}"}) / max by (pod) (cnpg_pg_settings_setting{name="max_connections", namespace=~"{{ $namespace }}", pod=~"{{ $podSelector }}"}) * 100 > 95
-          for: 5m
-          labels:
-            severity: critical
-        - alert: CNPGClusterLowDiskSpaceWarning
-          annotations:
-            summary: CNPG Instance is running out of disk space.
-            description: |-
-              CloudNativePG Cluster "{{ $cluster }}" is running low on disk space. Check attached PVCs.
-            runbook_url: https://github.com/cloudnative-pg/charts/blob/main/charts/cluster/docs/runbooks/CNPGClusterLowDiskSpaceWarning.md
-          expr: |
-            max(max by(persistentvolumeclaim) (1 - kubelet_volume_stats_available_bytes{namespace="{{ $namespace }}", persistentvolumeclaim=~"{{ $podSelector }}"} / kubelet_volume_stats_capacity_bytes{namespace="{{ $namespace }}", persistentvolumeclaim=~"{{ $podSelector }}"})) > 0.7 OR
-            max(max by(persistentvolumeclaim) (1 - kubelet_volume_stats_available_bytes{namespace="{{ $namespace }}", persistentvolumeclaim=~"{{ $podSelector }}-wal"} / kubelet_volume_stats_capacity_bytes{namespace="{{ $namespace }}", persistentvolumeclaim=~"{{ $podSelector }}-wal"})) > 0.7 OR
-            max(sum by (namespace,persistentvolumeclaim) (kubelet_volume_stats_used_bytes{namespace="{{ $namespace }}", persistentvolumeclaim=~"{{ $podSelector }}-tbs.*"})
-                /
-                sum by (namespace,persistentvolumeclaim) (kubelet_volume_stats_capacity_bytes{namespace="{{ $namespace }}", persistentvolumeclaim=~"{{ $podSelector }}-tbs.*"})
-                *
-                on(namespace, persistentvolumeclaim) group_left(volume)
-                kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~"{{ $podSelector }}"}
-            ) > 0.7
-          for: 5m
-          labels:
-            severity: warning
-        - alert: CNPGClusterLowDiskSpaceCritical
-          annotations:
-            summary: CNPG Instance is running out of disk space!
-            description: |-
-              CloudNativePG Cluster "{{ $cluster }}" is running extremely low on disk space. Check attached PVCs!
-            runbook_url: https://github.com/cloudnative-pg/charts/blob/main/charts/cluster/docs/runbooks/CNPGClusterLowDiskSpaceCritical.md
-          expr: |
-            max(max by(persistentvolumeclaim) (1 - kubelet_volume_stats_available_bytes{namespace="{{ $namespace }}", persistentvolumeclaim=~"{{ $podSelector }}"} / kubelet_volume_stats_capacity_bytes{namespace="{{ $namespace }}", persistentvolumeclaim=~"{{ $podSelector }}"})) > 0.9 OR
-            max(max by(persistentvolumeclaim) (1 - kubelet_volume_stats_available_bytes{namespace="{{ $namespace }}", persistentvolumeclaim=~"{{ $podSelector }}-wal"} / kubelet_volume_stats_capacity_bytes{namespace="{{ $namespace }}", persistentvolumeclaim=~"{{ $podSelector }}-wal"})) > 0.9 OR
-            max(sum by (namespace,persistentvolumeclaim) (kubelet_volume_stats_used_bytes{namespace="{{ $namespace }}", persistentvolumeclaim=~"{{ $podSelector }}-tbs.*"})
-                /
-                sum by (namespace,persistentvolumeclaim) (kubelet_volume_stats_capacity_bytes{namespace="{{ $namespace }}", persistentvolumeclaim=~"{{ $podSelector }}-tbs.*"})
-                *
-                on(namespace, persistentvolumeclaim) group_left(volume)
-                kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~"{{ $podSelector }}"}
-            ) > 0.9
-          for: 5m
-          labels:
-            severity: critical
+      rules: |
+        {{ $dict := dict "excludeRules" .Values.cluster.monitoring.prometheusRule.excludeRules -}}
+        {{- $_ := set $dict "value"       "{{ $value }}" -}}
+        {{- $_ := set $dict "namespace"   .Release.Namespace -}}
+        {{- $_ := set $dict "cluster"     (printf "%s/%s" .Release.Namespace (include "cluster.fullname" .)) -}}
+        {{- $_ := set $dict "labels"      (dict "job" "{{ $labels.job }}" "node" "{{ $labels.node }}" "pod" "{{ $labels.pod }}") -}}
+        {{- $_ := set $dict "podSelector" (printf "%s-([1-9][0-9]*)$" (include "cluster.fullname" .)) -}}
+        {{- $_ := set $dict "Values"      .Values -}}
+        {{- range $path, $_ := .Files.Glob  "prometheus_rules/**.yaml" }}
+        - {{ tpl ($.Files.Get $path) $dict | nindent 10 | trim -}}
+        {{- end -}}
 {{ end }}

--- a/charts/cluster/values.schema.json
+++ b/charts/cluster/values.schema.json
@@ -196,6 +196,9 @@
                             "properties": {
                                 "enabled": {
                                     "type": "boolean"
+                                },
+                                "excludeRules": {
+                                    "type": "array"
                                 }
                             }
                         }

--- a/charts/cluster/values.yaml
+++ b/charts/cluster/values.yaml
@@ -144,8 +144,11 @@ cluster:
       # -- Whether to enable the PodMonitor
       enabled: true
     prometheusRule:
-        # -- Whether to enable the PrometheusRule automated alerts
+      # -- Whether to enable the PrometheusRule automated alerts
       enabled: true
+      # -- Exclude specified rules
+      excludeRules: []
+        #- CNPGClusterZoneSpreadWarning
     # -- Custom Prometheus metrics
     customQueries: []
       # - name: "pg_cache_hit_ratio"

--- a/charts/cluster/values.yaml
+++ b/charts/cluster/values.yaml
@@ -148,7 +148,7 @@ cluster:
       enabled: true
       # -- Exclude specified rules
       excludeRules: []
-        #- CNPGClusterZoneSpreadWarning
+        # - CNPGClusterZoneSpreadWarning
     # -- Custom Prometheus metrics
     customQueries: []
       # - name: "pg_cache_hit_ratio"


### PR DESCRIPTION
Adds the ability to disable specific PrometheusRules:

```yaml
cluster:
  monitoring:
    prometheusRule:
      excludeRules: # NEW
        - CNPGClusterHAWarning
        - CNPGClusterZoneSpreadWarning
```

In the process I also restructured how Prometheus rules are generated so each one now has its own file.