### PR TITLE
Bug Fix: barmanObjectStore.serverName not initialized correctly

### DIFF
--- a/charts/cluster/README.md
+++ b/charts/cluster/README.md
@@ -123,7 +123,7 @@ refer to  the [CloudNativePG Documentation](https://cloudnative-pg.io/documentat
 | backups.data.compression | string | `"gzip"` | Data compression method. One of `` (for no compression), `gzip`, `bzip2` or `snappy`. |
 | backups.data.encryption | string | `"AES256"` | Whether to instruct the storage provider to encrypt data files. One of `` (use the storage container default), `AES256` or `aws:kms`. |
 | backups.data.jobs | int | `2` | Number of data files to be archived or restored in parallel. |
-| backups.destinationPath | string | `""` | Overrides the provider specific default path. Defaults to: S3: s3://<bucket><path> Azure: https://<storageAccount>.<serviceName>.core.windows.net/<clusterName><path> Google: gs://<bucket><path> |
+| backups.destinationPath | string | `""` | Overrides the provider specific default path. Defaults to: S3: s3://<bucket><path> Azure: https://<storageAccount>.<serviceName>.core.windows.net/<containerName><path> Google: gs://<bucket><path> |
 | backups.enabled | bool | `false` | You need to configure backups manually, so backups are disabled by default. |
 | backups.endpointCA | object | `{"create":false,"key":"","name":"","value":""}` | Specifies a CA bundle to validate a privately signed certificate. |
 | backups.endpointCA.create | bool | `false` | Creates a secret with the given value if true, otherwise uses an existing secret. |
@@ -191,8 +191,8 @@ refer to  the [CloudNativePG Documentation](https://cloudnative-pg.io/documentat
 | recovery.azure.storageKey | string | `""` |  |
 | recovery.azure.storageSasToken | string | `""` |  |
 | recovery.backupName | string | `""` | Backup Recovery Method |
-| recovery.clusterName | string | `""` | Object Store Recovery Method |
-| recovery.destinationPath | string | `""` | Overrides the provider specific default path. Defaults to: S3: s3://<bucket><path> Azure: https://<storageAccount>.<serviceName>.core.windows.net/<clusterName><path> Google: gs://<bucket><path> |
+| recovery.clusterName | string | `""` | The original cluster name when used in backups. Also known as serverName. |
+| recovery.destinationPath | string | `""` | Overrides the provider specific default path. Defaults to: S3: s3://<bucket><path> Azure: https://<storageAccount>.<serviceName>.core.windows.net/<containerName><path> Google: gs://<bucket><path> |
 | recovery.endpointCA | object | `{"create":false,"key":"","name":"","value":""}` | Specifies a CA bundle to validate a privately signed certificate. |
 | recovery.endpointCA.create | bool | `false` | Creates a secret with the given value if true, otherwise uses an existing secret. |
 | recovery.endpointURL | string | `""` | Overrides the provider specific default endpoint. Defaults to: S3: https://s3.<region>.amazonaws.com" Leave empty if using the default S3 endpoint |

--- a/charts/cluster/templates/_bootstrap.tpl
+++ b/charts/cluster/templates/_bootstrap.tpl
@@ -37,7 +37,7 @@ bootstrap:
 externalClusters:
   - name: objectStoreRecoveryCluster
     barmanObjectStore:
-      serverName: {{ .Values.recovery.serverName }}
+      serverName: {{ .Values.recovery.clusterName }}
       {{- $d := dict "chartFullname" (include "cluster.fullname" .) "scope" .Values.recovery "secretSuffix" "-recovery" -}}
       {{- include "cluster.barmanObjectStoreConfig" $d | nindent 4 }}
 {{-  else }}

--- a/charts/cluster/values.yaml
+++ b/charts/cluster/values.yaml
@@ -35,7 +35,7 @@ recovery:
   backupName: ""  # Name of the backup to recover from. Required if method is `backup`.
 
   ##
-  # -- Object Store Recovery Method
+  # -- The original cluster name when used in backups. Also known as serverName.
   clusterName: ""
   # -- Overrides the provider specific default endpoint. Defaults to:
   # S3: https://s3.<region>.amazonaws.com"
@@ -50,7 +50,7 @@ recovery:
     value: ""
   # -- Overrides the provider specific default path. Defaults to:
   # S3: s3://<bucket><path>
-  # Azure: https://<storageAccount>.<serviceName>.core.windows.net/<clusterName><path>
+  # Azure: https://<storageAccount>.<serviceName>.core.windows.net/<containerName><path>
   # Google: gs://<bucket><path>
   destinationPath: ""
   # -- One of `s3`, `azure` or `google`
@@ -204,7 +204,7 @@ backups:
 
   # -- Overrides the provider specific default path. Defaults to:
   # S3: s3://<bucket><path>
-  # Azure: https://<storageAccount>.<serviceName>.core.windows.net/<clusterName><path>
+  # Azure: https://<storageAccount>.<serviceName>.core.windows.net/<containerName><path>
   # Google: gs://<bucket><path>
   destinationPath: ""
   # -- One of `s3`, `azure` or `google`


### PR DESCRIPTION
Bug Fix: barmanObjectStore.serverName not initialized correctly preventing recovery when the cluster name is different.