### PR TITLE
feat(cluster): Make roles configurable

### DIFF
--- a/charts/cluster/README.md
+++ b/charts/cluster/README.md
@@ -168,6 +168,7 @@ refer to  the [CloudNativePG Documentation](https://cloudnative-pg.io/documentat
 | cluster.primaryUpdateStrategy | string | `"unsupervised"` | Strategy to follow to upgrade the primary server during a rolling update procedure, after all replicas have been successfully updated: it can be automated (unsupervised - default) or manual (supervised) |
 | cluster.priorityClassName | string | `""` |  |
 | cluster.resources | object | `{}` | Resources requirements of every generated Pod. Please refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ for more information. We strongly advise you use the same setting for limits and requests so that your cluster pods are given a Guaranteed QoS. See: https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/ |
+| cluster.roles | list | `[]` | This feature enables declarative management of existing roles, as well as the creation of new roles if they are not already present in the database. See: https://cloudnative-pg.io/documentation/current/declarative_role_management/ |
 | cluster.storage.size | string | `"8Gi"` |  |
 | cluster.storage.storageClass | string | `""` |  |
 | cluster.superuserSecret | string | `""` |  |

--- a/charts/cluster/templates/cluster.yaml
+++ b/charts/cluster/templates/cluster.yaml
@@ -57,6 +57,12 @@ spec:
       {{- toYaml . | nindent 6 }}
     {{ end }}
 
+  managed:
+    {{- with .Values.cluster.roles }}
+    roles:
+      {{- toYaml . | nindent 6 }}
+    {{ end }}
+
   monitoring:
     enablePodMonitor: {{ and .Values.cluster.monitoring.enabled .Values.cluster.monitoring.podMonitor.enabled }}
     {{- if not (empty .Values.cluster.monitoring.customQueries) }}

--- a/charts/cluster/values.schema.json
+++ b/charts/cluster/values.schema.json
@@ -242,6 +242,9 @@
                 "resources": {
                     "type": "object"
                 },
+                "roles": {
+                    "type": "array"
+                },
                 "storage": {
                     "type": "object",
                     "properties": {

--- a/charts/cluster/values.yaml
+++ b/charts/cluster/values.yaml
@@ -144,6 +144,19 @@ cluster:
   enableSuperuserAccess: true
   superuserSecret: ""
 
+  # -- This feature enables declarative management of existing roles, as well as the creation of new roles if they are not
+  # already present in the database.
+  # See: https://cloudnative-pg.io/documentation/current/declarative_role_management/
+  roles: []
+    # - name: dante
+    #   ensure: present
+    #   comment: Dante Alighieri
+    #   login: true
+    #   superuser: false
+    #   inRoles:
+    #     - pg_monitor
+    #     - pg_signal_backend
+
   monitoring:
     # -- Whether to enable monitoring
     enabled: false


### PR DESCRIPTION
This makes it possible to configure roles using the chart by adding an array in `cluster.roles` in `values.yaml`. The content of the array are taken as is and used as `.spec.managed.roles.`

This is a follow up to PR #226, which ended up with conflicts, so I started a new one.

In this new PR I signed off my changes, and I ran `make schema docs`.

The rationale for adding the `with` inside instead of outside `managed:` in `cluster.yaml` is that in case it is needed at some point to bring other things into `managed`, we would have to put an `if` with several conditions outside, and several `ifs` inside in order to avoid the empty element. I did try the chart without specifying roles to check if the empty `managed` was a problem, and there was no problem.

Closes #201 