### PR TITLE
bugfix(cluster): Propagate inheritFromAzureAD to the barman configuration

### DIFF
--- a/charts/cluster/templates/_barman_object_store.tpl
+++ b/charts/cluster/templates/_barman_object_store.tpl
@@ -35,7 +35,7 @@
   azureCredentials:
   {{- if .scope.azure.inheritFromAzureAD }}
     inheritFromAzureAD: true
-  {{- else if .scope.azure.inheritFromAzureAD }}
+  {{- else if .scope.azure.connectionString }}
     connectionString:
       name: {{ .chartFullname }}-backup-azure{{ .secretSuffix }}-creds
       key: AZURE_CONNECTION_STRING

--- a/charts/cluster/templates/_barman_object_store.tpl
+++ b/charts/cluster/templates/_barman_object_store.tpl
@@ -33,7 +33,7 @@
   destinationPath: "https://{{ required "You need to specify Azure storageAccount if destinationPath is not specified." .scope.azure.storageAccount }}.{{ .scope.azure.serviceName }}.core.windows.net/{{ .scope.azure.containerName }}{{ .scope.azure.path }}"
   {{- end }}
   azureCredentials:
-  {{- if .scope.azure.connectionString }}
+  {{- if .scope.azure.inheritFromAzureAD }}
     inheritFromAzureAD: true
   {{- else if .scope.azure.inheritFromAzureAD }}
     connectionString:

--- a/charts/cluster/templates/_barman_object_store.tpl
+++ b/charts/cluster/templates/_barman_object_store.tpl
@@ -34,6 +34,8 @@
   {{- end }}
   azureCredentials:
   {{- if .scope.azure.connectionString }}
+    inheritFromAzureAD: true
+  {{- else if .scope.azure.inheritFromAzureAD }}
     connectionString:
       name: {{ .chartFullname }}-backup-azure{{ .secretSuffix }}-creds
       key: AZURE_CONNECTION_STRING


### PR DESCRIPTION
Currently the cluster chart allows setting inheritFromAzureAD, but this is not propagated into the configuration.