### PR TITLE
Update charts/cluster/README.md - fix Getting Started doc markdown link by escaping space

### DIFF
--- a/charts/cluster/README.md
+++ b/charts/cluster/README.md
@@ -51,7 +51,7 @@ helm upgrade --install cnpg \
 cnpg/cluster
 ```
 
-A more detailed guide can be found here: [Getting Started](docs/Getting Started.md)
+A more detailed guide can be found in the [Getting Started docs](<./docs/Getting Started.md>).
 
 Cluster Configuration
 ---------------------

--- a/charts/cluster/README.md.gotmpl
+++ b/charts/cluster/README.md.gotmpl
@@ -58,7 +58,7 @@ helm upgrade --install cnpg \
 cnpg/cluster
 ```
 
-A more detailed guide can be found here: [Getting Started](docs/Getting Started.md)
+A more detailed guide can be found in the [Getting Started docs](<./docs/Getting Started.md>).
 
 
 Cluster Configuration


### PR DESCRIPTION
This add sandwiches the `Getting Started.md` file link in `<>` so that the space in the file is escaped, which will then render the link in the `README.md` when viewing on GitHub.