### PR TITLE
(fix) Bump chart dependency grafana-dashboards to version 0.2

### DIFF
--- a/charts/cloudnative-pg/Chart.yaml
+++ b/charts/cloudnative-pg/Chart.yaml
@@ -40,5 +40,5 @@ dependencies:
   - name: cluster
     alias: monitoring
     condition: monitoring.grafanaDashboard.create
-    version: "0.0"
+    version: "0.2"
     repository: https://cloudnative-pg.github.io/grafana-dashboards


### PR DESCRIPTION
Fixes #267 

Change the version of the dependency https://cloudnative-pg.github.io/grafana-dashboards to 0.2