### PR TITLE
fix init db to actually provision with a secret

### DIFF
--- a/charts/cluster/values.yaml
+++ b/charts/cluster/values.yaml
@@ -192,7 +192,8 @@ cluster:
   initdb: {}
     # database: app
     # owner: "" # Defaults to the database name
-    # secret: "" # Name of the secret containing the initial credentials for the owner of the user database. If empty a new secret will be created from scratch
+    # secret: 
+    #   name: "" # Name of the secret containing the initial credentials for the owner of the user database. If empty a new secret will be created from scratch
     # postInitSQL:
     #   - CREATE EXTENSION IF NOT EXISTS vector;
 


### PR DESCRIPTION
helm.go:84: [debug] admission webhook "mcluster.cnpg.io" denied the request: json: cannot unmarshal string into Go struct field BootstrapInitDB.spec.bootstrap.initdb.secret of type v1.LocalObjectReference


The defazult values fail to provision,

In order to get the secret to work, you have to add the name key,.