### PR TITLE
feat(cluster): add the possibility to use an existing secret for cloud credentials

### DIFF
--- a/charts/cluster/templates/_barman_object_store.tpl
+++ b/charts/cluster/templates/_barman_object_store.tpl
@@ -23,10 +23,10 @@
   {{- end }}
   s3Credentials:
     accessKeyId:
-      name: {{ .chartFullname }}-backup-s3{{ .secretSuffix }}-creds
+      name: {{ default (printf "%s-backup-s3%s-creds" .chartFullname (default "" .secretSuffix)) .scope.existingSecret }}
       key: ACCESS_KEY_ID
     secretAccessKey:
-      name: {{ .chartFullname }}-backup-s3{{ .secretSuffix }}-creds
+      name: {{ default (printf "%s-backup-s3%s-creds" .chartFullname (default "" .secretSuffix)) .scope.existingSecret }}
       key: ACCESS_SECRET_KEY
 {{- else if eq .scope.provider "azure" }}
   {{- if empty .scope.destinationPath }}
@@ -37,19 +37,19 @@
     inheritFromAzureAD: true
   {{- else if .scope.azure.connectionString }}
     connectionString:
-      name: {{ .chartFullname }}-backup-azure{{ .secretSuffix }}-creds
+      name: {{ default (printf "%s-backup-azure%s-creds" .chartFullname (default "" .secretSuffix)) .scope.existingSecret }}
       key: AZURE_CONNECTION_STRING
   {{- else }}
     storageAccount:
-      name: {{ .chartFullname }}-backup-azure{{ .secretSuffix }}-creds
+      name: {{ default (printf "%s-backup-azure%s-creds" .chartFullname (default "" .secretSuffix)) .scope.existingSecret }}
       key: AZURE_STORAGE_ACCOUNT
     {{- if .scope.azure.storageKey }}
     storageKey:
-      name: {{ .chartFullname }}-backup-azure{{ .secretSuffix }}-creds
+      name: {{ default (printf "%s-backup-azure%s-creds" .chartFullname (default "" .secretSuffix)) .scope.existingSecret }}
       key: AZURE_STORAGE_KEY
     {{- else }}
     storageSasToken:
-      name: {{ .chartFullname }}-backup-azure{{ .secretSuffix }}-creds
+      name: {{ default (printf "%s-backup-azure%s-creds" .chartFullname (default "" .secretSuffix)) .scope.existingSecret }}
       key: AZURE_STORAGE_SAS_TOKEN
     {{- end }}
   {{- end }}
@@ -60,7 +60,7 @@
   googleCredentials:
     gkeEnvironment: {{ .scope.google.gkeEnvironment }}
     applicationCredentials:
-      name: {{ .chartFullname }}-backup-google{{ .secretSuffix }}-creds
+      name: {{ default (printf "%s-backup-google%s-creds" .chartFullname (default "" .secretSuffix)) .scope.existingSecret }}
       key: APPLICATION_CREDENTIALS
 {{- end -}}
 {{- end -}}

--- a/charts/cluster/templates/backup-azure-creds.yaml
+++ b/charts/cluster/templates/backup-azure-creds.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.backups.enabled (eq .Values.backups.provider "azure") }}
+{{- if and .Values.backups.enabled (eq .Values.backups.provider "azure") (empty .Values.backups.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/cluster/templates/backup-azure-recovery-creds.yaml
+++ b/charts/cluster/templates/backup-azure-recovery-creds.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq .Values.mode "recovery" ) (eq .Values.recovery.method "object_store") (eq .Values.recovery.provider "azure") }}
+{{- if and (eq .Values.mode "recovery" ) (eq .Values.recovery.method "object_store") (eq .Values.recovery.provider "azure") (empty .Values.recovery.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/cluster/templates/backup-google-creds.yaml
+++ b/charts/cluster/templates/backup-google-creds.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.backups.enabled (eq .Values.backups.provider "google") }}
+{{- if and .Values.backups.enabled (eq .Values.backups.provider "google") (empty .Values.backups.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/cluster/templates/backup-google-recovery-creds.yaml
+++ b/charts/cluster/templates/backup-google-recovery-creds.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq .Values.mode "recovery" ) (eq .Values.recovery.method "object_store") (eq .Values.recovery.provider "google") }}
+{{- if and (eq .Values.mode "recovery" ) (eq .Values.recovery.method "object_store") (eq .Values.recovery.provider "google") (empty .Values.recovery.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/cluster/templates/backup-s3-creds.yaml
+++ b/charts/cluster/templates/backup-s3-creds.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.backups.enabled (eq .Values.backups.provider "s3") }}
+{{- if and .Values.backups.enabled (eq .Values.backups.provider "s3") (empty .Values.backups.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/cluster/templates/backup-s3-recovery-creds.yaml
+++ b/charts/cluster/templates/backup-s3-recovery-creds.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq .Values.mode "recovery" ) (eq .Values.recovery.method "object_store") (eq .Values.recovery.provider "s3") }}
+{{- if and (eq .Values.mode "recovery" ) (eq .Values.recovery.method "object_store") (eq .Values.recovery.provider "s3") (empty .Values.recovery.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/cluster/values.yaml
+++ b/charts/cluster/values.yaml
@@ -55,6 +55,13 @@ recovery:
   destinationPath: ""
   # -- One of `s3`, `azure` or `google`
   provider: s3
+  # -- Uses an existing secret for the recovery cloud credentials. If set then the credentials in the
+  # following cloud block are ignored. Depending on the cloud that should be
+  # used different parameters need to be set in the secret
+  # S3: ACCESS_KEY_ID and ACCESS_SECRET_KEY
+  # Azure: AZURE_CONNECTION_STRING, AZURE_STORAGE_ACCOUNT, AZURE_STORAGE_KEY and AZURE_STORAGE_SAS_TOKEN
+  # Google: APPLICATION_CREDENTIALS
+  existingSecret: ""
   s3:
     region: ""
     bucket: ""
@@ -222,6 +229,13 @@ backups:
   destinationPath: ""
   # -- One of `s3`, `azure` or `google`
   provider: s3
+  # -- Uses an existing secret for the backup cloud credentials. If set then the credentials in the
+  # following cloud block are ignored. Depending on the cloud that should be
+  # used different parameters need to be set in the secret
+  # S3: ACCESS_KEY_ID and ACCESS_SECRET_KEY
+  # Azure: AZURE_CONNECTION_STRING, AZURE_STORAGE_ACCOUNT, AZURE_STORAGE_KEY and AZURE_STORAGE_SAS_TOKEN
+  # Google: APPLICATION_CREDENTIALS
+  existingSecret: ""
   s3:
     region: ""
     bucket: ""


### PR DESCRIPTION
Our setup includes ArgoCD and SealedSecrets. As in the current helm chart the cloud credentials need to be in plaintext we can't commit this to git (GitOps).
That's why we adjusted the helm chart to accept an existing secret that we deployed earlier with ArgoCD and SealedSecrets.
We are currently using this for AWS s3 and the backup is working as expected.

We tried to adjust the helm chart as less as possible.

This PR should fix #197 