### PR TITLE
fix(cluster): Prometheus Rule CNPGClusterOffline false positives

### DIFF
--- a/charts/cluster/prometheus_rules/cluster-high_connection-critical.yaml
+++ b/charts/cluster/prometheus_rules/cluster-high_connection-critical.yaml
@@ -8,7 +8,7 @@ annotations:
     the maximum number of connections.
   runbook_url: https://github.com/cloudnative-pg/charts/blob/main/charts/cluster/docs/runbooks/CNPGClusterHighConnectionsCritical.md
 expr: |
-  sum by (pod) (cnpg_backends_total{namespace=~"{{ .namespace }}", pod=~"{{ .podSelector }}"}) / max by (pod) (cnpg_pg_settings_setting{name="max_connections", namespace=~"{{ .namespace }}", pod=~"{{ .podSelector }}"}) * 100 > 95
+  sum by (pod) (cnpg_backends_total{namespace="{{ .namespace }}", pod=~"{{ .podSelector }}"}) / max by (pod) (cnpg_pg_settings_setting{name="max_connections", namespace="{{ .namespace }}", pod=~"{{ .podSelector }}"}) * 100 > 95
 for: 5m
 labels:
   severity: critical

--- a/charts/cluster/prometheus_rules/cluster-high_connection-warning.yaml
+++ b/charts/cluster/prometheus_rules/cluster-high_connection-warning.yaml
@@ -8,7 +8,7 @@ annotations:
     the maximum number of connections.
   runbook_url: https://github.com/cloudnative-pg/charts/blob/main/charts/cluster/docs/runbooks/CNPGClusterHighConnectionsWarning.md
 expr: |
-  sum by (pod) (cnpg_backends_total{namespace=~"{{ .namespace }}", pod=~"{{ .podSelector }}"}) / max by (pod) (cnpg_pg_settings_setting{name="max_connections", namespace=~"{{ .namespace }}", pod=~"{{ .podSelector }}"}) * 100 > 80
+  sum by (pod) (cnpg_backends_total{namespace="{{ .namespace }}", pod=~"{{ .podSelector }}"}) / max by (pod) (cnpg_pg_settings_setting{name="max_connections", namespace="{{ .namespace }}", pod=~"{{ .podSelector }}"}) * 100 > 80
 for: 5m
 labels:
   severity: warning

--- a/charts/cluster/prometheus_rules/cluster-high_replication_lag.yaml
+++ b/charts/cluster/prometheus_rules/cluster-high_replication_lag.yaml
@@ -10,7 +10,7 @@ annotations:
     High replication lag indicates network issues, busy instances, slow queries or suboptimal configuration.
   runbook_url: https://github.com/cloudnative-pg/charts/blob/main/charts/cluster/docs/runbooks/CNPGClusterHighReplicationLag.md
 expr: |
-  max(cnpg_pg_replication_lag{namespace=~"{{ .namespace }}",pod=~"{{ .podSelector }}"}) * 1000 > 1000
+  max(cnpg_pg_replication_lag{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"}) * 1000 > 1000
 for: 5m
 labels:
   severity: warning

--- a/charts/cluster/prometheus_rules/cluster-instances_on_same_node.yaml
+++ b/charts/cluster/prometheus_rules/cluster-instances_on_same_node.yaml
@@ -10,7 +10,7 @@ annotations:
     A failure or scheduled downtime of a single node will lead to a potential service disruption and/or data loss.
   runbook_url: https://github.com/cloudnative-pg/charts/blob/main/charts/cluster/docs/runbooks/CNPGClusterInstancesOnSameNode.md
 expr: |
-  count by (node) (kube_pod_info{namespace=~"{{ .namespace }}", pod=~"{{ .podSelector }}"}) > 1
+  count by (node) (kube_pod_info{namespace="{{ .namespace }}", pod=~"{{ .podSelector }}"}) > 1
 for: 5m
 labels:
   severity: warning

--- a/charts/cluster/prometheus_rules/cluster-offline.yaml
+++ b/charts/cluster/prometheus_rules/cluster-offline.yaml
@@ -10,7 +10,7 @@ annotations:
     potential service disruption and/or data loss.
   runbook_url: https://github.com/cloudnative-pg/charts/blob/main/charts/cluster/docs/runbooks/CNPGClusterOffline.md
 expr: |
-  ({{ .Values.cluster.instances }} - count(cnpg_collector_up{namespace=~"{{ .namespace }}",pod=~"{{ .podSelector }}"}) OR vector(0)) > 0
+  ({{ .Values.cluster.instances }} - count(cnpg_collector_up{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"}) OR vector(0)) > 0
 for: 5m
 labels:
   severity: critical

--- a/charts/cluster/prometheus_rules/cluster-offline.yaml
+++ b/charts/cluster/prometheus_rules/cluster-offline.yaml
@@ -10,7 +10,7 @@ annotations:
     potential service disruption and/or data loss.
   runbook_url: https://github.com/cloudnative-pg/charts/blob/main/charts/cluster/docs/runbooks/CNPGClusterOffline.md
 expr: |
-  ({{ .Values.cluster.instances }} - count(cnpg_collector_up{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"}) OR vector(0)) > 0
+  (count(cnpg_collector_up{namespace="{{ .namespace }}",pod=~"{{ .podSelector }}"}) OR on() vector(0)) == 0
 for: 5m
 labels:
   severity: critical

--- a/charts/cluster/prometheus_rules/cluster-zone_spread-warning.yaml
+++ b/charts/cluster/prometheus_rules/cluster-zone_spread-warning.yaml
@@ -9,7 +9,7 @@ annotations:
     A disaster in one availability zone will lead to a potential service disruption and/or data loss.
   runbook_url: https://github.com/cloudnative-pg/charts/blob/main/charts/cluster/docs/runbooks/CNPGClusterZoneSpreadWarning.md
 expr: |
-  {{ .Values.cluster.instances }} > count(count by (label_topology_kubernetes_io_zone) (kube_pod_info{namespace=~"{{ .namespace }}", pod=~"{{ .podSelector }}"} * on(node,instance) group_left(label_topology_kubernetes_io_zone) kube_node_labels)) < 3
+  {{ .Values.cluster.instances }} > count(count by (label_topology_kubernetes_io_zone) (kube_pod_info{namespace="{{ .namespace }}", pod=~"{{ .podSelector }}"} * on(node,instance) group_left(label_topology_kubernetes_io_zone) kube_node_labels)) < 3
 for: 5m
 labels:
   severity: warning


### PR DESCRIPTION
Fixes the false positive `CNPGClusterOffline` alert reported in #283.

Additionally this improves the query performance by performing a direct match instead of a pattern match on `namespace`.

Closes: #283 