### PR TITLE
add ability to set WATCH_NAMESPACES

### DIFF
--- a/charts/cloudnative-pg/Chart.yaml
+++ b/charts/cloudnative-pg/Chart.yaml
@@ -18,7 +18,7 @@ name: cloudnative-pg
 description: CloudNativePG Operator Helm Chart
 icon: https://raw.githubusercontent.com/cloudnative-pg/artwork/main/cloudnativepg-logo.svg
 type: application
-version: "0.21.2"
+version: "0.22.0"
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning, they should reflect the version the application is using.

--- a/charts/cloudnative-pg/templates/deployment.yaml
+++ b/charts/cloudnative-pg/templates/deployment.yaml
@@ -72,6 +72,8 @@ spec:
               fieldPath: metadata.namespace
         - name: MONITORING_QUERIES_CONFIGMAP
           value: "{{ .Values.monitoringQueriesConfigMap.name }}"
+        - name: WATCH_NAMESPACE
+          value: "{{ .Values.watchNamespace }}"
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         livenessProbe:

--- a/charts/cloudnative-pg/values.yaml
+++ b/charts/cloudnative-pg/values.yaml
@@ -47,6 +47,9 @@ webhook:
   readinessProbe:
     initialDelaySeconds: 3
 
+# -- Namespaces to watch as comma separated list i.e namespace-a,namespace-b. Empty will default to all namespaces.
+watchNamespace: ""
+
 # -- Operator configuration.
 config:
   # -- Specifies whether the secret should be created.
@@ -61,7 +64,6 @@ config:
   data: {}
   # INHERITED_ANNOTATIONS: categories
   # INHERITED_LABELS: environment, workload, app
-  # WATCH_NAMESPACE: namespace-a,namespace-b
 
 # -- Additinal arguments to be added to the operator's args list.
 additionalArgs: []


### PR DESCRIPTION
add ability to set WATCH_NAMESPACES to restrict operator to only watch cluster instances in declared namespaces which defaults to all if empty as spcificied.