### PR TITLE
fix additionalEnv typo in deployment.yaml

### DIFF
--- a/charts/cloudnative-pg/templates/deployment.yaml
+++ b/charts/cloudnative-pg/templates/deployment.yaml
@@ -73,7 +73,7 @@ spec:
         - name: MONITORING_QUERIES_CONFIGMAP
           value: "{{ .Values.monitoringQueriesConfigMap.name }}"
         {{- if .Values.additionalEnv }}
-        {{- tpl (.Values.additionalEnvVars | toYaml) . | nindent 8 }}
+        {{- tpl (.Values.additionalEnv | toYaml) . | nindent 8 }}
         {{- end }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}


### PR DESCRIPTION
There was a typo in deployment.yaml  additionalEnvVars -> additionalEnv  

I accidentally let this in there from using the web ide