### PR TITLE
Add walStorage capability and remove gkeEnvironment conflict in cluster chart.

### DIFF
--- a/charts/cluster/templates/_barman_object_store.tpl
+++ b/charts/cluster/templates/_barman_object_store.tpl
@@ -62,8 +62,10 @@
   {{- $secretName := coalesce .scope.secret.name (printf "%s-%s-google-creds" .chartFullname .secretPrefix) }}
   googleCredentials:
     gkeEnvironment: {{ .scope.google.gkeEnvironment }}
+{{- if not .scope.google.gkeEnvironment }}
     applicationCredentials:
       name: {{ $secretName }}
       key: APPLICATION_CREDENTIALS
+{{- end }}
 {{- end -}}
 {{- end -}}

--- a/charts/cluster/templates/cluster.yaml
+++ b/charts/cluster/templates/cluster.yaml
@@ -28,7 +28,8 @@ spec:
   walStorage:
     size: {{ .Values.cluster.walStorage.size }}
     storageClass: {{ .Values.cluster.walStorage.storageClass }}
-{{- end }}  {{- with .Values.cluster.resources }}
+{{- end }}  
+  {{- with .Values.cluster.resources }}
   resources:
     {{- toYaml . | nindent 4 }}
   {{ end }}

--- a/charts/cluster/templates/cluster.yaml
+++ b/charts/cluster/templates/cluster.yaml
@@ -24,8 +24,11 @@ spec:
   storage:
     size: {{ .Values.cluster.storage.size }}
     storageClass: {{ .Values.cluster.storage.storageClass }}
-
-  {{- with .Values.cluster.resources }}
+{{- if .Values.cluster.walStorage }}
+  walStorage:
+    size: {{ .Values.cluster.walStorage.size }}
+    storageClass: {{ .Values.cluster.walStorage.storageClass }}
+{{- end }}  {{- with .Values.cluster.resources }}
   resources:
     {{- toYaml . | nindent 4 }}
   {{ end }}

--- a/charts/cluster/values.schema.json
+++ b/charts/cluster/values.schema.json
@@ -270,6 +270,17 @@
                         }
                     }
                 },
+                "walStorage": {
+                    "type": "object",
+                    "properties": {
+                        "size": {
+                            "type": "string"
+                        },
+                        "storageClass": {
+                            "type": "string"
+                        }
+                    }
+                },
                 "superuserSecret": {
                     "type": "string"
                 }

--- a/charts/cluster/values.yaml
+++ b/charts/cluster/values.yaml
@@ -101,6 +101,10 @@ cluster:
   storage:
     size: 8Gi
     storageClass: ""
+    
+  walStorage:
+    size: 1Gi
+    storageClass: ""
 
   # -- The UID of the postgres user inside the image, defaults to 26
   postgresUID: 26


### PR DESCRIPTION
The operator supports walStorage, but the chart does not (yet).  This PR fixes that.

In addition, this PR addresses issue https://github.com/cloudnative-pg/charts/issues/311 so gkeEnvironment can be set without the operator admission webhook rejecting the update.