### PR TITLE
chore: add support for `hostNetwork` in chart

### DIFF
--- a/charts/cloudnative-pg/templates/deployment.yaml
+++ b/charts/cloudnative-pg/templates/deployment.yaml
@@ -46,6 +46,12 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.hostNetwork }}
+      hostNetwork: {{ .Values.hostNetwork }}
+      {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy }}
+      {{- end }}
       containers:
       - args:
         - controller

--- a/charts/cloudnative-pg/values.schema.json
+++ b/charts/cloudnative-pg/values.schema.json
@@ -95,6 +95,12 @@
         "imagePullSecrets": {
             "type": "array"
         },
+        "hostNetwork": {
+            "type": "boolean"
+        },
+        "dnsPolicy": {
+            "type": "string"
+        },
         "monitoring": {
             "type": "object",
             "properties": {

--- a/charts/cloudnative-pg/values.yaml
+++ b/charts/cloudnative-pg/values.yaml
@@ -29,6 +29,9 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+hostNetwork: false
+dnsPolicy: "ClusterFirst"
+
 crds:
   # -- Specifies whether the CRDs should be created when installing the chart.
   create: true

--- a/charts/cloudnative-pg/values.yaml
+++ b/charts/cloudnative-pg/values.yaml
@@ -30,7 +30,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 hostNetwork: false
-dnsPolicy: "ClusterFirst"
+dnsPolicy: ""
 
 crds:
   # -- Specifies whether the CRDs should be created when installing the chart.


### PR DESCRIPTION
When running in eks, the deployment is failing because of the webhook with the following error:

> Internal error occurred: failed calling webhook "mcluster.cnpg.io": failed to call webhook: Address is not allowed

The fix would be to set `hostNetwork` true but it is not configurable in the chart. 

In addition to that, the `dnsPolicy` needs to be set to `ClusterFirstWithHostNet` to give `hostNetwork` pods access to internal DNS.