### PR TITLE
feat(cloudnative-pg): add support for CRD annotations

### DIFF
--- a/charts/cloudnative-pg/templates/crds/crds.yaml
+++ b/charts/cloudnative-pg/templates/crds/crds.yaml
@@ -5,6 +5,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
     helm.sh/resource-policy: keep
+    {{- with .Values.crds.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: backups.postgresql.cnpg.io
 spec:
   group: postgresql.cnpg.io
@@ -442,6 +445,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
     helm.sh/resource-policy: keep
+    {{- with .Values.crds.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: clusterimagecatalogs.postgresql.cnpg.io
 spec:
   group: postgresql.cnpg.io
@@ -524,6 +530,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
     helm.sh/resource-policy: keep
+    {{- with .Values.crds.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: clusters.postgresql.cnpg.io
 spec:
   group: postgresql.cnpg.io
@@ -6756,6 +6765,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
     helm.sh/resource-policy: keep
+    {{- with .Values.crds.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: imagecatalogs.postgresql.cnpg.io
 spec:
   group: postgresql.cnpg.io
@@ -6837,6 +6849,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
     helm.sh/resource-policy: keep
+    {{- with .Values.crds.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: poolers.postgresql.cnpg.io
 spec:
   group: postgresql.cnpg.io
@@ -15613,6 +15628,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
     helm.sh/resource-policy: keep
+    {{- with .Values.crds.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: scheduledbackups.postgresql.cnpg.io
 spec:
   group: postgresql.cnpg.io

--- a/charts/cloudnative-pg/values.yaml
+++ b/charts/cloudnative-pg/values.yaml
@@ -35,6 +35,8 @@ dnsPolicy: ""
 crds:
   # -- Specifies whether the CRDs should be created when installing the chart.
   create: true
+  # -- Additional CRDs annotations
+  annotations: {}
 
 # -- The webhook configuration.
 webhook:


### PR DESCRIPTION
Adding support for CRD annotations can be really usefull especially with deployment services like argocd, spinnaker or others.
For example, in my case I would like to set this annotations due to the size of the CRDs:
```
    annotations:
      argocd.argoproj.io/sync-options: ServerSideApply=true
```
Ref docs: https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#server-side-apply