### PR TITLE
Bug Fix: lint-job not working

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - '**'
       - '!gh-pages'
+  pull_request:
+    branches-ignore:
+      - 'gh-pages'
 
 jobs:
   linter:


### PR DESCRIPTION
The Lint job doesn't run for PRs from outside, because the job is configured to only run on pushes to branches. This fixes that.