### PR TITLE
Revert to walStorage disabled by default and add enabled flag to enable

### DIFF
--- a/charts/cluster/templates/cluster.yaml
+++ b/charts/cluster/templates/cluster.yaml
@@ -24,7 +24,7 @@ spec:
   storage:
     size: {{ .Values.cluster.storage.size }}
     storageClass: {{ .Values.cluster.storage.storageClass }}
-{{- if .Values.cluster.walStorage }}
+{{- if .Values.cluster.walStorage.enabled }}
   walStorage:
     size: {{ .Values.cluster.walStorage.size }}
     storageClass: {{ .Values.cluster.walStorage.storageClass }}

--- a/charts/cluster/test/postgresql-cluster-configuration/01-non_default_configuration_cluster.yaml
+++ b/charts/cluster/test/postgresql-cluster-configuration/01-non_default_configuration_cluster.yaml
@@ -9,6 +9,7 @@ cluster:
     size: 256Mi
     storageClass: standard
   walStorage:
+    enabled: true
     size: 256Mi
     storageClass: standard
   postgresUID: 1001

--- a/charts/cluster/values.schema.json
+++ b/charts/cluster/values.schema.json
@@ -276,6 +276,9 @@
                 "walStorage": {
                     "type": "object",
                     "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
                         "size": {
                             "type": "string"
                         },

--- a/charts/cluster/values.yaml
+++ b/charts/cluster/values.yaml
@@ -136,6 +136,7 @@ cluster:
     storageClass: ""
 
   walStorage:
+    enabled: false
     size: 1Gi
     storageClass: ""
 


### PR DESCRIPTION
Fixes https://github.com/cloudnative-pg/charts/issues/366

Upgrading from cluster-v0.0.9 to cluster-v0.0.10 forces walStorage to enabled with no way to disable it.

This reverts to walStorage not being configured as in cluster-v0.0.9 unless `.Values.cluster.walStorage.enabled` is set to true.