### PR TITLE
add PGDBNAME to database-ping-test

### DIFF
--- a/charts/cluster/templates/tests/ping.yaml
+++ b/charts/cluster/templates/tests/ping.yaml
@@ -30,8 +30,13 @@ spec:
                 secretKeyRef:
                   name: {{ include "cluster.fullname" . }}-app
                   key: password
+            - name: PGDBNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "cluster.fullname" . }}-app
+                  key: dbname
           args:
             - "-c"
             - >-
               apk add postgresql-client &&
-              psql "postgresql://$PGUSER:$PGPASS@{{ include "cluster.fullname" . }}-rw.{{ .Release.Namespace }}.svc.cluster.local:5432" -c 'SELECT 1'
+              psql "postgresql://$PGUSER:$PGPASS@{{ include "cluster.fullname" . }}-rw.{{ .Release.Namespace }}.svc.cluster.local:5432/$PGDBNAME" -c 'SELECT 1'

--- a/charts/cluster/templates/tests/ping.yaml
+++ b/charts/cluster/templates/tests/ping.yaml
@@ -35,8 +35,9 @@ spec:
                 secretKeyRef:
                   name: {{ include "cluster.fullname" . }}-app
                   key: dbname
+                  optional: true
           args:
             - "-c"
             - >-
               apk add postgresql-client &&
-              psql "postgresql://$PGUSER:$PGPASS@{{ include "cluster.fullname" . }}-rw.{{ .Release.Namespace }}.svc.cluster.local:5432/$PGDBNAME" -c 'SELECT 1'
+              psql "postgresql://$PGUSER:$PGPASS@{{ include "cluster.fullname" . }}-rw.{{ .Release.Namespace }}.svc.cluster.local:5432/${PGDBNAME:-$PGUSER}" -c 'SELECT 1'


### PR DESCRIPTION
Fix #368 by adding `$PGDBNAME` env var to database-ping-test. 

Note that if the user uses a custom secret in the initdb, they will also need to add the dbname to the secret. 

I am happy to help in case of any missing changes for the fix. 