### PR TITLE
Change walStorage to an empty map in values.yaml

### DIFF
--- a/charts/cluster/values.yaml
+++ b/charts/cluster/values.yaml
@@ -135,9 +135,9 @@ cluster:
     size: 8Gi
     storageClass: ""
 
-  walStorage:
-    size: 1Gi
-    storageClass: ""
+  walStorage: {}
+    # size: 1Gi
+    # storageClass: ""
 
   # -- The UID of the postgres user inside the image, defaults to 26
   postgresUID: 26


### PR DESCRIPTION
Fixes https://github.com/cloudnative-pg/charts/issues/366
Replaces https://github.com/cloudnative-pg/charts/pull/367

This makes it optional so walStorage isn't forced to be included in the Cluster manifest