### PR TITLE
Add explicit `postgresql` in places where inferred by default `type`

### DIFF
--- a/charts/cluster/examples/basic.yaml
+++ b/charts/cluster/examples/basic.yaml
@@ -1,3 +1,4 @@
+type: postgresql
 mode: standalone
 version:
   postgresql: "16"

--- a/charts/cluster/examples/pgbouncer.yaml
+++ b/charts/cluster/examples/pgbouncer.yaml
@@ -1,3 +1,4 @@
+type: postgresql
 mode: standalone
 cluster:
   instances: 1

--- a/charts/cluster/examples/recovery-backup.yaml
+++ b/charts/cluster/examples/recovery-backup.yaml
@@ -1,3 +1,4 @@
+type: postgresql
 mode: recovery
 
 recovery:

--- a/charts/cluster/examples/recovery-object_store.yaml
+++ b/charts/cluster/examples/recovery-object_store.yaml
@@ -1,3 +1,4 @@
+type: postgresql
 mode: recovery
 
 recovery:

--- a/charts/cluster/examples/recovery-pg_basebackup.yaml
+++ b/charts/cluster/examples/recovery-pg_basebackup.yaml
@@ -1,3 +1,4 @@
+type: postgresql
 mode: "recovery"
 
 recovery:

--- a/charts/cluster/examples/standalone-s3.yaml
+++ b/charts/cluster/examples/standalone-s3.yaml
@@ -1,3 +1,4 @@
+type: postgresql
 mode: standalone
 
 cluster:

--- a/charts/cluster/test/monitoring/01-monitoring_cluster.yaml
+++ b/charts/cluster/test/monitoring/01-monitoring_cluster.yaml
@@ -1,3 +1,4 @@
+type: postgresql
 mode: standalone
 cluster:
   instances: 2

--- a/charts/cluster/test/pooler/01-pooler_cluster.yaml
+++ b/charts/cluster/test/pooler/01-pooler_cluster.yaml
@@ -1,3 +1,4 @@
+type: postgresql
 mode: standalone
 cluster:
   instances: 2

--- a/charts/cluster/test/postgresql-cluster-configuration/01-non_default_configuration_cluster.yaml
+++ b/charts/cluster/test/postgresql-cluster-configuration/01-non_default_configuration_cluster.yaml
@@ -1,3 +1,4 @@
+type: postgresql
 mode: standalone
 cluster:
   instances: 2

--- a/charts/cluster/test/postgresql-minio-backup-restore/01-standalone_cluster.yaml
+++ b/charts/cluster/test/postgresql-minio-backup-restore/01-standalone_cluster.yaml
@@ -1,3 +1,4 @@
+type: postgresql
 mode: standalone
 
 cluster:

--- a/charts/cluster/test/postgresql-minio-backup-restore/05-recovery_backup_cluster.yaml
+++ b/charts/cluster/test/postgresql-minio-backup-restore/05-recovery_backup_cluster.yaml
@@ -1,3 +1,4 @@
+type: postgresql
 mode: recovery
 
 cluster:

--- a/charts/cluster/test/postgresql-minio-backup-restore/07-recovery_object_store_cluster.yaml
+++ b/charts/cluster/test/postgresql-minio-backup-restore/07-recovery_object_store_cluster.yaml
@@ -1,3 +1,4 @@
+type: postgresql
 mode: recovery
 
 cluster:

--- a/charts/cluster/test/postgresql-minio-backup-restore/09-recovery_backup_pitr_cluster.yaml
+++ b/charts/cluster/test/postgresql-minio-backup-restore/09-recovery_backup_pitr_cluster.yaml
@@ -1,3 +1,4 @@
+type: postgresql
 mode: recovery
 
 cluster:

--- a/charts/cluster/test/postgresql-pg_basebackup/00-source-cluster.yaml
+++ b/charts/cluster/test/postgresql-pg_basebackup/00-source-cluster.yaml
@@ -1,3 +1,4 @@
+type: postgresql
 mode: "standalone"
 cluster:
   instances: 1

--- a/charts/cluster/test/postgresql-pg_basebackup/02-pg_basebackup-cluster.yaml
+++ b/charts/cluster/test/postgresql-pg_basebackup/02-pg_basebackup-cluster.yaml
@@ -1,3 +1,4 @@
+type: postgresql
 mode: "recovery"
 recovery:
   method: "pg_basebackup"


### PR DESCRIPTION
In a few tests, the `type: ` is not provided, defaulting to `postgresql`. If a new value is set as default in the `values.yaml` file, the tests fail. This ensures that this won't be the case anymore.