### PR TITLE
Add empty string to the enum of allowed values for wal/backup encryption

### DIFF
--- a/charts/cloudnative-pg/templates/crds/crds.yaml
+++ b/charts/cloudnative-pg/templates/crds/crds.yaml
@@ -1689,6 +1689,7 @@ spec:
                             enum:
                             - AES256
                             - aws:kms
+                            - ''
                             type: string
                           immediateCheckpoint:
                             description: |-
@@ -1882,6 +1883,7 @@ spec:
                             enum:
                             - AES256
                             - aws:kms
+                            - ''
                             type: string
                           maxParallel:
                             description: |-


### PR DESCRIPTION
The [documentation](https://cloudnative-pg.io/documentation/1.24/cloudnative-pg.v1/#postgresql-cnpg-io-v1-DataBackupConfiguration) as well as the CRD itself mentions that empty string is a valid value, but it was missing from the property enum, causing some CI validation error on a project I'm working on (https://integration.wikimedia.org/ci/job/helm-lint/20336/console)

```
Cluster pg-basic is invalid: For field spec.backup.barmanObjectStore.wal.encryption: spec.backup.barmanObjectStore.wal.encryption must be one of the following: "AES256", "aws:kms" - For field spec.backup.barmanObjectStore.data.encryption: spec.backup.barmanObjectStore.data.encryption must be one of the following: "AES256", "aws:kms"
```