### PR TITLE
Re-order template keywords

### DIFF
--- a/charts/cluster/templates/cluster.yaml
+++ b/charts/cluster/templates/cluster.yaml
@@ -60,12 +60,12 @@ spec:
       {{- toYaml . | nindent 6 }}
       {{- end }}
     {{- with .Values.cluster.postgresql }}
-    parameters:
-      {{- toYaml .parameters | nindent 6 }}
     pg_hba:
       {{- toYaml .pg_hba | nindent 6 }}
     pg_ident:
       {{- toYaml .pg_ident | nindent 6 }}
+    parameters:
+      {{- toYaml .parameters | nindent 6 }}
     {{ end }}
 
   managed:


### PR DESCRIPTION
Issue was because YAML output for this section of the cluster.yaml was

parameters:
  parameters: {}
  pg_hba: []
  pg_indent: []

Whereas it should be

parameters: {}
pg_hba: {}
pg_indent: {}

but parameters is a helm keyword so it would consume all the keywords in the parameters step before pg_hba or pg_indent were called.

This simple re-ordering should fix the issue (and has for me in testing)

Closes: #408 