### PR TITLE
Fixed versions typo in image-catalog-timescaledb-ha 

### DIFF
--- a/charts/cluster/templates/image-catalog-timescaledb-ha.yaml
+++ b/charts/cluster/templates/image-catalog-timescaledb-ha.yaml
@@ -6,11 +6,11 @@ metadata:
 spec:
   images:
     - major: 12
-      image: timescale/timescaledb-ha:pg15-ts{{ .Values.version.timescaledb }}
+      image: timescale/timescaledb-ha:pg12-ts{{ .Values.version.timescaledb }}
     - major: 13
-      image: timescale/timescaledb-ha:pg15-ts{{ .Values.version.timescaledb }}
+      image: timescale/timescaledb-ha:pg13-ts{{ .Values.version.timescaledb }}
     - major: 14
-      image: timescale/timescaledb-ha:pg15-ts{{ .Values.version.timescaledb }}
+      image: timescale/timescaledb-ha:pg14-ts{{ .Values.version.timescaledb }}
     - major: 15
       image: timescale/timescaledb-ha:pg15-ts{{ .Values.version.timescaledb }}
     - major: 16


### PR DESCRIPTION
Older images needed their corresponding versions too. Fixed typo in charts/cluster/templates/image-catalog-timescaledb-ha.yaml