### PR TITLE
feat(cluster) add ServiceAccountTemplate annotations and labels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ schema: cloudnative-pg-schema cluster-schema ## Generate charts' schema using he
 
 cloudnative-pg-schema:
 	@helm schema-gen charts/cloudnative-pg/values.yaml | cat > charts/cloudnative-pg/values.schema.json || \
-		(echo "Please, run: helm plugin install https://github.com/karuppiah7890/helm-schema-gen.git" && exit 1)
+		(echo "Please, run: helm plugin install https://github.com/KnechtionsCoding/helm-schema-gen.git" && exit 1)
 
 cluster-schema:
 	@helm schema-gen charts/cluster/values.yaml | cat > charts/cluster/values.schema.json || \
-		(echo "Please, run: helm plugin install https://github.com/karuppiah7890/helm-schema-gen.git" && exit 1)
+		(echo "Please, run: helm plugin install https://github.com/KnechtionsCoding/helm-schema-gen.git" && exit 1)

--- a/charts/cluster/README.md
+++ b/charts/cluster/README.md
@@ -180,6 +180,8 @@ refer to  the [CloudNativePG Documentation](https://cloudnative-pg.io/documentat
 | cluster.priorityClassName | string | `""` |  |
 | cluster.resources | object | `{}` | Resources requirements of every generated Pod. Please refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ for more information. We strongly advise you use the same setting for limits and requests so that your cluster pods are given a Guaranteed QoS. See: https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/ |
 | cluster.roles | list | `[]` | This feature enables declarative management of existing roles, as well as the creation of new roles if they are not already present in the database. See: https://cloudnative-pg.io/documentation/current/declarative_role_management/ |
+| cluster.serviceAccount.annotations | object | `{}` | Annotations to be added to the ServiceAccount See: https://cloudnative-pg.io/documentation/current/appendixes/object_stores/#running-inside-google-kubernetes-engine See: https://cloudnative-pg.io/documentation/current/appendixes/object_stores/#iam-role-for-service-account-irsa |
+| cluster.serviceAccount.labels | object | `{}` | Labels to be added to the ServiceAccount |
 | cluster.storage.size | string | `"8Gi"` |  |
 | cluster.storage.storageClass | string | `""` |  |
 | cluster.superuserSecret | string | `""` |  |
@@ -274,4 +276,3 @@ TODO
 ----
 * IAM Role for S3 Service Account
 * Automatic provisioning of a Alert Manager configuration
-

--- a/charts/cluster/README.md.gotmpl
+++ b/charts/cluster/README.md.gotmpl
@@ -153,6 +153,3 @@ TODO
 ----
 * IAM Role for S3 Service Account
 * Automatic provisioning of a Alert Manager configuration
-
-
-{{ template "helm-docs.versionFooter" . }}

--- a/charts/cluster/templates/cluster.yaml
+++ b/charts/cluster/templates/cluster.yaml
@@ -28,7 +28,7 @@ spec:
   walStorage:
     size: {{ .Values.cluster.walStorage.size }}
     storageClass: {{ .Values.cluster.walStorage.storageClass }}
-{{- end }}  
+{{- end }}
   {{- with .Values.cluster.resources }}
   resources:
     {{- toYaml . | nindent 4 }}
@@ -38,6 +38,17 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   priorityClassName: {{ .Values.cluster.priorityClassName }}
+
+  serviceAccountTemplate:
+    metadata:
+      {{- with .Values.cluster.serviceAccount.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.cluster.serviceAccount.labels }}
+      labels:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
 
   primaryUpdateMethod: {{ .Values.cluster.primaryUpdateMethod }}
   primaryUpdateStrategy: {{ .Values.cluster.primaryUpdateStrategy }}

--- a/charts/cluster/test/postgresql-cluster-configuration/01-non_default_configuration_cluster-assert.yaml
+++ b/charts/cluster/test/postgresql-cluster-configuration/01-non_default_configuration_cluster-assert.yaml
@@ -60,6 +60,12 @@ spec:
             values:
             - node1
             - node2
+  serviceAccountTemplate:
+    metadata:
+      annotations:
+        foo: bar
+      labels:
+        bar: foo
   resources:
     requests:
       cpu: 100m

--- a/charts/cluster/test/postgresql-cluster-configuration/01-non_default_configuration_cluster.yaml
+++ b/charts/cluster/test/postgresql-cluster-configuration/01-non_default_configuration_cluster.yaml
@@ -52,6 +52,11 @@ cluster:
        inRoles:
          - pg_monitor
          - pg_signal_backend
+  serviceAccount:
+    annotations:
+      foo: bar
+    labels:
+      bar: foo
   postgresql:
     parameters:
       max_connections: "42"

--- a/charts/cluster/values.schema.json
+++ b/charts/cluster/values.schema.json
@@ -288,6 +288,17 @@
                 "roles": {
                     "type": "array"
                 },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "labels": {
+                            "type": "object"
+                        }
+                    }
+                },
                 "storage": {
                     "type": "object",
                     "properties": {

--- a/charts/cluster/values.yaml
+++ b/charts/cluster/values.yaml
@@ -284,6 +284,13 @@ cluster:
   additionalLabels: {}
   annotations: {}
 
+  serviceAccount:
+    # -- Annotations to be added to the ServiceAccount
+    # See: https://cloudnative-pg.io/documentation/current/appendixes/object_stores/#running-inside-google-kubernetes-engine
+    # See: https://cloudnative-pg.io/documentation/current/appendixes/object_stores/#iam-role-for-service-account-irsa
+    annotations: {}
+    # -- Labels to be added to the ServiceAccount
+    labels: {}
 
 backups:
   # -- You need to configure backups manually, so backups are disabled by default.


### PR DESCRIPTION
- Updated the Helm plugin installation URL to `https://github.com/KnechtionsCoding/helm-schema-gen.git` and up-to-date fork of the original `https://github.com/karuppiah7890/helm-schema-gen.git` which is not compatible with macOS.
- adding support for service account annotations and labels

fixes #309