### PR TITLE
fix(cluster): correct CNPGClusterOffline rule description

### DIFF
--- a/charts/cluster/prometheus_rules/cluster-offline.yaml
+++ b/charts/cluster/prometheus_rules/cluster-offline.yaml
@@ -4,7 +4,7 @@ alert: {{ $alert }}
 annotations:
   summary: CNPG Cluster has no running instances!
   description: |-
-    CloudNativePG Cluster "{{ .labels.job }}" has no ready instances.
+    CloudNativePG Cluster "{{ .namespace }}/{{ .cluster }}" has no ready instances.
 
     Having an offline cluster means your applications will not be able to access the database, leading to
     potential service disruption and/or data loss.


### PR DESCRIPTION
Use `namespace/cluster` instead of `labels.job` which is not returned in the expression.

Fixes: #428