### PR TITLE
feat: support cnpg operator namespace-restricted installation

### DIFF
--- a/.github/actions/deploy-cluster/action.yml
+++ b/.github/actions/deploy-cluster/action.yml
@@ -1,0 +1,27 @@
+name: Deploy a CNPG Cluster
+description: Deploys a CNPG Cluster
+inputs:
+  namespace:
+    description: 'The name of the namespace where the Cluster will be deployed'
+    required: false
+    default: 'default'
+runs:
+  using: composite
+  steps:
+    - name: Deploy a cluster
+      shell: bash
+      env:
+        NAMESPACE: ${{ inputs.namespace }}
+      run: |
+        cat <<EOF | kubectl apply -f -
+        # Example of PostgreSQL cluster
+        apiVersion: postgresql.cnpg.io/v1
+        kind: Cluster
+        metadata:
+          name: cluster-example
+          namespace: $NAMESPACE
+        spec:
+          instances: 3
+          storage:
+            size: 1Gi
+        EOF

--- a/.github/actions/deploy-operator/action.yml
+++ b/.github/actions/deploy-operator/action.yml
@@ -1,16 +1,29 @@
 name: Deploy the CNPG Operator
 description: Deploys the CNPG Operator to a Kubernetes cluster
+inputs:
+  namespace:
+    description: 'The name of the namespace where the operator will be deployed'
+    required: false
+    default: 'cnpg-system'
+  cluster-wide:
+    description: 'If the operator should be deployed cluster-wide or in single-namespace mode'
+    required: false
+    default: 'true'
 runs:
   using: composite
   steps:
     - name: Deploy the operator
       shell: bash
+      env:
+        NAMESPACE: ${{ inputs.namespace }}
+        CLUSTER_WIDE: ${{ inputs.cluster-wide }}
       run:
         helm dependency update charts/cloudnative-pg
 
         helm upgrade
         --install 
-        --namespace cnpg-system
+        --namespace $NAMESPACE
         --create-namespace
+        --set config.clusterWide=$CLUSTER_WIDE
         --wait
         cnpg charts/cloudnative-pg

--- a/.github/actions/verify-cluster-ready/action.yml
+++ b/.github/actions/verify-cluster-ready/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: The name of the cluster to verify
     required: true
     default: database-cluster
+  namespace:
+    description: 'The name of the namespace where the Cluster is deployed'
+    required: false
+    default: 'default'
   ready-instances:
     description: The amount of ready instances to wait for
     required: true
@@ -15,6 +19,10 @@ runs:
   steps:
     - name: Wait for the cluster to become ready
       shell: bash
+      env:
+        CLUSTER_NAME: ${{ inputs.cluster-name }}
+        NAMESPACE: ${{ inputs.namespace }}
+        EXPECTED_READY_INSTANCES: ${{ inputs.ready-instances }}
       run: |
         ITER=0
         while true; do
@@ -22,8 +30,8 @@ runs:
             echo "Cluster not ready"
             exit 1
           fi
-          READY_INSTANCES=$(kubectl get clusters.postgresql.cnpg.io ${INPUT_CLUSTER_NAME} -o jsonpath='{.status.readyInstances}')
-          if [[ "$READY_INSTANCES" == ${INPUT_READY_INSTANCES} ]]; then
+          READY_INSTANCES=$(kubectl get clusters.postgresql.cnpg.io $CLUSTER_NAME -n $NAMESPACE -o jsonpath='{.status.readyInstances}')
+          if [[ "$READY_INSTANCES" == "$EXPECTED_READY_INSTANCES" ]]; then
             echo "Cluster up and running"
             break
           fi

--- a/.github/workflows/tests-operator.yml
+++ b/.github/workflows/tests-operator.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   deploy_operator:
+    name: Deploy the operator in cluster-wide mode
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -21,21 +22,40 @@ jobs:
         uses: ./.github/actions/deploy-operator
 
       - name: Deploy a cluster
-        run: |
-          cat <<EOF | kubectl apply -f -
-          # Example of PostgreSQL cluster
-          apiVersion: postgresql.cnpg.io/v1
-          kind: Cluster
-          metadata:
-            name: cluster-example
-          spec:
-            instances: 3
-            storage:
-             size: 1Gi
-          EOF
+        uses: ./.github/actions/deploy-cluster
 
       - name: Verify that the cluster is ready
         uses: ./.github/actions/verify-cluster-ready
         with:
           cluster-name: cluster-example
-          ready-instances: 3
+          ready-instances: '3'
+
+  deploy_operator_single_namespace:
+    name: Deploy the operator in single-namespace mode
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          fetch-depth: 0
+
+      - name: Setup kind
+        uses: ./.github/actions/setup-kind
+
+      - name: Deploy the operator
+        uses: ./.github/actions/deploy-operator
+        with:
+          namespace: 'single-install'
+          cluster-wide: 'false'
+
+      - name: Deploy a cluster
+        uses: ./.github/actions/deploy-cluster
+        with:
+          namespace: 'single-install'
+
+      - name: Verify that the cluster is ready
+        uses: ./.github/actions/verify-cluster-ready
+        with:
+          namespace: 'single-install'
+          cluster-name: 'cluster-example'
+          ready-instances: '3'

--- a/.github/workflows/tests-operator.yml
+++ b/.github/workflows/tests-operator.yml
@@ -59,3 +59,15 @@ jobs:
           namespace: 'single-install'
           cluster-name: 'cluster-example'
           ready-instances: '3'
+
+      - name: Create a separate namespace
+        run: kubectl create ns test-ignore
+
+      - name: Deploy a cluster in 'test-ignore'
+        uses: ./.github/actions/deploy-cluster
+        with:
+          namespace: 'test-ignore'
+
+      - name: Verify the cluster in 'test-ignore' is being ignored
+        run: |
+          kubectl -n test-ignore get pods 2>&1 >/dev/null | grep 'No resources found'

--- a/README.md
+++ b/README.md
@@ -24,6 +24,30 @@ helm upgrade --install cnpg \
   cnpg/cloudnative-pg
 ```
 
+#### Single namespace installation
+
+It is possible to limit the operator's capabilities to solely the namespace in
+which it has been installed. With this restriction, the cluster-level
+permissions required by the operator will be substantially reduced, and
+the security profile of the installation will be enhanced.
+
+You can install the operator in single-namespace mode by setting the
+`config.clusterWide` flag to false, as in the following example:
+
+```console
+helm upgrade --install cnpg \
+  --namespace cnpg-system \
+  --create-namespace \
+  --set config.clusterWide=false \
+  cnpg/cloudnative-pg
+```
+
+**IMPORTANT**: the single-namespace installation mode can't coexist
+with the cluster-wide operator. Otherwise there would be collisions when
+managing the resources in the namespace watched by the single-namespace
+operator.
+It is up to the user to ensure there is no collision between operators.
+
 Refer to the [Operator Chart documentation](charts/cloudnative-pg/README.md) for advanced configuration and monitoring.
 
 ## Cluster chart

--- a/charts/cloudnative-pg/README.md
+++ b/charts/cloudnative-pg/README.md
@@ -30,7 +30,8 @@ CloudNativePG Operator Helm Chart
 | additionalEnv | list | `[]` | Array containing extra environment variables which can be templated. For example:  - name: RELEASE_NAME    value: "{{ .Release.Name }}"  - name: MY_VAR    value: "mySpecialKey" |
 | affinity | object | `{}` | Affinity for the operator to be installed. |
 | commonAnnotations | object | `{}` | Annotations to be added to all other resources. |
-| config | object | `{"create":true,"data":{},"name":"cnpg-controller-manager-config","secret":false}` | Operator configuration. |
+| config | object | `{"clusterWide":true,"create":true,"data":{},"name":"cnpg-controller-manager-config","secret":false}` | Operator configuration. |
+| config.clusterWide | bool | `true` | This option determines if the operator is responsible for observing events across the entire Kubernetes cluster or if its focus should be narrowed down to the specific namespace within which it has been deployed. |
 | config.create | bool | `true` | Specifies whether the secret should be created. |
 | config.data | object | `{}` | The content of the configmap/secret, see https://cloudnative-pg.io/documentation/current/operator_conf/#available-options for all the available options. |
 | config.name | string | `"cnpg-controller-manager-config"` | The name of the configmap/secret to use. |

--- a/charts/cloudnative-pg/templates/NOTES.txt
+++ b/charts/cloudnative-pg/templates/NOTES.txt
@@ -1,6 +1,6 @@
 
 CloudNativePG operator should be installed in namespace "{{ .Release.Namespace }}".
-You can now create a PostgreSQL cluster with 3 nodes in the current namespace as follows:
+You can now create a PostgreSQL cluster with 3 nodes as follows:
 
 cat <<EOF | kubectl apply -f -
 # Example of PostgreSQL cluster
@@ -8,11 +8,14 @@ apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
   name: cluster-example
+  {{if not .Values.config.clusterWide  -}}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
 spec:
   instances: 3
   storage:
     size: 1Gi
 EOF
 
-kubectl get cluster
+kubectl get -A cluster
 

--- a/charts/cloudnative-pg/templates/_helpers.tpl
+++ b/charts/cloudnative-pg/templates/_helpers.tpl
@@ -60,3 +60,225 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Define the common set of rules that can be applied either with
+namespace scope or clusterwide
+*/}}
+{{- define "cloudnative-pg.commonRules" }}
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  - secrets/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - pods
+  - pods/exec
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/status
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - podmonitors
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - postgresql.cnpg.io
+  resources:
+  - backups
+  - clusters
+  - poolers
+  - scheduledbackups
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - postgresql.cnpg.io
+  resources:
+  - backups/status
+  - scheduledbackups/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - postgresql.cnpg.io
+  resources:
+  - imagecatalogs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - postgresql.cnpg.io
+  resources:
+  - clusters/finalizers
+  - poolers/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - postgresql.cnpg.io
+  resources:
+  - clusters/status
+  - poolers/status
+  verbs:
+  - get
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - watch
+{{- end }}
+
+{{/*
+Define the set of rules that must be applied clusterwide
+*/}}
+{{- define "cloudnative-pg.clusterwideRules" }}
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - patch
+- apiGroups:
+  - postgresql.cnpg.io
+  resources:
+  - clusterimagecatalogs
+  verbs:
+  - get
+  - list
+  - watch
+{{- end }}

--- a/charts/cloudnative-pg/templates/config.yaml
+++ b/charts/cloudnative-pg/templates/config.yaml
@@ -26,7 +26,13 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 data:
+  {{- if .Values.config.clusterWide -}}
   {{- toYaml .Values.config.data | nindent 2 }}
+  {{- else -}}
+  {{- $watchNamespaceMap := dict "WATCH_NAMESPACE" .Release.Namespace -}}
+  {{- $fullConfiguration := merge .Values.config.data $watchNamespaceMap -}}
+  {{- toYaml $fullConfiguration | nindent 2 }}
+  {{- end -}}
 {{- else }}
 apiVersion: v1
 kind: Secret
@@ -40,6 +46,12 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 stringData:
+  {{- if .Values.config.clusterWide -}}
   {{- toYaml .Values.config.data | nindent 2 }}
+  {{- else -}}
+  {{- $watchNamespaceMap := dict "WATCH_NAMESPACE" .Release.Namespace -}}
+  {{- $fullConfiguration := merge .Values.config.data $watchNamespaceMap -}}
+  {{- toYaml $fullConfiguration | nindent 2 }}
+  {{- end -}}
 {{- end }}
 {{- end }}

--- a/charts/cloudnative-pg/templates/deployment.yaml
+++ b/charts/cloudnative-pg/templates/deployment.yaml
@@ -78,6 +78,10 @@ spec:
               fieldPath: metadata.namespace
         - name: MONITORING_QUERIES_CONFIGMAP
           value: "{{ .Values.monitoringQueriesConfigMap.name }}"
+        {{ if not .Values.config.clusterWide -}}
+        - name: WATCH_NAMESPACE
+          value: "{{ .Release.Namespace }}"
+        {{- end }}
         {{- if .Values.additionalEnv }}
         {{- tpl (.Values.additionalEnv | toYaml) . | nindent 8 }}
         {{- end }}

--- a/charts/cloudnative-pg/templates/podmonitor.yaml
+++ b/charts/cloudnative-pg/templates/podmonitor.yaml
@@ -1,3 +1,18 @@
+#
+# Copyright The CloudNativePG Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 {{- if .Values.monitoring.podMonitorEnabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor

--- a/charts/cloudnative-pg/templates/rbac.yaml
+++ b/charts/cloudnative-pg/templates/rbac.yaml
@@ -40,208 +40,14 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  - secrets
-  - services
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - configmaps/status
-  - secrets/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - persistentvolumeclaims
-  - pods
-  - pods/exec
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - pods/status
-  verbs:
-  - get
-- apiGroups:
-  - ""
-  resources:
-  - serviceaccounts
-  verbs:
-  - create
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - admissionregistration.k8s.io
-  resources:
-  - mutatingwebhookconfigurations
-  - validatingwebhookconfigurations
-  verbs:
-  - get
-  - patch
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - watch
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - create
-  - get
-  - update
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - podmonitors
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - watch
-- apiGroups:
-  - policy
-  resources:
-  - poddisruptionbudgets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - postgresql.cnpg.io
-  resources:
-  - backups
-  - clusters
-  - poolers
-  - scheduledbackups
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - postgresql.cnpg.io
-  resources:
-  - backups/status
-  - scheduledbackups/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - postgresql.cnpg.io
-  resources:
-  - clusterimagecatalogs
-  - imagecatalogs
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - postgresql.cnpg.io
-  resources:
-  - clusters/finalizers
-  - poolers/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - postgresql.cnpg.io
-  resources:
-  - clusters/status
-  - poolers/status
-  verbs:
-  - get
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
-  - rolebindings
-  - roles
-  verbs:
-  - create
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshots
-  verbs:
-  - create
-  - get
-  - list
-  - patch
-  - watch
+{{- include "cloudnative-pg.clusterwideRules" . }}
+{{/*
+If we're doing a clusterWide installation (default)
+we add ALL the necessary rules for the operator to the ClusterRole
+*/}}
+{{- if .Values.config.clusterWide }}
+{{- include "cloudnative-pg.commonRules" . }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -249,7 +55,7 @@ metadata:
   name: {{ include "cloudnative-pg.fullname" . }}
   labels:
     {{- include "cloudnative-pg.labels" . | nindent 4 }}
-  {{- with .Values.commonAnnotations.annotations }}
+  {{- with .Values.commonAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -261,6 +67,46 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "cloudnative-pg.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+{{/*
+If we're doing a single-namespace installation
+we create a Role with the common rules for the operator,
+and a RoleBinding. We already created the ClusterRole above with the
+required cluster-wide rules
+*/}}
+{{- if eq .Values.config.clusterWide false }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "cloudnative-pg.fullname" . }}
+  labels:
+    {{- include "cloudnative-pg.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+{{- include "cloudnative-pg.commonRules" . }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "cloudnative-pg.fullname" . }}
+  labels:
+    {{- include "cloudnative-pg.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "cloudnative-pg.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "cloudnative-pg.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/charts/cloudnative-pg/values.schema.json
+++ b/charts/cloudnative-pg/values.schema.json
@@ -17,6 +17,9 @@
         "config": {
             "type": "object",
             "properties": {
+                "clusterWide": {
+                    "type": "boolean"
+                },
                 "create": {
                     "type": "boolean"
                 },

--- a/charts/cloudnative-pg/values.yaml
+++ b/charts/cloudnative-pg/values.yaml
@@ -58,6 +58,10 @@ config:
   name: cnpg-controller-manager-config
   # -- Specifies whether it should be stored in a secret, instead of a configmap.
   secret: false
+  # -- This option determines if the operator is responsible for observing
+  # events across the entire Kubernetes cluster or if its focus should be
+  # narrowed down to the specific namespace within which it has been deployed.
+  clusterWide: true
   # -- The content of the configmap/secret, see
   # https://cloudnative-pg.io/documentation/current/operator_conf/#available-options
   # for all the available options.


### PR DESCRIPTION
Add a way to deploy the operator in single-namespace mode, restricting the operator's capabilities to solely the namespace in which it has been installed.

Closes #435 