### PR TITLE
chore: bump helm to v3.16

### DIFF
--- a/.github/actions/setup-kind/action.yml
+++ b/.github/actions/setup-kind/action.yml
@@ -12,9 +12,9 @@ runs:
   steps:
     - id: helm
       name: Set up Helm
-      uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
+      uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
       with:
-        version: v3.6.2
+        version: v3.16.2
 
     - id: kubectl
       name: Install kubectl

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,9 +19,9 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
+        uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
         with:
-          version: v3.4.0
+          version: v3.16.2
 
       - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
         with:
-          version: v3.14.1
+          version: v3.16.2
 
       - name: Add chart dependencies
         run: |


### PR DESCRIPTION
An old version of helm is being used for the linter and inside the setup-kind reusable workflow.
This makes the linter fail with an error that's been already fixed in newer versions of helm:
```
==> Linting charts/cloudnative-pg
Error:  templates/podmonitor.yaml: object name must be between 0 and 253 characters: ""
```

Not sure why Renovate is not opening an automated PR for these files.. (maybe given that the helm version currently hardcoded is very old it can't find an upgrade path?!)