### PR TITLE
Adds Itay Grudev to the default list of CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,6 +2,6 @@
 # responsible for code in a repository. For details, please refer to
 # https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-*               @fcanovai @gbartolini @leonardoce @mnencia @phisco @sxd
+*               @fcanovai @gbartolini @leonardoce @mnencia @phisco @sxd @itay-grudev
 /.github        @fcanovai @gbartolini @leonardoce @mnencia @phisco @sxd @itay-grudev
 /charts/cluster @itay-grudev


### PR DESCRIPTION
Adds Itay Grudev to the default CODEOWNERS rule, as per the governance document:
https://github.com/cloudnative-pg/governance/blob/main/COMPONENT-OWNERS.md#operator-chart