### PR TITLE
Make container securityContext optional for OpenShift compatibility

### DIFF
--- a/charts/cloudnative-pg/README.md
+++ b/charts/cloudnative-pg/README.md
@@ -35,7 +35,14 @@ CloudNativePG Operator Helm Chart
 | config.data | object | `{}` | The content of the configmap/secret, see https://cloudnative-pg.io/documentation/current/operator_conf/#available-options for all the available options. |
 | config.name | string | `"cnpg-controller-manager-config"` | The name of the configmap/secret to use. |
 | config.secret | bool | `false` | Specifies whether it should be stored in a secret, instead of a configmap. |
-| containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":10001,"runAsUser":10001,"seccompProfile":{"type":"RuntimeDefault"}}` | Container Security Context. |
+| containerSecurityContext | object | See below | Container Security Context. |
+| containerSecurityContext.enableSecurityContext | bool | `true` | Determines whether the container-level securityContext is included in the Deployment. Set to `false` to disable the container securityContext (useful for OpenShift). |
+| containerSecurityContext.allowPrivilegeEscalation | bool | `false` | Controls whether a process can gain more privileges than its parent process. |
+| containerSecurityContext.readOnlyRootFilesystem | bool | `true` | Whether the container has a read-only root filesystem. |
+| containerSecurityContext.runAsUser | int | `10001` | The user ID to run the container process. |
+| containerSecurityContext.runAsGroup | int | `10001` | The group ID for the container process. |
+| containerSecurityContext.seccompProfile | object | `{"type":"RuntimeDefault"}` | Seccomp profile for the container. |
+| containerSecurityContext.capabilities | object | `{"drop":["ALL"]}` | Linux capabilities to be dropped from the container. |
 | crds.create | bool | `true` | Specifies whether the CRDs should be created when installing the chart. |
 | dnsPolicy | string | `""` |  |
 | fullnameOverride | string | `""` |  |

--- a/charts/cloudnative-pg/templates/deployment.yaml
+++ b/charts/cloudnative-pg/templates/deployment.yaml
@@ -109,8 +109,11 @@ spec:
           {{- end }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
+        {{- if .Values.containerSecurityContext.enableSecurityContext }}
+        {{- $containerSecurityContext := omit .Values.containerSecurityContext "enableSecurityContext" }}
         securityContext:
-          {{- toYaml .Values.containerSecurityContext | nindent 10 }}
+          {{- toYaml $containerSecurityContext | nindent 10 }}
+        {{- end }}
         volumeMounts:
         - mountPath: /controller
           name: scratch-data

--- a/charts/cloudnative-pg/values.yaml
+++ b/charts/cloudnative-pg/values.yaml
@@ -100,6 +100,7 @@ podLabels: {}
 
 # -- Container Security Context.
 containerSecurityContext:
+  enableSecurityContext: true
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
   runAsUser: 10001


### PR DESCRIPTION
**Summary**:

This pull request adds a new configuration option to make the container-level securityContext optional in the CloudNativePG Helm chart. This change improves compatibility with OpenShift by allowing users to disable the container `securityContext` when deploying the operator.

**Background**:

When deploying the CloudNativePG operator on OpenShift, the predefined container `securityContext` can cause conflicts due to OpenShift's strict security policies. OpenShift manages user and group IDs dynamically and does not allow containers to run as a specific user or group unless explicitly permitted. Hardcoded  `runAsUser` and `runAsGroup` values (values.yaml) in the container securityContext may prevent pods from starting on OpenShift clusters.

**Changes Introduced:**

- Added a new boolean flag `enableSecurityContext` under `containerSecurityContext` in `values.yaml`, defaulting to `true` to maintain existing behavior.
- Modified `deployment.yaml` to include the container `securityContext` only when `enableSecurityContext` is set to `true`.
- Updated the `README.md` to document the new configuration option and guide users on how to use it.

**Benefits**:

- Flexibility: Users can now disable the container securityContext when deploying to OpenShift or other environments with strict security constraints.
- Compatibility: Resolves deployment issues on OpenShift by preventing conflicts with the platform's security policies.
- Maintainability: Maintains the default behavior for existing users while providing an option for those who need it.


**Usage Example**:

To disable the container `securityContext` on OpenShift, set `enableSecurityContext` to` false` in your custom values/override file:

```
containerSecurityContext:
  enableSecurityContext: false
```

**Testing**:

- Verified that the operator deploys successfully on OpenShift with enableSecurityContext set to false.
- Confirmed that the default behavior remains unchanged when the flag is set to true.