### PR TITLE
chore: enable overriding pod monitor api version

### DIFF
--- a/charts/cloudnative-pg/templates/podmonitor.yaml
+++ b/charts/cloudnative-pg/templates/podmonitor.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 {{- if .Values.monitoring.podMonitorEnabled }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: {{ .Values.monitoring.podMonitorApiVersion }}
 kind: PodMonitor
 metadata:
   name: {{ include "cloudnative-pg.fullname" . }}

--- a/charts/cloudnative-pg/values.yaml
+++ b/charts/cloudnative-pg/values.yaml
@@ -157,6 +157,8 @@ affinity: {}
 
 monitoring:
 
+  # -- The API version of the PodMonitor.
+  podMonitorApiVersion: monitoring.coreos.com/v1
   # -- Specifies whether the monitoring should be enabled. Requires Prometheus Operator CRDs.
   podMonitorEnabled: false
   # -- Metrics relabel configurations to apply to samples before ingestion.


### PR DESCRIPTION
This PR enables users to override the Pod Monitor API version if they are using Azure managed prometheus which uses `azmonitoring.coreos.com/v1` instead of the default `monitoring.coreos.com/v1`.

Closes #455 