### PR TITLE
add option to use spec.enablePDB

### DIFF
--- a/charts/cluster/templates/cluster.yaml
+++ b/charts/cluster/templates/cluster.yaml
@@ -38,6 +38,7 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   priorityClassName: {{ .Values.cluster.priorityClassName }}
+  enablePDB: {{ .Values.cluster.enablePDB }}
 
   primaryUpdateMethod: {{ .Values.cluster.primaryUpdateMethod }}
   primaryUpdateStrategy: {{ .Values.cluster.primaryUpdateStrategy }}

--- a/charts/cluster/values.yaml
+++ b/charts/cluster/values.yaml
@@ -160,6 +160,9 @@ cluster:
   # -- The GID of the postgres user inside the image, defaults to 26
   postgresGID: -1
 
+  # -- Enable the PodDisruptionBudget for the cluster
+  enablePDB: true
+
   # -- Resources requirements of every generated Pod.
   # Please refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ for more information.
   # We strongly advise you use the same setting for limits and requests so that your cluster pods are given a Guaranteed QoS.


### PR DESCRIPTION
This adds the ability to pass in the .spec.enablePDB for the Cluster if you run a test/dev cluster. Right now Karpenter is blocked for consolidating nodes due to this