### PR TITLE
Bug Fix: namespaceOverride template error in Scheduled Backups

### DIFF
--- a/charts/cluster/templates/scheduled-backups.yaml
+++ b/charts/cluster/templates/scheduled-backups.yaml
@@ -6,7 +6,7 @@ apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:
   name: {{ include "cluster.fullname" $context  }}-{{ .name }}
-  namespace: {{ include "cluster.namespace" . }}
+  namespace: {{ include "cluster.namespace" $ }}
   labels: {{ include "cluster.labels" $context | nindent 4 }}
 spec:
   immediate: true

--- a/charts/cluster/test/scheduledbackups/00-minio_cleanup-assert.yaml
+++ b/charts/cluster/test/scheduledbackups/00-minio_cleanup-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: minio-cleanup
+status:
+  succeeded: 1

--- a/charts/cluster/test/scheduledbackups/00-minio_cleanup.yaml
+++ b/charts/cluster/test/scheduledbackups/00-minio_cleanup.yaml
@@ -1,0 +1,16 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: minio-cleanup
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: minio-cleanup
+        image: minio/mc
+        command: ['sh', '-c']
+        args:
+         - |
+           mc alias set myminio https://minio.minio.svc.cluster.local minio minio123
+           mc rm --recursive --force myminio/mybucket/scheduledbackups

--- a/charts/cluster/test/scheduledbackups/01-scheduledbackups_cluster-assert.yaml
+++ b/charts/cluster/test/scheduledbackups/01-scheduledbackups_cluster-assert.yaml
@@ -1,0 +1,30 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: scheduledbackups-cluster
+status:
+  readyInstances: 1
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: scheduledbackups-cluster-daily-backup
+spec:
+  immediate: true
+  schedule: "0 0 0 * * *"
+  method: barmanObjectStore
+  backupOwnerReference: self
+  cluster:
+    name: scheduledbackups-cluster
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: scheduledbackups-cluster-weekly-backup
+spec:
+  immediate: true
+  schedule: "0 0 0 * * 1"
+  method: barmanObjectStore
+  backupOwnerReference: self
+  cluster:
+    name: scheduledbackups-cluster

--- a/charts/cluster/test/scheduledbackups/01-scheduledbackups_cluster-assert.yaml
+++ b/charts/cluster/test/scheduledbackups/01-scheduledbackups_cluster-assert.yaml
@@ -28,3 +28,10 @@ spec:
   backupOwnerReference: self
   cluster:
     name: scheduledbackups-cluster
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Backup
+spec:
+  method: barmanObjectStore
+  cluster:
+    name: scheduledbackups-cluster

--- a/charts/cluster/test/scheduledbackups/01-scheduledbackups_cluster.yaml
+++ b/charts/cluster/test/scheduledbackups/01-scheduledbackups_cluster.yaml
@@ -1,0 +1,36 @@
+type: postgresql
+mode: standalone
+
+cluster:
+  instances: 1
+  storage:
+    size: 256Mi
+
+backups:
+  enabled: true
+  provider: s3
+  endpointURL: "https://minio.minio.svc.cluster.local"
+  endpointCA:
+    name: kube-root-ca.crt
+    key: ca.crt
+  wal:
+    encryption: ""
+  data:
+    encryption: ""
+  s3:
+    bucket: "mybucket"
+    path: "/scheduledbackups/v1"
+    accessKey: "minio"
+    secretKey: "minio123"
+    region: "local"
+  retentionPolicy: "30d"
+  scheduledBackups:
+    - name: daily-backup
+      schedule: "0 0 0 * * *"
+      backupOwnerReference: self
+      method: barmanObjectStore
+    - name: weekly-backup
+      schedule: "0 0 0 * * 1"
+      backupOwnerReference: self
+      method: barmanObjectStore
+

--- a/charts/cluster/test/scheduledbackups/chainsaw-test.yaml
+++ b/charts/cluster/test/scheduledbackups/chainsaw-test.yaml
@@ -5,8 +5,8 @@ metadata:
 spec:
   timeouts:
     apply: 1s
-    assert: 60s
-    cleanup: 30s
+    assert: 1m
+    cleanup: 1m
   steps:
     - name: Install the a cluster with ScheduledBackups
       try:

--- a/charts/cluster/test/scheduledbackups/chainsaw-test.yaml
+++ b/charts/cluster/test/scheduledbackups/chainsaw-test.yaml
@@ -1,17 +1,14 @@
-##
-# This is a test that verifies that non-default configuration options are correctly propagated to the CNPG cluster.
-# P.S. This test is not designed to have a good running configuration, it is designed to test the configuration propagation!
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
-  name: postgresql-cluster-configuration
+  name: scheduledbackups
 spec:
   timeouts:
     apply: 1s
     assert: 60s
     cleanup: 30s
   steps:
-    - name: Install the non-default configuration cluster
+    - name: Install the a cluster with ScheduledBackups
       try:
         - script:
             content: |

--- a/charts/cluster/test/scheduledbackups/chainsaw-test.yaml
+++ b/charts/cluster/test/scheduledbackups/chainsaw-test.yaml
@@ -1,0 +1,30 @@
+##
+# This is a test that verifies that non-default configuration options are correctly propagated to the CNPG cluster.
+# P.S. This test is not designed to have a good running configuration, it is designed to test the configuration propagation!
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: postgresql-cluster-configuration
+spec:
+  timeouts:
+    apply: 1s
+    assert: 60s
+    cleanup: 30s
+  steps:
+    - name: Install the non-default configuration cluster
+      try:
+        - script:
+            content: |
+              helm upgrade \
+                --install \
+                --namespace $NAMESPACE \
+                --values ./01-scheduledbackups_cluster.yaml \
+                --wait \
+                scheduledbackups ../../
+        - assert:
+            file: ./01-scheduledbackups_cluster-assert.yaml
+    - name: Cleanup
+      try:
+        - script:
+            content: |
+              helm uninstall --namespace $NAMESPACE scheduledbackups


### PR DESCRIPTION
Fixes an issue introduced in #461 causing template evaluation to fail for ScheduledBackups.

This PR also adds a new test case specifically for `ScheduledBackups` so similar issues are caught.