### PR TITLE
fix(cnpg): syntax error in deployment template prevents config.clusterWide from working

### DIFF
--- a/charts/cloudnative-pg/templates/deployment.yaml
+++ b/charts/cloudnative-pg/templates/deployment.yaml
@@ -79,7 +79,7 @@ spec:
               fieldPath: metadata.namespace
         - name: MONITORING_QUERIES_CONFIGMAP
           value: "{{ .Values.monitoringQueriesConfigMap.name }}"
-        {{ if not .Values.config.clusterWide -}}
+        {{- if not .Values.config.clusterWide }}
         - name: WATCH_NAMESPACE
           value: "{{ .Release.Namespace }}"
         {{- end }}


### PR DESCRIPTION
Instead of `{{- … }}`, the hyphen went to the end, i.e. `{{ … -}}`.
Therefore, `WATCH_NAMESPACE` is not set in the environment variables when `config.clusterWide: false`.
