### PR TITLE
add imageregistry prefix to timescaledb images

### DIFF
--- a/charts/cluster/templates/image-catalog-timescaledb-ha.yaml
+++ b/charts/cluster/templates/image-catalog-timescaledb-ha.yaml
@@ -7,13 +7,13 @@ metadata:
 spec:
   images:
     - major: 12
-      image: timescale/timescaledb-ha:pg12-ts{{ .Values.version.timescaledb }}
+      image: {{.Values.global.imageRegistry | default ""}}timescale/timescaledb-ha:pg12-ts{{ .Values.version.timescaledb }}
     - major: 13
-      image: timescale/timescaledb-ha:pg13-ts{{ .Values.version.timescaledb }}
+      image: {{.Values.global.imageRegistry | default ""}}timescale/timescaledb-ha:pg13-ts{{ .Values.version.timescaledb }}
     - major: 14
-      image: timescale/timescaledb-ha:pg14-ts{{ .Values.version.timescaledb }}
+      image: {{.Values.global.imageRegistry | default ""}}timescale/timescaledb-ha:pg14-ts{{ .Values.version.timescaledb }}
     - major: 15
-      image: timescale/timescaledb-ha:pg15-ts{{ .Values.version.timescaledb }}
+      image: {{.Values.global.imageRegistry | default ""}}timescale/timescaledb-ha:pg15-ts{{ .Values.version.timescaledb }}
     - major: 16
-      image: timescale/timescaledb-ha:pg16-ts{{ .Values.version.timescaledb }}
+      image: {{.Values.global.imageRegistry | default ""}}timescale/timescaledb-ha:pg16-ts{{ .Values.version.timescaledb }}
 {{ end }}


### PR DESCRIPTION
Right now timescaledb does not support container proxies, so I've added support for common .global.imageRegistry chart parameter to remove dependency on dockerhub