### PR TITLE
feat(cluster): add ldap configuration and documentation

### DIFF
--- a/charts/cluster/README.md
+++ b/charts/cluster/README.md
@@ -173,6 +173,7 @@ refer to  the [CloudNativePG Documentation](https://cloudnative-pg.io/documentat
 | cluster.monitoring.prometheusRule.excludeRules | list | `[]` | Exclude specified rules |
 | cluster.postgresGID | int | `-1` | The GID of the postgres user inside the image, defaults to 26 |
 | cluster.postgresUID | int | `-1` | The UID of the postgres user inside the image, defaults to 26 |
+| cluster.postgresql.ldap | object | `{}` | PostgreSQL LDAP configuration (see https://cloudnative-pg.io/documentation/current/postgresql_conf/#ldap-configuration) |
 | cluster.postgresql.parameters | object | `{}` | PostgreSQL configuration options (postgresql.conf) |
 | cluster.postgresql.pg_hba | list | `[]` | PostgreSQL Host Based Authentication rules (lines to be appended to the pg_hba.conf file) |
 | cluster.postgresql.pg_ident | list | `[]` | PostgreSQL User Name Maps rules (lines to be appended to the pg_ident.conf file) |

--- a/charts/cluster/templates/cluster.yaml
+++ b/charts/cluster/templates/cluster.yaml
@@ -77,7 +77,7 @@ spec:
     pg_ident:
       {{- toYaml . | nindent 6 }}
     {{- end }}
-    {{- with .ldap }}
+    {{- with .Values.cluster.postgresql.ldap  }}
     ldap:
       {{- toYaml . | nindent 6 }}
     {{- end}}

--- a/charts/cluster/templates/cluster.yaml
+++ b/charts/cluster/templates/cluster.yaml
@@ -77,6 +77,10 @@ spec:
     pg_ident:
       {{- toYaml . | nindent 6 }}
     {{- end }}
+    {{- with .ldap }}
+    ldap:
+      {{- toYaml . | nindent 6 }}
+    {{- end}}
     {{- with .Values.cluster.postgresql.synchronous }}
     synchronous:
       {{- toYaml . | nindent 6 }}

--- a/charts/cluster/test/postgresql-cluster-configuration/01-non_default_configuration_cluster-assert.yaml
+++ b/charts/cluster/test/postgresql-cluster-configuration/01-non_default_configuration_cluster-assert.yaml
@@ -13,6 +13,15 @@ spec:
   postgresGID: 1002
   instances: 2
   postgresql:
+    ldap:
+      server: 'openldap.default.svc.cluster.local'
+      bindSearchAuth:
+        baseDN: 'ou=org,dc=example,dc=com'
+        bindDN: 'cn=admin,dc=example,dc=com'
+        bindPassword:
+          name: 'ldapBindPassword'
+          key: 'data'
+        searchAttribute: 'uid'
     parameters:
       max_connections: "42"
     pg_hba:

--- a/charts/cluster/test/postgresql-cluster-configuration/01-non_default_configuration_cluster.yaml
+++ b/charts/cluster/test/postgresql-cluster-configuration/01-non_default_configuration_cluster.yaml
@@ -66,6 +66,15 @@ cluster:
          - pg_monitor
          - pg_signal_backend
   postgresql:
+    ldap:
+      server: 'openldap.default.svc.cluster.local'
+      bindSearchAuth:
+        baseDN: 'ou=org,dc=example,dc=com'
+        bindDN: 'cn=admin,dc=example,dc=com'
+        bindPassword:
+          name: 'ldapBindPassword'
+          key: 'data'
+        searchAttribute: 'uid'
     parameters:
       max_connections: "42"
     pg_hba:

--- a/charts/cluster/values.schema.json
+++ b/charts/cluster/values.schema.json
@@ -265,6 +265,9 @@
                 "postgresql": {
                     "type": "object",
                     "properties": {
+                        "ldap": {
+                            "type": "object"
+                        },
                         "parameters": {
                             "type": "object"
                         },

--- a/charts/cluster/values.yaml
+++ b/charts/cluster/values.yaml
@@ -280,6 +280,7 @@ cluster:
     # -- Lists of shared preload libraries to add to the default ones
     shared_preload_libraries: []
       # - pgaudit
+    # -- PostgreSQL LDAP configuration (see https://cloudnative-pg.io/documentation/current/postgresql_conf/#ldap-configuration)
     ldap: {}
       # https://cloudnative-pg.io/documentation/1.24/postgresql_conf/#ldap-configuration
       # server: 'openldap.default.svc.cluster.local'

--- a/charts/cluster/values.yaml
+++ b/charts/cluster/values.yaml
@@ -280,6 +280,17 @@ cluster:
     # -- Lists of shared preload libraries to add to the default ones
     shared_preload_libraries: []
       # - pgaudit
+    ldap: {}
+      # https://cloudnative-pg.io/documentation/1.24/postgresql_conf/#ldap-configuration
+      # server: 'openldap.default.svc.cluster.local'
+      # bindSearchAuth:
+        # baseDN: 'ou=org,dc=example,dc=com'
+        # bindDN: 'cn=admin,dc=example,dc=com'
+        # bindPassword:
+          # name: 'ldapBindPassword'
+          # key: 'data'
+        # searchAttribute: 'uid'
+
 
   # -- BootstrapInitDB is the configuration of the bootstrap process when initdb is used.
   # See: https://cloudnative-pg.io/documentation/current/bootstrap/


### PR DESCRIPTION
This PR adds the possibility to set the LDAP Configuration which is documented [here](https://cloudnative-pg.io/documentation/1.20/postgresql_conf/#ldap-configuration)

Same as in #409 without the merged service config feature. 