### PR TITLE
Increased Scheduled Backups test cleanup timeout

### DIFF
--- a/charts/cluster/test/scheduledbackups/chainsaw-test.yaml
+++ b/charts/cluster/test/scheduledbackups/chainsaw-test.yaml
@@ -6,7 +6,7 @@ spec:
   timeouts:
     apply: 1s
     assert: 1m
-    cleanup: 2m
+    cleanup: 5m
   steps:
     - name: Install the a cluster with ScheduledBackups
       try:

--- a/charts/cluster/test/scheduledbackups/chainsaw-test.yaml
+++ b/charts/cluster/test/scheduledbackups/chainsaw-test.yaml
@@ -6,7 +6,7 @@ spec:
   timeouts:
     apply: 1s
     assert: 1m
-    cleanup: 1m
+    cleanup: 2m
   steps:
     - name: Install the a cluster with ScheduledBackups
       try:


### PR DESCRIPTION
Currently the scheduled backups test times out causing a test failure, simply because it take a bit longer to remove the backup objects.