### PR TITLE
ci: cancel concurrent lint and test workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,10 @@ on:
     branches-ignore:
       - 'gh-pages'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   linter:
     runs-on: ubuntu-24.04

--- a/.github/workflows/tests-cluster-chainsaw.yaml
+++ b/.github/workflows/tests-cluster-chainsaw.yaml
@@ -5,6 +5,10 @@ on:
     branches-ignore:
       - 'gh-pages'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-list:
     runs-on: ubuntu-24.04

--- a/.github/workflows/tests-operator.yml
+++ b/.github/workflows/tests-operator.yml
@@ -5,6 +5,10 @@ on:
     branches-ignore:
       - 'gh-pages'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deploy_operator:
     name: Deploy the operator in cluster-wide mode


### PR DESCRIPTION
This pull request introduces concurrency settings to multiple GitHub Actions workflows to prevent overlapping runs and ensure that only the latest run is processed. The most important changes include the addition of concurrency groups and the cancellation of in-progress runs.

Concurrency settings added to GitHub Actions workflows:

* [`.github/workflows/lint.yml`](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2R12-R15): Added `concurrency` settings to group by workflow and reference, and cancel in-progress runs.
* [`.github/workflows/tests-cluster-chainsaw.yaml`](diffhunk://#diff-db0644a31a1823cb3e59a64234e91f5a3f7d2b6db60f3eecef7c501566294538R8-R11): Added `concurrency` settings to group by workflow and reference, and cancel in-progress runs.
* [`.github/workflows/tests-operator.yml`](diffhunk://#diff-3a21e50fbf65e34e1d1bfc91363c921bfacfd44c30af594c06b6fa8e7dc346aaR8-R11): Added `concurrency` settings to group by workflow and reference, and cancel in-progress runs.