### PR TITLE
Fixed names of objectstore recovery clusters

### DIFF
--- a/charts/cluster/templates/_bootstrap.tpl
+++ b/charts/cluster/templates/_bootstrap.tpl
@@ -90,11 +90,11 @@ externalClusters:
     backup:
       name: {{ .Values.recovery.backupName }}
     {{- else if eq .Values.recovery.method "object_store" }}
-    source: objectStoreRecoveryCluster
+    source: {{ default (include "cluster.fullname" .) .Values.recovery.clusterName }}
     {{- end }}
 
 externalClusters:
-  - name: objectStoreRecoveryCluster
+  - name: {{ default (include "cluster.fullname" .) .Values.recovery.clusterName }}
     barmanObjectStore:
       serverName: {{ .Values.recovery.clusterName }}
       {{- $d := dict "chartFullname" (include "cluster.fullname" .) "scope" .Values.recovery "secretPrefix" "recovery" -}}


### PR DESCRIPTION
Closes #486 

Hey there!

The cluster name in recovery has to be the same as the cluster which was backed up to the objectstore, so I made a small update in the values for this. So far it was hardcoded with value `objectStoreRecoveryCluster`. 

Now it should default to the current cluster's name, if `.Values.recovery.clusterName` is not defined. I have tested this with s3 backups and works well. Let me know if you like the idea.