### PR TITLE
docs: corrected spelling mistake

### DIFF
--- a/charts/cluster/README.md
+++ b/charts/cluster/README.md
@@ -185,7 +185,7 @@ refer to  the [CloudNativePG Documentation](https://cloudnative-pg.io/documentat
 | cluster.resources | object | `{}` | Resources requirements of every generated Pod. Please refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ for more information. We strongly advise you use the same setting for limits and requests so that your cluster pods are given a Guaranteed QoS. See: https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/ |
 | cluster.roles | list | `[]` | This feature enables declarative management of existing roles, as well as the creation of new roles if they are not already present in the database. See: https://cloudnative-pg.io/documentation/current/declarative_role_management/ |
 | cluster.serviceAccountTemplate | object | `{}` | Configure the metadata of the generated service account |
-| cluster.services | object | `{}` | Customization of service definions. Please refer to https://cloudnative-pg.io/documentation/1.24/service_management/ |
+| cluster.services | object | `{}` | Customization of service definitions. Please refer to https://cloudnative-pg.io/documentation/1.24/service_management/ |
 | cluster.storage.size | string | `"8Gi"` |  |
 | cluster.storage.storageClass | string | `""` |  |
 | cluster.superuserSecret | string | `""` |  |

--- a/charts/cluster/values.yaml
+++ b/charts/cluster/values.yaml
@@ -212,7 +212,7 @@ cluster:
   # -- The GID of the postgres user inside the image, defaults to 26
   postgresGID: -1
 
-  # -- Customization of service definions. Please refer to https://cloudnative-pg.io/documentation/1.24/service_management/
+  # -- Customization of service definitions. Please refer to https://cloudnative-pg.io/documentation/1.24/service_management/
   services: {}
 
   # -- Resources requirements of every generated Pod.


### PR DESCRIPTION
Corrected `definions` to `definitions`