### PR TITLE
Cluster Chart: Add possibility to recover a specific database & owner for type object_store & backup

### DIFF
--- a/charts/cluster/templates/_bootstrap.tpl
+++ b/charts/cluster/templates/_bootstrap.tpl
@@ -92,6 +92,12 @@ externalClusters:
     {{- else if eq .Values.recovery.method "object_store" }}
     source: objectStoreRecoveryCluster
     {{- end }}
+    {{ with .Values.recovery.database }}
+    database: {{ . }}
+    {{- end }}
+    {{ with .Values.recovery.owner }}
+    owner: {{ . }}
+    {{- end }}
 
 externalClusters:
   - name: objectStoreRecoveryCluster

--- a/charts/cluster/values.yaml
+++ b/charts/cluster/values.yaml
@@ -103,9 +103,9 @@ recovery:
   pgBaseBackup:
     # -- Name of the database used by the application. Default: `app`.
     database: app
-    # -- Name of the owner of the database in the instance to be used by applications. Defaults to the value of the `database` key.
-    secret: ""
     # -- Name of the secret containing the initial credentials for the owner of the user database. If empty a new secret will be created from scratch
+    secret: ""
+    # -- Name of the owner of the database in the instance to be used by applications. Defaults to the value of the `database` key.
     owner: ""
     source:
       host: ""

--- a/charts/cluster/values.yaml
+++ b/charts/cluster/values.yaml
@@ -49,6 +49,10 @@ recovery:
   ##
   # -- The original cluster name when used in backups. Also known as serverName.
   clusterName: ""
+  # -- Name of the database used by the application. Default: `app`.
+  database: app
+  # -- Name of the owner of the database in the instance to be used by applications. Defaults to the value of the `database` key.
+  owner: ""
   # -- Overrides the provider specific default endpoint. Defaults to:
   # S3: https://s3.<region>.amazonaws.com"
   # Leave empty if using the default S3 endpoint


### PR DESCRIPTION
Closes #557 and fixes mixed up docs for `recovery.pgBaseBackup.secret/owner`