### PR TITLE
feat(recovery): generalize recovery target config

### DIFF
--- a/charts/cluster/README.md
+++ b/charts/cluster/README.md
@@ -258,7 +258,7 @@ refer to  the [CloudNativePG Documentation](https://cloudnative-pg.io/documentat
 | recovery.pgBaseBackup.source.sslRootCertSecret.key | string | `""` |  |
 | recovery.pgBaseBackup.source.sslRootCertSecret.name | string | `""` |  |
 | recovery.pgBaseBackup.source.username | string | `""` |  |
-| recovery.pitrTarget.time | string | `""` | Time in RFC3339 format |
+| recovery.recoveryTarget | object | `{}` | Recovery target, e.g. targetTime. See: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-RecoveryTarget |
 | recovery.provider | string | `"s3"` | One of `s3`, `azure` or `google` |
 | recovery.s3.accessKey | string | `""` |  |
 | recovery.s3.bucket | string | `""` |  |

--- a/charts/cluster/docs/Recovery.md
+++ b/charts/cluster/docs/Recovery.md
@@ -19,7 +19,7 @@ To begin, create a `values.yaml` that contains the following:
 1. Set `mode: recovery` to indicate that you want to perform bootstrap the new cluster from an existing one.
 2. Set the `recovery.method` to the type of recovery you want to perform.
 3. Set either the `recovery.backupName` or the Barman Object Store configuration - i.e. `recovery.provider` and appropriate S3, Azure or GCS configuration. In case of `pg_basebackup` complete the `recovery.pgBaseBackup` section. 
-4. Optionally set the `recovery.pitrTarget.time` in RFC3339 format to perform a point-in-time recovery (not applicable for `pgBaseBackup`).
+4. Optionally set the `recovery.recoveryTarget.targetTime` in RFC3339 format to perform a point-in-time recovery (not applicable for `pgBaseBackup`).
 5. Retain the identical PostgreSQL version and configuration as the original cluster.
 6. Make sure you don't use the same backup section name as the original cluster. We advise you change the `path` within the storage location if you want to reuse the same storage location/bucket.
     One pattern is adding a version number at the end of the path, e.g. `/v1` or `/v2` after each recovery procedure.

--- a/charts/cluster/templates/NOTES.txt
+++ b/charts/cluster/templates/NOTES.txt
@@ -6,6 +6,11 @@
   {{ fail ".Values.cluster.postgresql has been deprecated. Use .Values.cluster.postgresql.parameters instead." }}
 {{- end -}}
 
+{{/* Parentheses are needed to avoid nil pointer errors */}}
+{{- if (((.Values.recovery).pitrTarget).time) -}}
+  {{/* We don't fail here, otherwise that would be a breaking change */}}
+  DEPRECATION NOTICE: .Values.recovery.pitrTarget.time has been deprecated. Use .Values.recovery.recoveryTarget.targetTime instead.
+{{- end -}}
 
 {{ if .Release.IsInstall }}
 The {{ include "cluster.color-info" (include "cluster.fullname" .) }} has been installed successfully.

--- a/charts/cluster/templates/_bootstrap.tpl
+++ b/charts/cluster/templates/_bootstrap.tpl
@@ -82,10 +82,18 @@ externalClusters:
 
 {{- else }}
   recovery:
-    {{- with .Values.recovery.pitrTarget.time }}
+    {{- with .Values.recovery.recoveryTarget }}
     recoveryTarget:
-      targetTime: {{ . }}
+      {{- toYaml . | nindent 6 }}
     {{- end }}
+
+    {{/* DEPRECATED, replaced by .Values.recovery.recoveryTarget above */}}
+    {{/* Will fail if both pitrTarget.time and recoveryTarget are specified */}}
+	{{- with .Values.recovery.pitrTarget.time }}
+	recoveryTarget:
+	  targetTime: {{ . }}
+	{{- end }}
+
     {{- if eq .Values.recovery.method "backup" }}
     backup:
       name: {{ .Values.recovery.backupName }}

--- a/charts/cluster/test/postgresql-minio-backup-restore/chainsaw-test.yaml
+++ b/charts/cluster/test/postgresql-minio-backup-restore/chainsaw-test.yaml
@@ -120,7 +120,7 @@ spec:
                 --install \
                 --namespace $NAMESPACE \
                 --values ./09-recovery_backup_pitr_cluster.yaml \
-                --set recovery.pitrTarget.time="$DATE_NO_BAD_TABLE" \
+                --set recovery.recoveryTarget.targetTime="$DATE_NO_BAD_TABLE" \
                 --wait \
                 recovery-backup-pitr ../../
         - assert:

--- a/charts/cluster/test/timescale-minio-backup-restore/chainsaw-test.yaml
+++ b/charts/cluster/test/timescale-minio-backup-restore/chainsaw-test.yaml
@@ -98,7 +98,7 @@ spec:
                 --install \
                 --namespace $NAMESPACE \
                 --values ./07-recovery_backup_pitr_cluster.yaml \
-                --set recovery.pitrTarget.time="$DATE_NO_BAD_TABLE" \
+                --set recovery.recoveryTarget.targetTime="$DATE_NO_BAD_TABLE" \
                 --wait \
                 recovery-backup-pitr ../../
         - assert:

--- a/charts/cluster/values.schema.json
+++ b/charts/cluster/values.schema.json
@@ -623,6 +623,9 @@
                         }
                     }
                 },
+                "recoveryTarget": {
+                    "type": "object"
+                },
                 "pitrTarget": {
                     "type": "object",
                     "properties": {

--- a/charts/cluster/values.yaml
+++ b/charts/cluster/values.yaml
@@ -37,7 +37,14 @@ recovery:
   # * `import` - Import one or more databases from an existing Postgres cluster.
   method: backup
 
+  ##
+  # -- Recovery target:
+  # It is passed directly to the CR. For example, for point in time recovery,
+  # specify `targetTime`.
+  recoveryTarget: {}
+
   ## -- Point in time recovery target. Specify one of the following:
+  # DEPRECATED: Use `recoveryTarget` instead.
   pitrTarget:
     # -- Time in RFC3339 format
     time: ""


### PR DESCRIPTION
Replace `.Values.recovery.pitrTarget.time` with `.Values.recovery.recoveryTarget`, so that we can use any kind of recovery target.

This enables configuration of more advanced recovery options, such as:
- targetTime
- targetXID
- targetLSN
- targetName
- etc.

The previous behaviour is actually preserved, but deprecated, so there are no breaking changes.

Resolves cloudnative-pg/charts#272