### PR TITLE
feat(cluster): add pvcTemplate to storage config

### DIFF
--- a/charts/cluster/templates/cluster.yaml
+++ b/charts/cluster/templates/cluster.yaml
@@ -27,11 +27,19 @@ spec:
     {{- if not (empty .Values.cluster.storage.storageClass) }}
     storageClass: {{ .Values.cluster.storage.storageClass }}
     {{- end }}
+    {{- if .Values.cluster.storage.pvcTemplate }}
+    pvcTemplate:
+      {{- toYaml .Values.cluster.storage.pvcTemplate | nindent 6 }}
+    {{- end }}
   {{- if .Values.cluster.walStorage.enabled }}
   walStorage:
     size: {{ .Values.cluster.walStorage.size }}
     {{- if not (empty .Values.cluster.walStorage.storageClass) }}
     storageClass: {{ .Values.cluster.walStorage.storageClass }}
+    {{- end }}
+    {{- if .Values.cluster.walStorage.pvcTemplate }}
+    pvcTemplate:
+      {{- toYaml .Values.cluster.walStorage.pvcTemplate | nindent 6 }}
     {{- end }}
   {{- end }}
   {{- with .Values.cluster.resources }}

--- a/charts/cluster/values.yaml
+++ b/charts/cluster/values.yaml
@@ -204,11 +204,40 @@ cluster:
   storage:
     size: 8Gi
     storageClass: ""
+    # -- Custom pvc template. Defining this makes size and storageClass redundant
+    # See: https://cloudnative-pg.io/documentation/1.25/cloudnative-pg.v1/#postgresql-cnpg-io-v1-StorageConfiguration:~:text=pvcTemplate
+    # Def: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#persistentvolumeclaimspec-v1-core
+    #
+    # pvcTemplate:
+    #   storageClassName: ""
+    #   selector:
+    #     matchLabels:
+    #       provided-for: custom-label-to-select-pv
+    #   accessModes:
+    #     - ReadWriteOnce
+    #   resources:
+    #     requests:
+    #       storage: 8Gi
+
 
   walStorage:
     enabled: false
     size: 1Gi
     storageClass: ""
+    # -- Custom pvc template. Defining this makes size and storageClass redundant
+    # See: https://cloudnative-pg.io/documentation/1.25/cloudnative-pg.v1/#postgresql-cnpg-io-v1-StorageConfiguration:~:text=pvcTemplate
+    # Def: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#persistentvolumeclaimspec-v1-core
+    #
+    # pvcTemplate:
+    #   storageClassName: ""
+    #   selector:
+    #     matchLabels:
+    #       provided-for: custom-label-to-select-pv
+    #   accessModes:
+    #     - ReadWriteOnce
+    #   resources:
+    #     requests:
+    #       storage: 8Gi
 
   # -- The UID of the postgres user inside the image, defaults to 26
   postgresUID: -1


### PR DESCRIPTION
Added the option "pvcTemplate" to `cluster.storage` and `cluster.walStorage`. Added some documentation and references to the documentation