### PR TITLE
fix: dead readme link to `charts/cluster/docs/recovery.md`

### DIFF
--- a/charts/cluster/README.md
+++ b/charts/cluster/README.md
@@ -100,7 +100,7 @@ below. Refer to the table for the full list of parameters and place the configur
 Recovery
 --------
 
-There is a separate document outlining the recovery procedure here: **[Recovery](docs/recovery.md)**
+There is a separate document outlining the recovery procedure here: **[Recovery](docs/Recovery.md)**
 
 Examples
 --------

--- a/charts/cluster/README.md.gotmpl
+++ b/charts/cluster/README.md.gotmpl
@@ -109,7 +109,7 @@ below. Refer to the table for the full list of parameters and place the configur
 Recovery
 --------
 
-There is a separate document outlining the recovery procedure here: **[Recovery](docs/recovery.md)**
+There is a separate document outlining the recovery procedure here: **[Recovery](docs/Recovery.md)**
 
 
 Examples


### PR DESCRIPTION
Looks like `cluster/docs/recovery.md` file was renamed to `cluster/docs/Recovery.md`, but `charts/cluster/README.md` still leads to old filename.