### PR TITLE
feat( cluster ): Advanced configuration for monitoring queries

### DIFF
--- a/charts/cluster/templates/user-metrics.yaml
+++ b/charts/cluster/templates/user-metrics.yaml
@@ -12,6 +12,12 @@ data:
     {{- range .Values.cluster.monitoring.customQueries }}
     {{ .name }}:
       query: {{ .query | quote }}
+      {{- with .target_databases }}
+      target_databases: {{ . | toJson }}
+      {{- end }}
+      {{- with .predicate_query }}
+      predicate_query: {{ tpl . $ | quote }}
+      {{- end }}
       metrics:
         {{- .metrics | toYaml | nindent 8 }}
     {{- end }}

--- a/charts/cluster/test/monitoring/01-monitoring_cluster-assert.yaml
+++ b/charts/cluster/test/monitoring/01-monitoring_cluster-assert.yaml
@@ -124,6 +124,8 @@ data:
   custom-queries: |
     pg_cache_hit_ratio:
       query: "SELECT current_database() as datname, sum(heap_blks_hit) / (sum(heap_blks_hit) + sum(heap_blks_read)) as ratio FROM pg_statio_user_tables;"
+      target_databases: ["*"]
+      predicate_query: "SELECT 'postgresql';"
       metrics:
         - datname:
             description: Name of the database

--- a/charts/cluster/test/monitoring/01-monitoring_cluster.yaml
+++ b/charts/cluster/test/monitoring/01-monitoring_cluster.yaml
@@ -11,6 +11,8 @@ cluster:
     customQueries:
       - name: "pg_cache_hit_ratio"
         query: "SELECT current_database() as datname, sum(heap_blks_hit) / (sum(heap_blks_hit) + sum(heap_blks_read)) as ratio FROM pg_statio_user_tables;"
+        target_databases: ["*"]
+        predicate_query: "SELECT '{{ .Values.type }}';"
         metrics:
           - datname:
               usage: "LABEL"

--- a/charts/cluster/values.yaml
+++ b/charts/cluster/values.yaml
@@ -303,6 +303,8 @@ cluster:
     customQueries: []
     #  - name: "pg_cache_hit_ratio"
     #    query: "SELECT current_database() as datname, sum(heap_blks_hit) / (sum(heap_blks_hit) + sum(heap_blks_read)) as ratio FROM pg_statio_user_tables;"
+    #    target_databases: ["*"]
+    #    predicate_query: "SELECT '{{ .Values.version.postgresql }}';"
     #    metrics:
     #      - datname:
     #          usage: "LABEL"


### PR DESCRIPTION
Adds support for:

* `cluster.monitoring.customQueries[].target_databases`
* `cluster.monitoring.customQueries[].predicate_query`

The `predicate_query` field is evaluated with `tpl` to allow users to specify more advanced configurations.