### PR TITLE
Support ClusterImageCatalog, Cluster replicationSlots/volumeSnapshot recovery

### DIFF
--- a/charts/cloudnative-pg/templates/clusterimagecatalog.yaml
+++ b/charts/cloudnative-pg/templates/clusterimagecatalog.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.clusterImageCatalogs }}
+{{- range $catalog := .Values.clusterImageCatalogs }}
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: ClusterImageCatalog
+metadata:
+  name: {{ $catalog.name }}
+  labels:
+    {{- include "cloudnative-pg.labels" $ | nindent 4 }}
+  {{- with $.Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  images:
+  {{- range $image := $catalog.images }}
+    - major: {{ $image.major }}
+      image: {{ $image.image }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/cloudnative-pg/values.schema.json
+++ b/charts/cloudnative-pg/values.schema.json
@@ -2,312 +2,339 @@
     "$schema": "http://json-schema.org/schema#",
     "type": "object",
     "properties": {
-        "additionalArgs": {
-            "type": "array"
-        },
-        "additionalEnv": {
-            "type": "array"
-        },
-        "affinity": {
-            "type": "object"
-        },
-        "topologySpreadConstraints": {
-            "type": "array"
-        },
-        "commonAnnotations": {
-            "type": "object"
-        },
-        "config": {
-            "type": "object",
-            "properties": {
-                "clusterWide": {
-                    "type": "boolean"
-                },
-                "create": {
-                    "type": "boolean"
-                },
-                "data": {
-                    "type": "object"
-                },
-                "maxConcurrentReconciles": {
-                    "type": "integer"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "secret": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "containerSecurityContext": {
-            "type": "object",
-            "properties": {
-                "allowPrivilegeEscalation": {
-                    "type": "boolean"
-                },
-                "capabilities": {
-                    "type": "object",
-                    "properties": {
-                        "drop": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "readOnlyRootFilesystem": {
-                    "type": "boolean"
-                },
-                "runAsGroup": {
-                    "type": "integer"
-                },
-                "runAsUser": {
-                    "type": "integer"
-                },
-                "seccompProfile": {
-                    "type": "object",
-                    "properties": {
-                        "type": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "crds": {
-            "type": "object",
-            "properties": {
-                "create": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "dnsPolicy": {
-            "type": "string"
-        },
-        "fullnameOverride": {
-            "type": "string"
-        },
-        "hostNetwork": {
+      "additionalArgs": {
+        "type": "array"
+      },
+      "additionalEnv": {
+        "type": "array"
+      },
+      "affinity": {
+        "type": "object"
+      },
+      "topologySpreadConstraints": {
+        "type": "array"
+      },
+      "commonAnnotations": {
+        "type": "object"
+      },
+      "config": {
+        "type": "object",
+        "properties": {
+          "clusterWide": {
             "type": "boolean"
-        },
-        "image": {
-            "type": "object",
-            "properties": {
-                "pullPolicy": {
-                    "type": "string"
-                },
-                "repository": {
-                    "type": "string"
-                },
-                "tag": {
-                    "type": "string"
-                }
-            }
-        },
-        "imagePullSecrets": {
-            "type": "array"
-        },
-        "monitoring": {
-            "type": "object",
-            "properties": {
-                "grafanaDashboard": {
-                    "type": "object",
-                    "properties": {
-                        "annotations": {
-                            "type": "object"
-                        },
-                        "configMapName": {
-                            "type": "string"
-                        },
-                        "create": {
-                            "type": "boolean"
-                        },
-                        "labels": {
-                            "type": "object"
-                        },
-                        "namespace": {
-                            "type": "string"
-                        },
-                        "sidecarLabel": {
-                            "type": "string"
-                        },
-                        "sidecarLabelValue": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "podMonitorAdditionalLabels": {
-                    "type": "object"
-                },
-                "podMonitorEnabled": {
-                    "type": "boolean"
-                },
-                "podMonitorMetricRelabelings": {
-                    "type": "array"
-                },
-                "podMonitorRelabelings": {
-                    "type": "array"
-                }
-            }
-        },
-        "monitoringQueriesConfigMap": {
-            "type": "object",
-            "properties": {
-                "name": {
-                    "type": "string"
-                },
-                "queries": {
-                    "type": "string"
-                }
-            }
-        },
-        "nameOverride": {
-            "type": "string"
-        },
-        "namespaceOverride": {
-            "type": "string"
-        },
-        "nodeSelector": {
+          },
+          "create": {
+            "type": "boolean"
+          },
+          "data": {
             "type": "object"
-        },
-        "podAnnotations": {
-            "type": "object"
-        },
-        "podLabels": {
-            "type": "object"
-        },
-        "podSecurityContext": {
-            "type": "object",
-            "properties": {
-                "runAsNonRoot": {
-                    "type": "boolean"
-                },
-                "seccompProfile": {
-                    "type": "object",
-                    "properties": {
-                        "type": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "priorityClassName": {
-            "type": "string"
-        },
-        "rbac": {
-            "type": "object",
-            "properties": {
-                "aggregateClusterRoles": {
-                    "type": "boolean"
-                },
-                "create": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "replicaCount": {
+          },
+          "maxConcurrentReconciles": {
             "type": "integer"
-        },
-        "resources": {
-            "type": "object"
-        },
-        "service": {
-            "type": "object",
-            "properties": {
-                "ipFamilies": {
-                    "type": "array"
-                },
-                "ipFamilyPolicy": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "port": {
-                    "type": "integer"
-                },
-                "type": {
-                    "type": "string"
-                }
-            }
-        },
-        "serviceAccount": {
-            "type": "object",
-            "properties": {
-                "create": {
-                    "type": "boolean"
-                },
-                "name": {
-                    "type": "string"
-                }
-            }
-        },
-        "tolerations": {
-            "type": "array"
-        },
-        "updateStrategy": {
-            "type": "object"
-        },
-        "webhook": {
-            "type": "object",
-            "properties": {
-                "livenessProbe": {
-                    "type": "object",
-                    "properties": {
-                        "initialDelaySeconds": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                "mutating": {
-                    "type": "object",
-                    "properties": {
-                        "create": {
-                            "type": "boolean"
-                        },
-                        "failurePolicy": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "port": {
-                    "type": "integer"
-                },
-                "readinessProbe": {
-                    "type": "object",
-                    "properties": {
-                        "initialDelaySeconds": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                "startupProbe": {
-                    "type": "object",
-                    "properties": {
-                        "failureThreshold": {
-                            "type": "integer"
-                        },
-                        "periodSeconds": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                "validating": {
-                    "type": "object",
-                    "properties": {
-                        "create": {
-                            "type": "boolean"
-                        },
-                        "failurePolicy": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
+          },
+          "name": {
+            "type": "string"
+          },
+          "secret": {
+            "type": "boolean"
+          }
         }
+      },
+      "containerSecurityContext": {
+        "type": "object",
+        "properties": {
+          "allowPrivilegeEscalation": {
+            "type": "boolean"
+          },
+          "capabilities": {
+            "type": "object",
+            "properties": {
+              "drop": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "readOnlyRootFilesystem": {
+            "type": "boolean"
+          },
+          "runAsGroup": {
+            "type": "integer"
+          },
+          "runAsUser": {
+            "type": "integer"
+          },
+          "seccompProfile": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "crds": {
+        "type": "object",
+        "properties": {
+          "create": {
+            "type": "boolean"
+          }
+        }
+      },
+      "dnsPolicy": {
+        "type": "string"
+      },
+      "fullnameOverride": {
+        "type": "string"
+      },
+      "hostNetwork": {
+        "type": "boolean"
+      },
+      "image": {
+        "type": "object",
+        "properties": {
+          "pullPolicy": {
+            "type": "string"
+          },
+          "repository": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          }
+        }
+      },
+      "imagePullSecrets": {
+        "type": "array"
+      },
+      "monitoring": {
+        "type": "object",
+        "properties": {
+          "grafanaDashboard": {
+            "type": "object",
+            "properties": {
+              "annotations": {
+                "type": "object"
+              },
+              "configMapName": {
+                "type": "string"
+              },
+              "create": {
+                "type": "boolean"
+              },
+              "labels": {
+                "type": "object"
+              },
+              "namespace": {
+                "type": "string"
+              },
+              "sidecarLabel": {
+                "type": "string"
+              },
+              "sidecarLabelValue": {
+                "type": "string"
+              }
+            }
+          },
+          "podMonitorAdditionalLabels": {
+            "type": "object"
+          },
+          "podMonitorEnabled": {
+            "type": "boolean"
+          },
+          "podMonitorMetricRelabelings": {
+            "type": "array"
+          },
+          "podMonitorRelabelings": {
+            "type": "array"
+          }
+        }
+      },
+      "monitoringQueriesConfigMap": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "queries": {
+            "type": "string"
+          }
+        }
+      },
+      "nameOverride": {
+        "type": "string"
+      },
+      "namespaceOverride": {
+        "type": "string"
+      },
+      "nodeSelector": {
+        "type": "object"
+      },
+      "podAnnotations": {
+        "type": "object"
+      },
+      "podLabels": {
+        "type": "object"
+      },
+      "podSecurityContext": {
+        "type": "object",
+        "properties": {
+          "runAsNonRoot": {
+            "type": "boolean"
+          },
+          "seccompProfile": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "priorityClassName": {
+        "type": "string"
+      },
+      "rbac": {
+        "type": "object",
+        "properties": {
+          "aggregateClusterRoles": {
+            "type": "boolean"
+          },
+          "create": {
+            "type": "boolean"
+          }
+        }
+      },
+      "replicaCount": {
+        "type": "integer"
+      },
+      "resources": {
+        "type": "object"
+      },
+      "service": {
+        "type": "object",
+        "properties": {
+          "ipFamilies": {
+            "type": "array"
+          },
+          "ipFamilyPolicy": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "port": {
+            "type": "integer"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "serviceAccount": {
+        "type": "object",
+        "properties": {
+          "create": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "tolerations": {
+        "type": "array"
+      },
+      "updateStrategy": {
+        "type": "object"
+      },
+      "webhook": {
+        "type": "object",
+        "properties": {
+          "livenessProbe": {
+            "type": "object",
+            "properties": {
+              "initialDelaySeconds": {
+                "type": "integer"
+              }
+            }
+          },
+          "mutating": {
+            "type": "object",
+            "properties": {
+              "create": {
+                "type": "boolean"
+              },
+              "failurePolicy": {
+                "type": "string"
+              }
+            }
+          },
+          "port": {
+            "type": "integer"
+          },
+          "readinessProbe": {
+            "type": "object",
+            "properties": {
+              "initialDelaySeconds": {
+                "type": "integer"
+              }
+            }
+          },
+          "startupProbe": {
+            "type": "object",
+            "properties": {
+              "failureThreshold": {
+                "type": "integer"
+              },
+              "periodSeconds": {
+                "type": "integer"
+              }
+            }
+          },
+          "validating": {
+            "type": "object",
+            "properties": {
+              "create": {
+                "type": "boolean"
+              },
+              "failurePolicy": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "clusterImageCatalogs": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": ["name", "images"],
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "images": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["major", "image"],
+                "properties": {
+                  "major": {
+                    "type": ["string", "integer"]
+                  },
+                  "image": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
 }

--- a/charts/cloudnative-pg/values.yaml
+++ b/charts/cloudnative-pg/values.yaml
@@ -199,6 +199,8 @@ monitoring:
     # -- Annotations that ConfigMaps can have to get configured in Grafana.
     annotations: {}
 
+clusterImageCatalogs: []
+
 # Default monitoring queries
 monitoringQueriesConfigMap:
   # -- The name of the default monitoring configmap.

--- a/charts/cluster/templates/_bootstrap.tpl
+++ b/charts/cluster/templates/_bootstrap.tpl
@@ -91,20 +91,28 @@ externalClusters:
       name: {{ .Values.recovery.backupName }}
     {{- else if eq .Values.recovery.method "object_store" }}
     source: objectStoreRecoveryCluster
+    {{- else if eq .Values.recovery.method "volumeSnapshot" }}
+    volumeSnapshots:
+      storage:
+        apiGroup: {{ .Values.recovery.volumeSnapshots.storage.apiGroup | quote }}
+        kind: {{ .Values.recovery.volumeSnapshots.storage.kind | quote }}
+        name: {{ .Values.recovery.volumeSnapshots.storage.name | quote }}
     {{- end }}
-    {{ with .Values.recovery.database }}
+    {{- with .Values.recovery.database }}
     database: {{ . }}
     {{- end }}
-    {{ with .Values.recovery.owner }}
+    {{- with .Values.recovery.owner }}
     owner: {{ . }}
     {{- end }}
 
+{{- if .Values.recovery.clusterName }}
 externalClusters:
   - name: objectStoreRecoveryCluster
     barmanObjectStore:
       serverName: {{ .Values.recovery.clusterName }}
       {{- $d := dict "chartFullname" (include "cluster.fullname" .) "scope" .Values.recovery "secretPrefix" "recovery" -}}
       {{- include "cluster.barmanObjectStoreConfig" $d | nindent 4 }}
+{{- end }}
 {{- end }}
 {{-  else }}
   {{ fail "Invalid cluster mode!" }}

--- a/charts/cluster/templates/cluster.yaml
+++ b/charts/cluster/templates/cluster.yaml
@@ -89,6 +89,10 @@ spec:
     parameters:
       {{- toYaml . | nindent 6 }}
     {{- end }}
+  {{- with .Values.cluster.replicationSlots }}
+  replicationSlots:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 
   {{- if not (and (empty .Values.cluster.roles) (empty .Values.cluster.services)) }}
   managed:

--- a/charts/cluster/values.schema.json
+++ b/charts/cluster/values.schema.json
@@ -170,132 +170,133 @@
         "cluster": {
             "type": "object",
             "properties": {
-                "additionalLabels": {
-                    "type": "object"
-                },
-                "affinity": {
-                    "type": "object",
-                    "properties": {
-                        "topologyKey": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "annotations": {
-                    "type": "object"
-                },
-                "certificates": {
-                    "type": "object"
-                },
-                "enablePDB": {
-                    "type": "boolean"
-                },
-                "enableSuperuserAccess": {
-                    "type": "boolean"
-                },
-                "imageCatalogRef": {
-                    "type": "object"
-                },
-                "imageName": {
+              "additionalLabels": {
+                "type": "object"
+              },
+              "affinity": {
+                "type": "object",
+                "properties": {
+                  "topologyKey": {
                     "type": "string"
-                },
-                "imagePullPolicy": {
-                    "type": "string"
-                },
-                "imagePullSecrets": {
+                  }
+                }
+              },
+              "annotations": {
+                "type": "object"
+              },
+              "certificates": {
+                "type": "object"
+              },
+              "enablePDB": {
+                "type": "boolean"
+              },
+              "enableSuperuserAccess": {
+                "type": "boolean"
+              },
+              "imageCatalogRef": {
+                "type": "object"
+              },
+              "imageName": {
+                "type": "string"
+              },
+              "imagePullPolicy": {
+                "type": "string"
+              },
+              "imagePullSecrets": {
+                "type": "array"
+              },
+              "initdb": {
+                "type": "object"
+              },
+              "instances": {
+                "type": "integer"
+              },
+              "logLevel": {
+                "type": "string"
+              },
+              "monitoring": {
+                "type": "object",
+                "properties": {
+                  "customQueries": {
                     "type": "array"
-                },
-                "initdb": {
-                    "type": "object"
-                },
-                "instances": {
-                    "type": "integer"
-                },
-                "logLevel": {
-                    "type": "string"
-                },
-                "monitoring": {
+                  },
+                  "customQueriesSecret": {
+                    "type": "array"
+                  },
+                  "disableDefaultQueries": {
+                    "type": "boolean"
+                  },
+                  "enabled": {
+                    "type": "boolean"
+                  },
+                  "podMonitor": {
                     "type": "object",
                     "properties": {
-                        "customQueries": {
-                            "type": "array"
-                        },
-                        "customQueriesSecret": {
-                            "type": "array"
-                        },
-                        "disableDefaultQueries": {
-                            "type": "boolean"
-                        },
-                        "enabled": {
-                            "type": "boolean"
-                        },
-                        "podMonitor": {
-                            "type": "object",
-                            "properties": {
-                                "enabled": {
-                                    "type": "boolean"
-                                },
-                                "metricRelabelings": {
-                                    "type": "array"
-                                },
-                                "relabelings": {
-                                    "type": "array"
-                                }
-                            }
-                        },
-                        "prometheusRule": {
-                            "type": "object",
-                            "properties": {
-                                "enabled": {
-                                    "type": "boolean"
-                                },
-                                "excludeRules": {
-                                    "type": "array"
-                                }
-                            }
-                        }
+                      "enabled": {
+                        "type": "boolean"
+                      },
+                      "metricRelabelings": {
+                        "type": "array"
+                      },
+                      "relabelings": {
+                        "type": "array"
+                      }
                     }
-                },
-                "postgresGID": {
-                    "type": "integer"
-                },
-                "postgresUID": {
-                    "type": "integer"
-                },
-                "postgresql": {
+                  },
+                  "prometheusRule": {
                     "type": "object",
                     "properties": {
-                        "ldap": {
-                            "type": "object"
-                        },
-                        "parameters": {
-                            "type": "object"
-                        },
-                        "pg_hba": {
-                            "type": "array"
-                        },
-                        "pg_ident": {
-                            "type": "array"
-                        },
-                        "shared_preload_libraries": {
-                            "type": "array"
-                        },
-                        "synchronous": {
-                            "type": "object"
-                        }
+                      "enabled": {
+                        "type": "boolean"
+                      },
+                      "excludeRules": {
+                        "type": "array"
+                      }
                     }
-                },
-                "primaryUpdateMethod": {
-                    "type": "string"
-                },
-                "primaryUpdateStrategy": {
-                    "type": "string"
-                },
-                "priorityClassName": {
-                    "type": "string"
-                },
-                "resources": {
+                  }
+                }
+              },
+              "postgresGID": {
+                "type": "integer"
+              },
+              "postgresUID": {
+                "type": "integer"
+              },
+              "postgresql": {
+                "type": "object",
+                "properties": {
+                  "ldap": {
                     "type": "object"
+                  },
+                  "parameters": {
+                    "type": "object"
+                  },
+                  "pg_hba": {
+                    "type": "array"
+                  },
+                  "pg_ident": {
+                    "type": "array"
+                  },
+                  "shared_preload_libraries": {
+                    "type": "array"
+                  },
+                  "synchronous": {
+                    "type": "object"
+                  }
+                }
+              },
+              "primaryUpdateMethod": {
+                "type": "string"
+              },
+              "primaryUpdateStrategy": {
+                "type": "string"
+              },
+              "priorityClassName": {
+                "type": "string"
+              },
+              "resources": {
+                "type": "object"
+              },
               "replicationSlots": {
                 "type": "object",
                 "properties": {
@@ -308,7 +309,7 @@
                     }
                   }
                 }
-              },
+              }
             }
         },
         "fullnameOverride": {

--- a/charts/cluster/values.schema.json
+++ b/charts/cluster/values.schema.json
@@ -296,44 +296,19 @@
                 },
                 "resources": {
                     "type": "object"
-                },
-                "roles": {
-                    "type": "array"
-                },
-                "serviceAccountTemplate": {
-                    "type": "object"
-                },
-                "services": {
-                    "type": "object"
-                },
-                "storage": {
+              "replicationSlots": {
+                "type": "object",
+                "properties": {
+                  "highAvailability": {
                     "type": "object",
                     "properties": {
-                        "size": {
-                            "type": "string"
-                        },
-                        "storageClass": {
-                            "type": "string"
-                        }
+                      "enabled": {
+                        "type": "boolean"
+                      }
                     }
-                },
-                "superuserSecret": {
-                    "type": "string"
-                },
-                "walStorage": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean"
-                        },
-                        "size": {
-                            "type": "string"
-                        },
-                        "storageClass": {
-                            "type": "string"
-                        }
-                    }
+                  }
                 }
+              },
             }
         },
         "fullnameOverride": {


### PR DESCRIPTION
## cloudnative-pg

- Add a template to allow creating one or `ClusterImageCatalog`

## cluster

- Allow updating the `replicationSlots` field of the `Cluster`
- Enable recovery from a volume snapshot