### PR TITLE
ci(security): set workflows permission to read-all by default

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,8 @@ on:
     branches-ignore:
       - 'gh-pages'
 
+permissions: read-all
+
 jobs:
   codespell:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -8,12 +8,13 @@ on:
     branches:
       - release/*-v*
 
-permissions:
-  pull-requests: write
+permissions: read-all
 
 jobs:
   create-pull-request:
     runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -5,14 +5,15 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write # Required for pushing the Helm charts to the gh-pages branch
-  packages: write # Required for GHCR access
-  id-token: write # Required for signing
+permissions: read-all
 
 jobs:
   release:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write # Required for pushing the Helm charts to the gh-pages branch
+      packages: write # Required for GHCR access
+      id-token: write # Required for signing
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/tests-cluster-chainsaw.yaml
+++ b/.github/workflows/tests-cluster-chainsaw.yaml
@@ -5,6 +5,8 @@ on:
     branches-ignore:
       - 'gh-pages'
 
+permissions: read-all
+
 jobs:
   test-list:
     runs-on: ubuntu-24.04

--- a/.github/workflows/tests-operator.yml
+++ b/.github/workflows/tests-operator.yml
@@ -5,6 +5,8 @@ on:
     branches-ignore:
       - 'gh-pages'
 
+permissions: read-all
+
 jobs:
   deploy_operator:
     name: Deploy the operator in cluster-wide mode


### PR DESCRIPTION
The permissions should be assigned on every job and by default should always be read

Closes #593 