### PR TITLE
fix(cluster): update backup template to use conditional encryption va…

### DIFF
--- a/charts/cluster/templates/_backup.tpl
+++ b/charts/cluster/templates/_backup.tpl
@@ -6,13 +6,13 @@ backup:
   barmanObjectStore:
     wal:
       compression: {{ .Values.backups.wal.compression }}
-      {{- if .Values.backups.wal.encryption}}
+      {{- if .Values.backups.wal.encryption }}
       encryption: {{ .Values.backups.wal.encryption }}
       {{- end }}
       maxParallel: {{ .Values.backups.wal.maxParallel }}
     data:
       compression: {{ .Values.backups.data.compression }}
-      {{- if .Values.backups.data.encryption}}
+      {{- if .Values.backups.data.encryption }}
       encryption: {{ .Values.backups.data.encryption }}
       {{- end }}
       jobs: {{ .Values.backups.data.jobs }}

--- a/charts/cluster/templates/_backup.tpl
+++ b/charts/cluster/templates/_backup.tpl
@@ -6,14 +6,14 @@ backup:
   barmanObjectStore:
     wal:
       compression: {{ .Values.backups.wal.compression }}
-      {{- with .Values.backups.wal.encryption}}
-      encryption: {{ . }}
+      {{- if .Values.backups.wal.encryption}}
+      encryption: {{ .Values.backups.wal.encryption }}
       {{- end }}
       maxParallel: {{ .Values.backups.wal.maxParallel }}
     data:
       compression: {{ .Values.backups.data.compression }}
-      {{- with .Values.backups.data.encryption }}
-      encryption: {{ . }}
+      {{- if .Values.backups.data.encryption}}
+      encryption: {{ .Values.backups.data.encryption }}
       {{- end }}
       jobs: {{ .Values.backups.data.jobs }}
 


### PR DESCRIPTION
By making the encryption value conditional you can now unset the value if needed and prevent the helm chart to pickup the default value which is `AES256`