### PR TITLE
feat(cloudnative-pg): Setup optional PDB

### DIFF
--- a/charts/cloudnative-pg/templates/pdb.yaml
+++ b/charts/cloudnative-pg/templates/pdb.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.podDisruptionBudget.enabled -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "cloudnative-pg.fullname" . }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "cloudnative-pg.selectorLabels" . | nindent 6 }}
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end  }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  {{- if (semverCompare ">= 1.27-0" .Capabilities.KubeVersion.Version) }}
+  unhealthyPodEvictionPolicy: {{ .Values.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  {{- end }}
+{{- end }}

--- a/charts/cloudnative-pg/values.schema.json
+++ b/charts/cloudnative-pg/values.schema.json
@@ -11,6 +11,9 @@
         "affinity": {
             "type": "object"
         },
+        "podDisruptionBudget": {
+            "type": "object"
+        },
         "commonAnnotations": {
             "type": "object"
         },

--- a/charts/cloudnative-pg/values.yaml
+++ b/charts/cloudnative-pg/values.yaml
@@ -173,6 +173,32 @@ tolerations: []
 # -- Affinity for the operator to be installed.
 affinity: {}
 
+# -- Setup podDisruptionBudget for the operator
+# https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+podDisruptionBudget:
+
+  # -- Specifies whether the PDB should be enabled
+  enabled: false
+  # The PDB definition three attributes to control the availability requirements:
+  # minAvailable or maxUnavailable (mutually exclusive).
+  # unhealthyPodEvictionPolicy
+  #
+  # Field maxUnavailable tells how many pods can be down and minAvailable tells how many pods must be running in a cluster.
+
+  # The pdb template will check values according to below order
+  #
+  #  {{- if .Values.podDisruptionBudget.minAvailable }}
+  #     minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  #  {{- end  }}
+  #  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  #     maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  #  {{- end }}
+  #
+  # If both values are set, the template will use the first one and ignore the second one. currently by default minAvailable is set to 1
+  minAvailable: 1
+  maxUnavailable:
+  unhealthyPodEvictionPolicy: IfHealthyBudget
+
 monitoring:
 
   # -- Specifies whether the monitoring should be enabled. Requires Prometheus Operator CRDs.


### PR DESCRIPTION
This permits putting a PDB around the operator deployment.