### PR TITLE
fix(cloudnative-pg): queries identation in cnpg-default-monitoring

### DIFF
--- a/charts/cloudnative-pg/values.yaml
+++ b/charts/cloudnative-pg/values.yaml
@@ -210,30 +210,30 @@ monitoringQueriesConfigMap:
   queries: |
     backends:
       query: |
-       SELECT sa.datname
-           , sa.usename
-           , sa.application_name
-           , states.state
-           , COALESCE(sa.count, 0) AS total
-           , COALESCE(sa.max_tx_secs, 0) AS max_tx_duration_seconds
-           FROM ( VALUES ('active')
-               , ('idle')
-               , ('idle in transaction')
-               , ('idle in transaction (aborted)')
-               , ('fastpath function call')
-               , ('disabled')
-               ) AS states(state)
-           LEFT JOIN (
-               SELECT datname
-                   , state
-                   , usename
-                   , COALESCE(application_name, '') AS application_name
-                   , COUNT(*)
-                   , COALESCE(EXTRACT (EPOCH FROM (max(now() - xact_start))), 0) AS max_tx_secs
-               FROM pg_catalog.pg_stat_activity
-               GROUP BY datname, state, usename, application_name
-           ) sa ON states.state = sa.state
-           WHERE sa.usename IS NOT NULL
+        SELECT sa.datname
+          , sa.usename
+          , sa.application_name
+          , states.state
+          , COALESCE(sa.count, 0) AS total
+          , COALESCE(sa.max_tx_secs, 0) AS max_tx_duration_seconds
+        FROM ( VALUES ('active')
+          , ('idle')
+          , ('idle in transaction')
+          , ('idle in transaction (aborted)')
+          , ('fastpath function call')
+          , ('disabled')
+          ) AS states(state)
+        LEFT JOIN (
+          SELECT datname
+            , state
+            , usename
+            , COALESCE(application_name, '') AS application_name
+            , COUNT(*)
+            , COALESCE(EXTRACT (EPOCH FROM (max(now() - xact_start))), 0) AS max_tx_secs
+          FROM pg_catalog.pg_stat_activity
+          GROUP BY datname, state, usename, application_name
+        ) sa ON states.state = sa.state
+        WHERE sa.usename IS NOT NULL
       metrics:
         - datname:
             usage: "LABEL"
@@ -256,22 +256,22 @@ monitoringQueriesConfigMap:
 
     backends_waiting:
       query: |
-       SELECT count(*) AS total
-       FROM pg_catalog.pg_locks blocked_locks
-       JOIN pg_catalog.pg_locks blocking_locks
-         ON blocking_locks.locktype = blocked_locks.locktype
-         AND blocking_locks.database IS NOT DISTINCT FROM blocked_locks.database
-         AND blocking_locks.relation IS NOT DISTINCT FROM blocked_locks.relation
-         AND blocking_locks.page IS NOT DISTINCT FROM blocked_locks.page
-         AND blocking_locks.tuple IS NOT DISTINCT FROM blocked_locks.tuple
-         AND blocking_locks.virtualxid IS NOT DISTINCT FROM blocked_locks.virtualxid
-         AND blocking_locks.transactionid IS NOT DISTINCT FROM blocked_locks.transactionid
-         AND blocking_locks.classid IS NOT DISTINCT FROM blocked_locks.classid
-         AND blocking_locks.objid IS NOT DISTINCT FROM blocked_locks.objid
-         AND blocking_locks.objsubid IS NOT DISTINCT FROM blocked_locks.objsubid
-         AND blocking_locks.pid != blocked_locks.pid
-       JOIN pg_catalog.pg_stat_activity blocking_activity ON blocking_activity.pid = blocking_locks.pid
-       WHERE NOT blocked_locks.granted
+        SELECT count(*) AS total
+        FROM pg_catalog.pg_locks blocked_locks
+        JOIN pg_catalog.pg_locks blocking_locks
+          ON blocking_locks.locktype = blocked_locks.locktype
+          AND blocking_locks.database IS NOT DISTINCT FROM blocked_locks.database
+          AND blocking_locks.relation IS NOT DISTINCT FROM blocked_locks.relation
+          AND blocking_locks.page IS NOT DISTINCT FROM blocked_locks.page
+          AND blocking_locks.tuple IS NOT DISTINCT FROM blocked_locks.tuple
+          AND blocking_locks.virtualxid IS NOT DISTINCT FROM blocked_locks.virtualxid
+          AND blocking_locks.transactionid IS NOT DISTINCT FROM blocked_locks.transactionid
+          AND blocking_locks.classid IS NOT DISTINCT FROM blocked_locks.classid
+          AND blocking_locks.objid IS NOT DISTINCT FROM blocked_locks.objid
+          AND blocking_locks.objsubid IS NOT DISTINCT FROM blocked_locks.objsubid
+          AND blocking_locks.pid != blocked_locks.pid
+        JOIN pg_catalog.pg_stat_activity blocking_activity ON blocking_activity.pid = blocking_locks.pid
+        WHERE NOT blocked_locks.granted
       metrics:
         - total:
             usage: "GAUGE"
@@ -309,16 +309,17 @@ monitoringQueriesConfigMap:
             description: "Time at which postgres started (based on epoch)"
 
     pg_replication:
-      query: "SELECT CASE WHEN (
-                NOT pg_catalog.pg_is_in_recovery()
-                OR pg_catalog.pg_last_wal_receive_lsn() = pg_catalog.pg_last_wal_replay_lsn())
-              THEN 0
-              ELSE GREATEST (0,
-                EXTRACT(EPOCH FROM (now() - pg_catalog.pg_last_xact_replay_timestamp())))
-              END AS lag,
-              pg_catalog.pg_is_in_recovery() AS in_recovery,
-              EXISTS (TABLE pg_stat_wal_receiver) AS is_wal_receiver_up,
-              (SELECT count(*) FROM pg_catalog.pg_stat_replication) AS streaming_replicas"
+      query: |
+        SELECT CASE WHEN (
+            NOT pg_catalog.pg_is_in_recovery()
+            OR pg_catalog.pg_last_wal_receive_lsn() = pg_catalog.pg_last_wal_replay_lsn())
+          THEN 0
+          ELSE GREATEST (0,
+            EXTRACT(EPOCH FROM (now() - pg_catalog.pg_last_xact_replay_timestamp())))
+          END AS lag,
+          pg_catalog.pg_is_in_recovery() AS in_recovery,
+          EXISTS (TABLE pg_stat_wal_receiver) AS is_wal_receiver_up,
+          (SELECT count(*) FROM pg_catalog.pg_stat_replication) AS streaming_replicas
       metrics:
         - lag:
             usage: "GAUGE"
@@ -586,20 +587,20 @@ monitoringQueriesConfigMap:
     pg_stat_replication:
       primary: true
       query: |
-       SELECT usename
-         , COALESCE(application_name, '') AS application_name
-         , COALESCE(client_addr::text, '') AS client_addr
-         , COALESCE(client_port::text, '') AS client_port
-         , EXTRACT(EPOCH FROM backend_start) AS backend_start
-         , COALESCE(pg_catalog.age(backend_xmin), 0) AS backend_xmin_age
-         , pg_catalog.pg_wal_lsn_diff(pg_catalog.pg_current_wal_lsn(), sent_lsn) AS sent_diff_bytes
-         , pg_catalog.pg_wal_lsn_diff(pg_catalog.pg_current_wal_lsn(), write_lsn) AS write_diff_bytes
-         , pg_catalog.pg_wal_lsn_diff(pg_catalog.pg_current_wal_lsn(), flush_lsn) AS flush_diff_bytes
-         , COALESCE(pg_catalog.pg_wal_lsn_diff(pg_catalog.pg_current_wal_lsn(), replay_lsn),0) AS replay_diff_bytes
-         , COALESCE((EXTRACT(EPOCH FROM write_lag)),0)::float AS write_lag_seconds
-         , COALESCE((EXTRACT(EPOCH FROM flush_lag)),0)::float AS flush_lag_seconds
-         , COALESCE((EXTRACT(EPOCH FROM replay_lag)),0)::float AS replay_lag_seconds
-       FROM pg_catalog.pg_stat_replication
+        SELECT usename
+          , COALESCE(application_name, '') AS application_name
+          , COALESCE(client_addr::text, '') AS client_addr
+          , COALESCE(client_port::text, '') AS client_port
+          , EXTRACT(EPOCH FROM backend_start) AS backend_start
+          , COALESCE(pg_catalog.age(backend_xmin), 0) AS backend_xmin_age
+          , pg_catalog.pg_wal_lsn_diff(pg_catalog.pg_current_wal_lsn(), sent_lsn) AS sent_diff_bytes
+          , pg_catalog.pg_wal_lsn_diff(pg_catalog.pg_current_wal_lsn(), write_lsn) AS write_diff_bytes
+          , pg_catalog.pg_wal_lsn_diff(pg_catalog.pg_current_wal_lsn(), flush_lsn) AS flush_diff_bytes
+          , COALESCE(pg_catalog.pg_wal_lsn_diff(pg_catalog.pg_current_wal_lsn(), replay_lsn),0) AS replay_diff_bytes
+          , COALESCE((EXTRACT(EPOCH FROM write_lag)),0)::float AS write_lag_seconds
+          , COALESCE((EXTRACT(EPOCH FROM flush_lag)),0)::float AS flush_lag_seconds
+          , COALESCE((EXTRACT(EPOCH FROM replay_lag)),0)::float AS replay_lag_seconds
+        FROM pg_catalog.pg_stat_replication
       metrics:
         - usename:
             usage: "LABEL"
@@ -659,13 +660,13 @@ monitoringQueriesConfigMap:
     pg_extensions:
       query: |
         SELECT
-         current_database() as datname,
-         name as extname,
-         default_version,
-         installed_version,
-         CASE
-           WHEN default_version = installed_version THEN 0
-           ELSE 1
+          current_database() as datname,
+          name as extname,
+          default_version,
+          installed_version,
+          CASE
+            WHEN default_version = installed_version THEN 0
+            ELSE 1
         END AS update_available
         FROM pg_catalog.pg_available_extensions
         WHERE installed_version IS NOT NULL


### PR DESCRIPTION
Use a consistent indentation of 2 spaces for all SQL queries; inconsistent spacing is often stripped by formatters, which can introduce errors.