### PR TITLE
Add support for additionalCommandArgs and configurable secretKey fields in barmanObjectStore. (fixes #653)

### DIFF
--- a/charts/cluster/templates/_backup.tpl
+++ b/charts/cluster/templates/_backup.tpl
@@ -10,12 +10,20 @@ backup:
       encryption: {{ .Values.backups.wal.encryption }}
       {{- end }}
       maxParallel: {{ .Values.backups.wal.maxParallel }}
+      {{- if .Values.backups.wal.additionalCommandArgs }}
+      additionalCommandArgs:
+        {{- toYaml .Values.backups.wal.additionalCommandArgs | nindent 8 }}
+      {{- end }}
     data:
       compression: {{ .Values.backups.data.compression }}
       {{- if .Values.backups.data.encryption }}
       encryption: {{ .Values.backups.data.encryption }}
       {{- end }}
       jobs: {{ .Values.backups.data.jobs }}
+      {{- if .Values.backups.data.additionalCommandArgs }}
+      additionalCommandArgs:
+        {{- toYaml .Values.backups.data.additionalCommandArgs | nindent 8 }}
+      {{- end }}
 
     {{- $d := dict "chartFullname" (include "cluster.fullname" .) "scope" .Values.backups "secretPrefix" "backup" }}
     {{- include "cluster.barmanObjectStoreConfig" $d | nindent 2 }}

--- a/charts/cluster/templates/_barman_object_store.tpl
+++ b/charts/cluster/templates/_barman_object_store.tpl
@@ -28,10 +28,10 @@
   {{- else }}
     accessKeyId:
       name: {{ $secretName }}
-      key: ACCESS_KEY_ID
+      key: {{ .scope.secret.accessKeyIdField | default "ACCESS_KEY_ID" }}
     secretAccessKey:
       name: {{ $secretName }}
-      key: ACCESS_SECRET_KEY
+      key: {{ .scope.secret.secretAccessKeyField | default "ACCESS_SECRET_KEY" }}
   {{- end }}
 {{- else if eq .scope.provider "azure" }}
   {{- if empty .scope.destinationPath }}

--- a/charts/cluster/templates/backup-s3-creds.yaml
+++ b/charts/cluster/templates/backup-s3-creds.yaml
@@ -5,6 +5,6 @@ metadata:
   name: {{ default (printf "%s-backup-s3-creds" (include "cluster.fullname" .)) .Values.backups.secret.name }}
   namespace: {{ include "cluster.namespace" . }}
 data:
-  ACCESS_KEY_ID: {{ required ".Values.backups.s3.accessKey is required, but not specified." .Values.backups.s3.accessKey | b64enc | quote }}
-  ACCESS_SECRET_KEY: {{ required ".Values.backups.s3.secretKey is required, but not specified." .Values.backups.s3.secretKey | b64enc | quote }}
+  {{ .Values.backups.secret.accessKeyIdField | default "ACCESS_KEY_ID" }}: {{ required ".Values.backups.s3.accessKey is required, but not specified." .Values.backups.s3.accessKey | b64enc | quote }}
+  {{ .Values.backups.secret.secretAccessKeyField | default "ACCESS_SECRET_KEY" }}: {{ required ".Values.backups.s3.secretKey is required, but not specified." .Values.backups.s3.secretKey | b64enc | quote }}
 {{- end }}

--- a/charts/cluster/templates/recovery-s3-creds.yaml
+++ b/charts/cluster/templates/recovery-s3-creds.yaml
@@ -5,6 +5,6 @@ metadata:
   name: {{ default (printf "%s-recovery-s3-creds" (include "cluster.fullname" .)) .Values.recovery.secret.name }}
   namespace: {{ include "cluster.namespace" . }}
 data:
-  ACCESS_KEY_ID: {{ required ".Values.recovery.s3.accessKey is required, but not specified." .Values.recovery.s3.accessKey | b64enc | quote }}
-  ACCESS_SECRET_KEY: {{ required ".Values.recovery.s3.secretKey is required, but not specified." .Values.recovery.s3.secretKey | b64enc | quote }}
+  {{ .Values.recovery.secret.accessKeyIdField | default "ACCESS_KEY_ID" }}: {{ required ".Values.recovery.s3.accessKey is required, but not specified." .Values.recovery.s3.accessKey | b64enc | quote }}
+  {{ .Values.recovery.secret.secretAccessKeyField | default "ACCESS_SECRET_KEY" }}: {{ required ".Values.recovery.s3.secretKey is required, but not specified." .Values.recovery.s3.secretKey | b64enc | quote }}
 {{- end }}

--- a/charts/cluster/values.yaml
+++ b/charts/cluster/values.yaml
@@ -418,6 +418,8 @@ backups:
     create: true
     # -- Name of the backup credentials secret
     name: ""
+    accessKeyIdField: ""
+    secretAccessKeyField: ""
 
   wal:
     # -- WAL compression method. One of `` (for no compression), `gzip`, `bzip2` or `snappy`.
@@ -426,6 +428,7 @@ backups:
     encryption: AES256
     # -- Number of WAL files to be archived or restored in parallel.
     maxParallel: 1
+    additionalCommandArgs: []
   data:
     # -- Data compression method. One of `` (for no compression), `gzip`, `bzip2` or `snappy`.
     compression: gzip
@@ -433,6 +436,7 @@ backups:
     encryption: AES256
     # -- Number of data files to be archived or restored in parallel.
     jobs: 2
+    additionalCommandArgs: []
 
   scheduledBackups:
     -

--- a/charts/cluster/values.yaml
+++ b/charts/cluster/values.yaml
@@ -98,6 +98,10 @@ recovery:
     create: true
     # -- Name of the backup credentials secret
     name: ""
+    # Definable accessKeyIdField to use (Left blank defaults to ACCESS_KEY_ID)
+    accessKeyIdField: ""
+    # Definable accessKeyIdField to use (Left blank defaults to ACCESS_SECRET_KEY)
+    secretAccessKeyField: ""
 
   # See https://cloudnative-pg.io/documentation/1.22/bootstrap/#bootstrap-from-a-live-cluster-pg_basebackup
   pgBaseBackup:
@@ -418,7 +422,9 @@ backups:
     create: true
     # -- Name of the backup credentials secret
     name: ""
+    # Definable accessKeyIdField to use (Left blank defaults to ACCESS_KEY_ID)
     accessKeyIdField: ""
+    # Definable secretAccessKeyField to use (Left blank defaults to ACCESS_SECRET_KEY)
     secretAccessKeyField: ""
 
   wal:

--- a/charts/cluster/values.yaml
+++ b/charts/cluster/values.yaml
@@ -98,9 +98,9 @@ recovery:
     create: true
     # -- Name of the backup credentials secret
     name: ""
-    # Definable accessKeyIdField to use (Left blank defaults to ACCESS_KEY_ID)
+    # -- Definable accessKeyIdField to use (Left blank defaults to ACCESS_KEY_ID)
     accessKeyIdField: ""
-    # Definable accessKeyIdField to use (Left blank defaults to ACCESS_SECRET_KEY)
+    # -- Definable accessKeyIdField to use (Left blank defaults to ACCESS_SECRET_KEY)
     secretAccessKeyField: ""
 
   # See https://cloudnative-pg.io/documentation/1.22/bootstrap/#bootstrap-from-a-live-cluster-pg_basebackup
@@ -422,9 +422,9 @@ backups:
     create: true
     # -- Name of the backup credentials secret
     name: ""
-    # Definable accessKeyIdField to use (Left blank defaults to ACCESS_KEY_ID)
+    # -- Definable accessKeyIdField to use (Left blank defaults to ACCESS_KEY_ID)
     accessKeyIdField: ""
-    # Definable secretAccessKeyField to use (Left blank defaults to ACCESS_SECRET_KEY)
+    # -- Definable secretAccessKeyField to use (Left blank defaults to ACCESS_SECRET_KEY)
     secretAccessKeyField: ""
 
   wal:


### PR DESCRIPTION
  - Add accessKeyIdField and secretAccessKeyField to backups.secret for custom S3 credential key fields
  - Add additionalCommandArgs support for both wal and data sections in barmanObjectStore
  
    Fixes #653
    