### PR TITLE
feat(cloudnative-pg): add annotations to all CRDs

### DIFF
--- a/charts/cloudnative-pg/README.md
+++ b/charts/cloudnative-pg/README.md
@@ -38,6 +38,7 @@ CloudNativePG Operator Helm Chart
 | config.secret | bool | `false` | Specifies whether it should be stored in a secret, instead of a configmap. |
 | containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":10001,"runAsUser":10001,"seccompProfile":{"type":"RuntimeDefault"}}` | Container Security Context. |
 | crds.create | bool | `true` | Specifies whether the CRDs should be created when installing the chart. |
+| crds.annotations | dict | `{}` | Annotations to pass to the CRDs created. Useful e.g. for ArgoCD ServerSideApply |
 | dnsPolicy | string | `""` |  |
 | fullnameOverride | string | `""` |  |
 | hostNetwork | bool | `false` |  |

--- a/charts/cloudnative-pg/templates/crds/crds.yaml
+++ b/charts/cloudnative-pg/templates/crds/crds.yaml
@@ -5,6 +5,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
     helm.sh/resource-policy: keep
+    {{- with .Values.crds.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: backups.postgresql.cnpg.io
 spec:
   group: postgresql.cnpg.io
@@ -451,6 +454,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
     helm.sh/resource-policy: keep
+    {{- with .Values.crds.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: clusterimagecatalogs.postgresql.cnpg.io
 spec:
   group: postgresql.cnpg.io
@@ -533,6 +539,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
     helm.sh/resource-policy: keep
+    {{- with .Values.crds.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: clusters.postgresql.cnpg.io
 spec:
   group: postgresql.cnpg.io
@@ -7104,6 +7113,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
     helm.sh/resource-policy: keep
+    {{- with .Values.crds.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: databases.postgresql.cnpg.io
 spec:
   group: postgresql.cnpg.io
@@ -7477,6 +7489,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
     helm.sh/resource-policy: keep
+    {{- with .Values.crds.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: failoverquorums.postgresql.cnpg.io
 spec:
   group: postgresql.cnpg.io
@@ -7555,6 +7570,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
     helm.sh/resource-policy: keep
+    {{- with .Values.crds.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: imagecatalogs.postgresql.cnpg.io
 spec:
   group: postgresql.cnpg.io
@@ -7636,6 +7654,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
     helm.sh/resource-policy: keep
+    {{- with .Values.crds.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: poolers.postgresql.cnpg.io
 spec:
   group: postgresql.cnpg.io
@@ -16503,6 +16524,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
     helm.sh/resource-policy: keep
+    {{- with .Values.crds.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: publications.postgresql.cnpg.io
 spec:
   group: postgresql.cnpg.io
@@ -16699,6 +16723,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
     helm.sh/resource-policy: keep
+    {{- with .Values.crds.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: scheduledbackups.postgresql.cnpg.io
 spec:
   group: postgresql.cnpg.io
@@ -16891,6 +16918,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
     helm.sh/resource-policy: keep
+    {{- with .Values.crds.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: subscriptions.postgresql.cnpg.io
 spec:
   group: postgresql.cnpg.io

--- a/charts/cloudnative-pg/values.yaml
+++ b/charts/cloudnative-pg/values.yaml
@@ -45,7 +45,8 @@ updateStrategy: {}
 crds:
   # -- Specifies whether the CRDs should be created when installing the chart.
   create: true
-
+  # -- Annotations to pass to the CRDs created. Useful e.g. for ArgoCD ServerSideApply
+  annotations: {}
 # -- The webhook configuration.
 webhook:
   port: 9443


### PR DESCRIPTION
We want to be able to pass annotations to all CustomResourceDefinitions.

This is helpful in that it allows passing an annotation to ArgoCD to enable ServerSideApply:

```
crds:
  annotations:
    argocd.argoproj.io/sync-options: ServerSideApply=true
```

Fixes #656