### PR TITLE
feat(pooler): create Secret and use pooler address in JDBC URL

### DIFF
--- a/charts/cluster/templates/_bootstrap.tpl
+++ b/charts/cluster/templates/_bootstrap.tpl
@@ -10,6 +10,13 @@ bootstrap:
     {{- if .Values.cluster.initdb.owner }}
     owner: {{ tpl .Values.cluster.initdb.owner . }}
     {{- end }}
+    {{- if .Values.poolers }}
+    secret:
+      name: {{ include "cluster.fullname" . }}-pooler-{{- range .Values.poolers }}{{- if eq .name "rw" }}{{ .name }}{{- end }}{{- end }}
+    {{- else if .Values.cluster.initdb.secret }}
+    secret:
+      {{- toYaml .Values.cluster.initdb.secret | nindent 6 }}
+    {{- end }}
     {{- if or (eq .Values.type "postgis") (eq .Values.type "timescaledb") (not (empty .Values.cluster.initdb.postInitApplicationSQL)) }}
     postInitApplicationSQL:
       {{- if eq .Values.type "postgis" }}
@@ -54,6 +61,13 @@ externalClusters:
     {{- end }}
     {{- if .Values.cluster.initdb.owner }}
     owner: {{ tpl .Values.cluster.initdb.owner . }}
+    {{- end }}
+    {{- if .Values.poolers }}
+    secret:
+      name: {{ include "cluster.fullname" . }}-{{ (index .Values.poolers 0).name }}-app
+    {{- else if .Values.cluster.initdb.secret }}
+    secret:
+      {{- toYaml .Values.cluster.initdb.secret | nindent 6 }}
     {{- end }}
     import:
       source:

--- a/charts/cluster/templates/pooler-secret.yaml
+++ b/charts/cluster/templates/pooler-secret.yaml
@@ -1,0 +1,49 @@
+{{- range .Values.poolers }}
+{{/* Only create secret for 'rw' pooler */}}
+{{- if eq .name "rw" }}
+{{- $username := "app" }}
+{{- $dbname := "app" }}
+{{- if $.Values.cluster.initdb }}
+  {{- $username = $.Values.cluster.initdb.owner | $.Values.cluster.initdb.database }}
+  {{- $dbname = $.Values.cluster.initdb.database }}
+{{- end }}
+
+{{- $port := "5432" }}
+{{- $poolerName := printf "%s-pooler-%s" (include "cluster.fullname" $) .name }}
+
+{{- $host := printf "%s.%s.svc.cluster.local" $poolerName $.Release.Namespace }}
+
+{{- /* Retrieve existing secret to prevent re-creation during Helm upgrade. */}}
+{{- $secretObj := lookup "v1" "Secret" $.Release.Namespace (printf "%s-%s-app" (include "cluster.fullname" $) .name) }}
+{{- $password := "" }}
+{{- if and $secretObj $secretObj.data (index $secretObj.data "password") }}
+  {{- $password = index $secretObj.data "password" }}
+{{- else }}
+  {{- $password = randAlphaNum 64 | b64enc }}
+{{- end }}
+
+{{- $uri := printf "postgresql://%s:%s@%s:%s/%s" $username ($password | b64dec) $host $port $dbname }}
+{{- $jdbcUri := printf "jdbc:postgresql://%s:%s/%s?user=%s&password=%s" $host $port $dbname $username ($password | b64dec) }}
+{{- $pgpass := printf "%s:%s:%s:%s:%s\n" $host $port $dbname $username ($password | b64dec) }}
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "cluster.fullname" $  }}-pooler-{{ .name }}
+  namespace: {{ include "cluster.namespace" $ }}
+type: kubernetes.io/basic-auth
+data:
+  dbname: {{ $dbname | b64enc }}
+  fqdn-jdbc-uri: {{ $jdbcUri | b64enc }}
+  fqdn-uri: {{ $uri | b64enc }}
+  host: {{ $host | b64enc }}
+  jdbc-uri: {{ $jdbcUri | b64enc }}
+  password: {{ $password }}
+  pgpass: {{ $pgpass | b64enc }}
+  port: {{ $port | b64enc | quote }}
+  uri: {{ $uri | b64enc }}
+  user: {{ $username | b64enc }}
+  username: {{ $username | b64enc }}
+---
+{{- end }}
+{{- end }}

--- a/charts/cluster/templates/tests/ping.yaml
+++ b/charts/cluster/templates/tests/ping.yaml
@@ -1,3 +1,17 @@
+{{- $clusterFullname := include "cluster.fullname" . -}}
+{{- $namespace := include "cluster.namespace" . -}}
+{{- $secretName := printf "%s-app" $clusterFullname -}}
+{{- $pgService := $secretName -}}
+
+{{- if .Values.poolers }}
+  {{- range .Values.poolers }}
+    {{- if eq .name "rw" }}
+      {{- $secretName = printf "%s-pooler-%s" $clusterFullname .name -}}
+      {{- $pgService = $secretName -}}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -24,21 +38,21 @@ spec:
             - name: PGUSER
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "cluster.fullname" . }}-app
+                  name: {{ $secretName }}
                   key: username
             - name: PGPASS
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "cluster.fullname" . }}-app
+                  name: {{ $secretName }}
                   key: password
             - name: PGDBNAME
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "cluster.fullname" . }}-app
+                  name: {{ $secretName }}
                   key: dbname
                   optional: true
           args:
             - "-c"
             - >-
               apk add postgresql-client &&
-              psql "postgresql://$PGUSER:$PGPASS@{{ include "cluster.fullname" . }}-rw.{{ include "cluster.namespace" . }}.svc.cluster.local:5432/${PGDBNAME:-$PGUSER}" -c 'SELECT 1'
+              psql "postgresql://$PGUSER:$PGPASS@{{ $pgService }}.{{ $namespace }}.svc.cluster.local:5432/${PGDBNAME:-$PGUSER}" -c 'SELECT 1'


### PR DESCRIPTION
## What the Issue Is

Currently, when enabling the pooler from the Helm chart (`values.yaml`), the pooler is created successfully, but the generated Secret is **not updated** to use the pooler endpoint.

Instead, the Secret continues to expose the default PostgreSQL connection URL (`postgresql://...`) from the cluster.

This means applications cannot automatically connect via the pooler, defeating the purpose of enabling it through the chart.

This behavior has been raised in related issues:

- [cloudnative-pg/cloudnative-pg#3201](https://github.com/cloudnative-pg/cloudnative-pg/issues/3201)  
- [cloudnative-pg/cloudnative-pg#3111](https://github.com/cloudnative-pg/cloudnative-pg/issues/3111)

---

## How the Solution Works

Since handling this directly in the operator is more complex and requires deeper architectural changes, this PR provides a Helm chart level solution.

When `pooler.enabled = true` in `values.yaml`:

- A new **Secret** is generated for the pooler containing:
  - JDBC URL pointing to the pooler service  
  - username  
  - password  

- The Secret is mapped to the cluster, ensuring workloads can connect using the pooler endpoint instead of the PostgreSQL endpoint.

This approach provides a simpler and more flexible way to expose pooler connectivity without waiting for operator level changes.

---

## Current Scope

- Implemented Secret generation for a **single pooler** (e.g., `rw` pooler).  
- The generated Secret is mapped to the cluster for easy consumption by applications.  

---

## Future Improvements (possible next steps)

- Support for multiple poolers (e.g., `ro` pooler or custom poolers).  
- Configurable Secret naming convention.  
