### PR TITLE
ISSUE-668 templated clusterImageCatalogs

### DIFF
--- a/charts/cloudnative-pg/templates/ClusterImageCatalog.yaml
+++ b/charts/cloudnative-pg/templates/ClusterImageCatalog.yaml
@@ -1,0 +1,36 @@
+#
+# Copyright The CloudNativePG Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+{{- if .Values.clusterImageCatalogs }}
+{{- range $clusterImageCatalog := .Values.clusterImageCatalogs }}
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: ClusterImageCatalog
+metadata:
+  name: {{ required "Items in .Values.clusterImageCatalogs require key 'name'." $clusterImageCatalog.name }}
+  labels:
+    {{- include "cloudnative-pg.labels" $ | nindent 4 }}
+  {{- with $.Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  images:
+  {{- range $entry := required "Items in .Values.clusterImageCatalogs[] require key 'images'." $clusterImageCatalog.images }}
+  - image: {{ required "Items in .Values.clusterImageCatalogs[].images[] require key 'image'." $entry.image | quote }}
+    major: {{ required "Items in .Values.clusterImageCatalogs[].images[] require key 'major'." $entry.major }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/cloudnative-pg/values.schema.json
+++ b/charts/cloudnative-pg/values.schema.json
@@ -11,6 +11,33 @@
         "affinity": {
             "type": "object"
         },
+        "clusterImageCatalogs": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["name", "images"],
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "images": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": ["major", "image"],
+                            "properties": {
+                                "major": {
+                                    "type": "integer"
+                                },
+                                "image": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "commonAnnotations": {
             "type": "object"
         },

--- a/charts/cloudnative-pg/values.yaml
+++ b/charts/cloudnative-pg/values.yaml
@@ -176,6 +176,17 @@ tolerations: []
 # -- Affinity for the operator to be installed.
 affinity: {}
 
+# -- List of ClusterImageCatalogs to provision alongside the operator.
+# Each entry must have a `name` and a list of `images` with `image` and `major` keys.
+# @default -- `[]`
+clusterImageCatalogs: []
+  # - name: postgresql
+  #   images:
+  #     - image: ghcr.io/cloudnative-pg/postgresql:17.0
+  #       major: 17
+  #     - image: ghcr.io/cloudnative-pg/postgresql:16.4
+  #       major: 16
+
 monitoring:
 
   # -- Specifies whether the monitoring should be enabled. Requires Prometheus Operator CRDs.


### PR DESCRIPTION
## Summary

Adds support for provisioning ClusterImageCatalog resources alongside the operator via a new clusterImageCatalogs values key.

Since the operator is cluster-scoped and ClusterImageCatalog is also cluster-scoped, it makes sense to install them together in a single helm install, rather than requiring a separate kubectl apply step.

Closes #668

## Changes
- New template ClusterImageCatalog.yaml with license header, standard labels, commonAnnotations support
- Input validation via Helm required function for clear error messages
- JSON schema validation in values.schema.json
- Default clusterImageCatalogs: [] with commented example in values.yaml

## Prior art
Aware of #588 which implements the same feature. This PR builds on that approach with additional improvements:
- Apache 2.0 license header (matching all other templates)
- required validation for clear template-time error messages
- | quote on image values for YAML safety
- Strict integer type for major in the JSON schema (matching the CRD spec)
