### PR TITLE
feat(plugin-barman-cloud): add user facing roles view and edit

### DIFF
--- a/charts/plugin-barman-cloud/README.md
+++ b/charts/plugin-barman-cloud/README.md
@@ -49,6 +49,7 @@ Helm Chart for CloudNativePG's CNPG-I backup plugin using Barman Cloud
 | podSecurityContext | object | `{"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Security Context for the whole pod. |
 | priorityClassName | string | `""` | Priority indicates the importance of a Pod relative to other Pods. |
 | rbac.create | bool | `true` | Specifies whether Role and RoleBinding should be created. |
+| rbac.aggregateClusterRoles | bool | `false` | Aggregate ClusterRoles to Kubernetes default user-facing roles. Ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
 | service.ipFamilies | list | `[]` | Sets the families that should be supported and the order in which they should be applied to ClusterIP as well. Can be IPv4 and/or IPv6. |

--- a/charts/plugin-barman-cloud/templates/rbac.yaml
+++ b/charts/plugin-barman-cloud/templates/rbac.yaml
@@ -114,4 +114,52 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "plugin-barman-cloud.serviceAccountName" . }}
   namespace: {{ include "plugin-barman-cloud.namespace" . }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    {{- include "plugin-barman-cloud.labels" . | nindent 4 }}
+    {{- if .Values.rbac.aggregateClusterRoles }}
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    {{- end }}
+  name: {{ include "plugin-barman-cloud.fullname" . }}-viewer
+rules:
+- apiGroups:
+  - barmancloud.cnpg.io
+  resources:
+  - objectstores
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - barmancloud.cnpg.io
+  resources:
+  - objectstores/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    {{- include "plugin-barman-cloud.labels" . | nindent 4 }}
+    {{- if .Values.rbac.aggregateClusterRoles }}
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    {{- end }}
+  name: {{ include "plugin-barman-cloud.fullname" . }}-editor
+rules:
+- apiGroups:
+  - barmancloud.cnpg.io
+  resources:
+  - objectstores
+  verbs:
+  - create
+  - delete
+  - patch
+  - update
 {{- end }}

--- a/charts/plugin-barman-cloud/values.schema.json
+++ b/charts/plugin-barman-cloud/values.schema.json
@@ -318,6 +318,12 @@
           "required": [],
           "title": "create",
           "type": "boolean"
+        },
+        "aggregateClusterRoles": {
+          "default": false,
+          "description": "Specifies whether ClusterRoles should be aggregated to standard user roles",
+          "required": [],
+          "type": "boolean"
         }
       },
       "required": [

--- a/charts/plugin-barman-cloud/values.yaml
+++ b/charts/plugin-barman-cloud/values.yaml
@@ -92,6 +92,9 @@ serviceAccount:
 rbac:
   # -- Specifies whether Role and RoleBinding should be created.
   create: true
+  # -- Aggregate ClusterRoles to Kubernetes default user-facing roles.
+  # Ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles
+  aggregateClusterRoles: false
 
 # @schema
 # additionalProperties: true


### PR DESCRIPTION
Based on https://github.com/cloudnative-pg/plugin-barman-cloud/blob/v0.7.0/config/rbac/objectstore_viewer_role.yaml, https://github.com/cloudnative-pg/plugin-barman-cloud/blob/v0.7.0/config/rbac/objectstore_editor_role.yaml

Essentially the same as https://github.com/cloudnative-pg/charts/pull/39 but for the `ObjectStore` resource from the barman plugin