### PR TITLE
Fixed default sql query for `backend_waiting` metric.

### DIFF
--- a/charts/cloudnative-pg/values.yaml
+++ b/charts/cloudnative-pg/values.yaml
@@ -271,7 +271,7 @@ monitoringQueriesConfigMap:
          AND blocking_locks.objsubid IS NOT DISTINCT FROM blocked_locks.objsubid
          AND blocking_locks.pid != blocked_locks.pid
        JOIN pg_catalog.pg_stat_activity blocking_activity ON blocking_activity.pid = blocking_locks.pid
-       WHERE NOT blocked_locks.granted
+       WHERE NOT blocked_locks.granted AND blocking_locks.granted
       metrics:
         - total:
             usage: "GAUGE"


### PR DESCRIPTION
Fixed default sql query for `backend_waiting` metric, where multiple locks on the same row may cause spuriously high "blocked_queries".

By adding `AND blocking_locks.granted`, we only consider lock pairs where the blocking lock is granted (i.e. process is using the lock) and the blocked lock is not granted (i.e. is waiting for lock). This seems more appropriate since the dashboard displays this metric as `Blocked Queries`, whereas the original query collects all possible potential block pairs.