### PR TITLE
Fix schema validation for recovery.pgBaseBackup.secret

### DIFF
--- a/charts/cluster/values.schema.json
+++ b/charts/cluster/values.schema.json
@@ -561,7 +561,12 @@
                             "type": "string"
                         },
                         "secret": {
-                            "type": "string"
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                }
+                            }
                         },
                         "source": {
                             "type": "object",

--- a/charts/cluster/values.yaml
+++ b/charts/cluster/values.yaml
@@ -103,8 +103,10 @@ recovery:
   pgBaseBackup:
     # -- Name of the database used by the application. Default: `app`.
     database: app
-    # -- Name of the secret containing the initial credentials for the owner of the user database. If empty a new secret will be created from scratch
-    secret: ""
+    # -- The secret containing the initial credentials for the owner of the user database. If empty a new secret will be created from scratch
+    secret:
+      # -- Name of the secret used for the owner of the user database.
+      name: ""
     # -- Name of the owner of the database in the instance to be used by applications. Defaults to the value of the `database` key.
     owner: ""
     source:


### PR DESCRIPTION
We are running into the already opened issue, so I thought I could quickly fix this.

https://github.com/cloudnative-pg/charts/issues/652

## Testing

Running the following command fails with the current main, but works as expected in with this fix:

```
helm template charts/cluster --set "recovery.pgBaseBackup.secret.name=foo"
```