### PR TITLE
feat(plugin-barman-cloud): add additional annotations to service account

### DIFF
--- a/charts/plugin-barman-cloud/templates/rbac.yaml
+++ b/charts/plugin-barman-cloud/templates/rbac.yaml
@@ -23,9 +23,14 @@ kind: ServiceAccount
 metadata:
   labels:
     {{- include "plugin-barman-cloud.labels" . | nindent 4 }}
-  {{- with .Values.commonAnnotations }}
+  {{- if or .Values.serviceAccount.additionalAnnotations .Values.commonAnnotations }}
   annotations:
+  {{- with .Values.serviceAccount.additionalAnnotations }}
     {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- end }}
   name: {{ include "plugin-barman-cloud.serviceAccountName" . }}
   namespace: {{ include "plugin-barman-cloud.namespace" . }}

--- a/charts/plugin-barman-cloud/values.schema.json
+++ b/charts/plugin-barman-cloud/values.schema.json
@@ -383,6 +383,12 @@
     },
     "serviceAccount": {
       "properties": {
+        "additionalAnnotations": {
+          "additionalProperties": true,
+          "description": "Annotations to be added only to the service account.",
+          "required": [],
+          "title": "additionalAnnotations"
+        },
         "create": {
           "default": true,
           "description": "Specifies whether the service account should be created.",
@@ -455,7 +461,7 @@
     },
     "updateStrategy": {
       "additionalProperties": true,
-      "description": "Update strategy for the operator.\nref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy\nFor example:\n type: RollingUpdate\n rollingUpdate:\n   maxSurge: 25%\n   maxUnavailable: 25%\n\nWARNING: the RollingUpdate strategy is not supported by the operator yet so it can\ncurrently. only use the Recreate strategy.",
+      "description": "Update strategy for the operator.\nref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy\nFor example:\n type: RollingUpdate\n rollingUpdate:\n   maxSurge: 25%\n   maxUnavailable: 25%\n\nWARNING: the RollingUpdate strategy is not supported by the operator yet so it can\ncurrently only use the Recreate strategy.",
       "required": [],
       "title": "updateStrategy"
     }

--- a/charts/plugin-barman-cloud/values.yaml
+++ b/charts/plugin-barman-cloud/values.yaml
@@ -88,6 +88,11 @@ serviceAccount:
   # -- The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template.
   name: ""
+  # @schema
+  # additionalProperties: true
+  # @schema
+  # -- Annotations to be added only to the service account if it's created.
+  additionalAnnotations: {}
 
 rbac:
   # -- Specifies whether Role and RoleBinding should be created.


### PR DESCRIPTION
This PR adds the possibility for a user to add additional annotations to the service account if it's created from the chart.

This is especially useful when using [IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) authentication on AWS kubernetes clusters as the user can add the annotation directly in the chart's values.