### PR TITLE
test(cluster): fix monitoring test

### DIFF
--- a/charts/cluster/test/monitoring/01-monitoring_cluster-assert.yaml
+++ b/charts/cluster/test/monitoring/01-monitoring_cluster-assert.yaml
@@ -41,10 +41,7 @@ spec:
     matchLabels:
       cnpg.io/cluster: monitoring-cluster
   podMetricsEndpoints:
-    - bearerTokenSecret:
-        key: ''
-        name: ''
-      relabelings:
+    - relabelings:
         - targetLabel: environment
           replacement: test
         - targetLabel: team
@@ -66,10 +63,7 @@ spec:
     matchLabels:
       cnpg.io/poolerName: monitoring-cluster-pooler-rw
   podMetricsEndpoints:
-    - bearerTokenSecret:
-        key: ''
-        name: ''
-      relabelings:
+    - relabelings:
         - targetLabel: type
           replacement: rw
           action: replace
@@ -93,10 +87,7 @@ spec:
     matchLabels:
       cnpg.io/poolerName: monitoring-cluster-pooler-ro
   podMetricsEndpoints:
-    - bearerTokenSecret:
-        key: ''
-        name: ''
-      relabelings:
+    - relabelings:
         - targetLabel: type
           replacement: ro
           action: replace


### PR DESCRIPTION
After prometheus-operator/prometheus-operator#7975, released in prometheus-operator 0.86.0, the `bearerTokenSecret` is not present anymore in the serialized form unless explicitly set.

This patch removes that field from all the PodMonitoring asserts.