### PR TITLE
feat: support overriding test image

### DIFF
--- a/charts/cluster/templates/tests/ping.yaml
+++ b/charts/cluster/templates/tests/ping.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.test.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -16,10 +17,15 @@ spec:
         app.kubernetes.io/component: database-ping-test
     spec:
       restartPolicy: Never
+      {{- if .Values.test.securityContext }}
+      securityContext:
+        {{- .Values.test.securityContext | toYaml | nindent 8 }}
+      {{- end }}
       containers:
-        - name: alpine
-          image: alpine:3.17
-          command: [ 'sh' ]
+        - name: ping
+          image: "{{ .Values.test.image.registry }}/{{ .Values.test.image.repository }}:{{ .Values.test.image.tag }}"
+          command:
+            - {{ .Values.test.shell }}
           env:
             - name: PGUSER
               valueFrom:
@@ -42,3 +48,10 @@ spec:
             - >-
               apk add postgresql-client &&
               psql "postgresql://$PGUSER:$PGPASS@{{ include "cluster.fullname" . }}-rw.{{ include "cluster.namespace" . }}.svc.cluster.local:5432/${PGDBNAME:-$PGUSER}" -c 'SELECT 1'
+          resources:
+            {{- .Values.test.resources | toYaml | nindent 12 }}
+          {{- if .Values.test.containerSecurityContext }}
+          securityContext:
+            {{- .Values.test.containerSecurityContext | toYaml | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/charts/cluster/values.yaml
+++ b/charts/cluster/values.yaml
@@ -528,3 +528,28 @@ poolers: []
   #   # -- Custom PgBouncer deployment template.
   #   # Use to override image, specify resources, etc.
   #   template: {}
+
+# -- Define values for chart tests
+test:
+  enabled: true
+  # -- Container image for ping.yaml
+  image:
+    registry: docker.io
+    repository: alpine
+    tag: 3.17
+  shell: sh
+  # -- Resources request/limit for ping Pod
+  resources: {}
+    # limits:
+    #   cpu: 50m
+    #   memory: 32Mi
+    # requests:
+    #   cpu: 25m
+    #   memory: 16Mi
+  # -- Security context for ping Pod
+  securityContext:
+    runAsUser: 5051
+    runAsGroup: 5051
+    fsGroup: 5051
+  # -- Container security context for ping Pod
+  containerSecurityContext: null

--- a/charts/cluster/values.yaml
+++ b/charts/cluster/values.yaml
@@ -547,9 +547,6 @@ test:
     #   cpu: 25m
     #   memory: 16Mi
   # -- Security context for ping Pod
-  securityContext:
-    runAsUser: 5051
-    runAsGroup: 5051
-    fsGroup: 5051
+  securityContext: null
   # -- Container security context for ping Pod
   containerSecurityContext: null


### PR DESCRIPTION
## Description

The test resource is currently hard-coded to a specific alpine image. This image is old and contains [vulnerabilities](https://hub.docker.com/layers/library/alpine/3.17/images/sha256-920690a8d840be3c20bf5205001bc913be3a4d8c39ea191bbdaf8e187ffcb180).
Users should be able to override this image when required.

I did not change the image as that may be considered a breaking change

## Related Issue

Related: #700

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/cloudnative-pg/charts/blob/main/CONTRIBUTING.md#how-to-contribute) followed