### PR TITLE
Barman Plugin: Conditionally create self-signed Issuer based on certificate settings

### DIFF
--- a/charts/plugin-barman-cloud/templates/certificate-issuer.yaml
+++ b/charts/plugin-barman-cloud/templates/certificate-issuer.yaml
@@ -16,6 +16,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
+{{- if or .Values.certificate.createClientCertificate .Values.certificate.createServerCertificate }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Issuer
@@ -24,3 +25,4 @@ metadata:
   namespace: {{ include "plugin-barman-cloud.namespace" . }}
 spec:
   selfSigned: {}
+{{- end }}

--- a/charts/plugin-barman-cloud/templates/deployment.yaml
+++ b/charts/plugin-barman-cloud/templates/deployment.yaml
@@ -79,11 +79,17 @@ spec:
           {{- toYaml .Values.resources | nindent 10 }}
         securityContext:
           {{- toYaml .Values.containerSecurityContext | nindent 10 }}
+        {{- if or .Values.certificate.createClientCertificate .Values.certificate.createServerCertificate }}
         volumeMounts:
+        {{- if .Values.certificate.createServerCertificate }}
         - mountPath: /server
           name: server
+        {{- end }}
+        {{- if .Values.certificate.createClientCertificate }}
         - mountPath: /client
           name: client
+        {{- end }}
+        {{- end }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
@@ -106,10 +112,16 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if or .Values.certificate.createClientCertificate .Values.certificate.createServerCertificate }}
       volumes:
+      {{- if .Values.certificate.createServerCertificate }}
       - name: server
         secret:
           secretName: barman-cloud-server-tls
+      {{- end }}
+      {{- if .Values.certificate.createClientCertificate }}
       - name: client
         secret:
           secretName: barman-cloud-client-tls
+      {{- end }}
+      {{- end }}


### PR DESCRIPTION
Update on Helm template for the Issuer resource so it is created only when certificate generation is explicitly enabled. This caused unnecessary issuer creation even when no client or server certificates were required.