### PR TITLE
feat: Add namespaced deployment to helm chart

### DIFF
--- a/charts/cloudnative-pg/README.md
+++ b/charts/cloudnative-pg/README.md
@@ -31,6 +31,7 @@ CloudNativePG Operator Helm Chart
 | affinity | object | `{}` | Affinity for the operator to be installed. |
 | commonAnnotations | object | `{}` | Annotations to be added to all other resources. |
 | config.clusterWide | bool | `true` | This option determines if the operator is responsible for observing events across the entire Kubernetes cluster or if its focus should be narrowed down to the specific namespace within which it has been deployed. |
+| config.namespaced | bool | `false` | When true, limits the operator to not access any `Nodes` or `ClusterImageCatalog` resources. The rbac policy will not include any ClusterRole and it will install the operator in namespaced deployment. See see https://cloudnative-pg.io/documentation/current/operator_conf/#available-options for more details on namespaced deployment. |
 | config.create | bool | `true` | Specifies whether the secret should be created. |
 | config.data | object | `{}` | The content of the configmap/secret, see https://cloudnative-pg.io/documentation/current/operator_conf/#available-options for all the available options. |
 | config.maxConcurrentReconciles | int | `10` | The maximum number of concurrent reconciles. Defaults to 10. |

--- a/charts/cloudnative-pg/templates/_helpers.tpl
+++ b/charts/cloudnative-pg/templates/_helpers.tpl
@@ -310,3 +310,13 @@ Define the set of rules that must be applied clusterwide
   - list
   - watch
 {{- end }}
+
+{{/*
+Validate configuration compatibility and return namespaced value
+*/}}
+{{- define "cloudnative-pg.validateNamespaced" -}}
+{{- if and .Values.config.namespaced .Values.config.clusterWide -}}
+{{- fail "config.namespaced and config.clusterWide cannot both be true. When config.namespaced is true, config.clusterWide must be false." -}}
+{{- end -}}
+{{- .Values.config.namespaced -}}
+{{- end -}}

--- a/charts/cloudnative-pg/templates/deployment.yaml
+++ b/charts/cloudnative-pg/templates/deployment.yaml
@@ -87,6 +87,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: NAMESPACED
+          value: {{ include "cloudnative-pg.validateNamespaced" . }}
         - name: MONITORING_QUERIES_CONFIGMAP
           value: "{{ .Values.monitoringQueriesConfigMap.name }}"
         {{- if not .Values.config.clusterWide }}

--- a/charts/cloudnative-pg/templates/rbac.yaml
+++ b/charts/cloudnative-pg/templates/rbac.yaml
@@ -32,6 +32,7 @@ metadata:
 {{- end }}
 
 {{- if .Values.rbac.create }}
+{{- if not .Values.config.namespaced }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -77,6 +78,7 @@ we create a Role with the common rules for the operator,
 and a RoleBinding. We already created the ClusterRole above with the
 required cluster-wide rules
 */}}
+{{- end }}
 {{- if eq .Values.config.clusterWide false }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/cloudnative-pg/values.schema.json
+++ b/charts/cloudnative-pg/values.schema.json
@@ -20,6 +20,9 @@
                 "clusterWide": {
                     "type": "boolean"
                 },
+                "namespaced": {
+                    "type": "boolean"
+                },
                 "create": {
                     "type": "boolean"
                 },

--- a/charts/cloudnative-pg/values.yaml
+++ b/charts/cloudnative-pg/values.yaml
@@ -78,6 +78,9 @@ config:
   # events across the entire Kubernetes cluster or if its focus should be
   # narrowed down to the specific namespace within which it has been deployed.
   clusterWide: true
+  # -- This option makes the dependency on nodes and clusterImageCatalog optional.
+  # can only be configured with config.clusterWide set to false.
+  namespaced: false
   # -- The content of the configmap/secret, see
   # https://cloudnative-pg.io/documentation/current/operator_conf/#available-options
   # for all the available options.


### PR DESCRIPTION
Add helm chart related changes for the namespaced deployment If one wants to use the namespaced deployment it is possible to deploy the operator setting config.namespaced=true and config.clusterwide=false. If clusterwide is true and namespaced true, rendering will fail. Add short documentation reference to CNPG documentation. 

This commit makes the helm chart packaged rbac settings compliant with the intended behavior of a namespaced deployment described in feature request [#9346 of CNPG ](https://github.com/cloudnative-pg/cloudnative-pg/issues/9346)

