### PR TITLE
fix(ci): use PAT instead of GITHUB_TOKEN in release-pr workflow

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Create Pull Request
         id: create-pr
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.REPO_GHA_PAT }}
         run: |
           TAG="${GITHUB_REF##*/}"
           TITLE="Release ${TAG}"


### PR DESCRIPTION
PRs created with GITHUB_TOKEN don't trigger other workflows. Using
REPO_GHA_PAT instead allows the continuous-delivery and lint workflows
to run properly on release PRs.