### PR TITLE
fix(metrics): make port configurable

### DIFF
--- a/charts/cloudnative-pg/README.md
+++ b/charts/cloudnative-pg/README.md
@@ -41,6 +41,7 @@ CloudNativePG Operator Helm Chart
 | dnsPolicy | string | `""` |  |
 | fullnameOverride | string | `""` |  |
 | hostNetwork | bool | `false` |  |
+| metrics.port | int | `8080` | Port used by the controller to expose Prometheus metrics. Useful when running with hostNetwork=true to avoid conflicts. |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"ghcr.io/cloudnative-pg/cloudnative-pg"` |  |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |

--- a/charts/cloudnative-pg/templates/deployment.yaml
+++ b/charts/cloudnative-pg/templates/deployment.yaml
@@ -75,6 +75,7 @@ spec:
         {{- end }}
         {{- end }}
         - --webhook-port={{ .Values.webhook.port }}
+        - "--metrics-bind-address=:{{ .Values.metrics.port }}"
         {{- range .Values.additionalArgs }}
         - {{ . }}
         {{- end }}
@@ -108,7 +109,7 @@ spec:
           {{- end }}
         name: manager
         ports:
-        - containerPort: 8080
+        - containerPort: {{ .Values.metrics.port }}
           name: metrics
           protocol: TCP
         - containerPort: {{ .Values.webhook.port }}

--- a/charts/cloudnative-pg/templates/service.yaml
+++ b/charts/cloudnative-pg/templates/service.yaml
@@ -40,5 +40,8 @@ spec:
   - port: {{ .Values.service.port }}
     targetPort: webhook-server
     name: webhook-server
+  - port: {{ .Values.metrics.port }}
+    targetPort: metrics
+    name: metrics
   selector:
     {{- include "cloudnative-pg.selectorLabels" . | nindent 4 }}

--- a/charts/cloudnative-pg/values.yaml
+++ b/charts/cloudnative-pg/values.yaml
@@ -66,6 +66,12 @@ webhook:
     failureThreshold: 6
     periodSeconds: 5
 
+# Metrics configuration for the operator
+metrics:
+  # -- Port used by the controller to expose Prometheus metrics.
+  # Useful when running with hostNetwork=true to avoid conflicts.
+  port: 8080
+
 # Operator configuration.
 config:
   # -- Specifies whether the secret should be created.


### PR DESCRIPTION
This change makes the Prometheus metrics port configurable in the cloudnative-pg Helm chart (instead of being hardcoded to 8080).