### PR TITLE
feat: allow specification of revisionHistoryLimit on certificates

### DIFF
--- a/charts/plugin-barman-cloud/README.md
+++ b/charts/plugin-barman-cloud/README.md
@@ -30,6 +30,7 @@ Helm Chart for CloudNativePG's CNPG-I backup plugin using Barman Cloud
 | certificate.duration | string | `"2160h"` | The duration of the certificates. |
 | certificate.issuerName | string | `"selfsigned-issuer"` | The name of the issuer to use for the certificates. |
 | certificate.renewBefore | string | `"360h"` | The renew before time for the certificates. |
+| certificate.revisionHistoryLimit | int | `1` | The maximum number of CertificateRequests to retain for each certificate. |
 | commonAnnotations | object | `{}` | Annotations to be added to all other resources. |
 | containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":10001,"runAsUser":10001,"seccompProfile":{"type":"RuntimeDefault"}}` | Container Security Context. |
 | crds.create | bool | `true` | Specifies whether the CRDs should be created when installing the chart. |

--- a/charts/plugin-barman-cloud/templates/client-certificate.yaml
+++ b/charts/plugin-barman-cloud/templates/client-certificate.yaml
@@ -32,6 +32,9 @@ spec:
     kind: Issuer
     name: {{ include "plugin-barman-cloud.fullname" . }}-selfsigned-issuer
   renewBefore: {{ .Values.certificate.renewBefore | default "360h" }}
+  {{- with .Values.certificate.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ . }}
+  {{- end }}
   secretName: barman-cloud-client-tls
   usages:
     - client auth

--- a/charts/plugin-barman-cloud/templates/server-certificate.yaml
+++ b/charts/plugin-barman-cloud/templates/server-certificate.yaml
@@ -34,6 +34,9 @@ spec:
     kind: Issuer
     name: {{ include "plugin-barman-cloud.fullname" . }}-selfsigned-issuer
   renewBefore: {{ .Values.certificate.renewBefore | default "360h" }}
+  {{- with .Values.certificate.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ . }}
+  {{- end }}
   secretName: barman-cloud-server-tls
   usages:
     - server auth

--- a/charts/plugin-barman-cloud/values.schema.json
+++ b/charts/plugin-barman-cloud/values.schema.json
@@ -61,6 +61,13 @@
           "required": [],
           "title": "renewBefore",
           "type": "string"
+        },
+        "revisionHistoryLimit": {
+          "default": 1,
+          "description": "The maximum number of CertificateRequests to retain for each certificate.",
+          "required": [],
+          "title": "revisionHistoryLimit",
+          "type": "integer"
         }
       },
       "required": [
@@ -68,7 +75,8 @@
         "createServerCertificate",
         "issuerName",
         "duration",
-        "renewBefore"
+        "renewBefore",
+        "revisionHistoryLimit"
       ],
       "title": "certificate",
       "type": "object"

--- a/charts/plugin-barman-cloud/values.yaml
+++ b/charts/plugin-barman-cloud/values.yaml
@@ -195,3 +195,5 @@ certificate:
   duration: 2160h
   # -- The renew before time for the certificates.
   renewBefore: 360h
+  # -- The maximum number of CertificateRequests to retain for each certificate.
+  revisionHistoryLimit: 1


### PR DESCRIPTION
Every time cert-manager renews a certificate it creates a new `CertificateRequest` resource for that renewal and, in cert-manager versions older than 1.18.0, old `CertificateRequest` resources are never cleaned up.  Version 1.18.0 and later keeps only the latest request by default, but in order to make older cert-manager delete old requests after a renewal it is necessary to specify an explicit `revisionHistoryLimit` on the `Certificate` resource.

This change sets a default history limit of 1, matching the default in cert-manager >=1.18.0, but allows this to be overridden via chart values.

Fixes #762