### PR TITLE
feat(cloudnative-pg): add optional networkPolicy

### DIFF
--- a/charts/cloudnative-pg/templates/networkpolicy.yaml
+++ b/charts/cloudnative-pg/templates/networkpolicy.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "cloudnative-pg.fullname" . }}-network-policy
+  namespace: {{ include "cloudnative-pg.namespace" . }}
+spec:
+  egress:
+    {{- with .Values.networkPolicy.egress }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  ingress:
+    {{- with .Values.networkPolicy.ingress }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  podSelector:
+    matchLabels:
+      {{- include "cloudnative-pg.selectorLabels" . | nindent 6 }}
+  policyTypes:
+  - Egress
+  - Ingress
+{{- end }}

--- a/charts/cloudnative-pg/values.schema.json
+++ b/charts/cloudnative-pg/values.schema.json
@@ -167,6 +167,9 @@
         "namespaceOverride": {
             "type": "string"
         },
+        "networkPolicy": {
+            "type": "object"
+        },
         "nodeSelector": {
             "type": "object"
         },

--- a/charts/cloudnative-pg/values.yaml
+++ b/charts/cloudnative-pg/values.yaml
@@ -66,6 +66,34 @@ webhook:
     failureThreshold: 6
     periodSeconds: 5
 
+# Configure a networkPolicy for the operator
+networkPolicy:
+  # -- Specifies whether the networkPolicy should be created.
+  enabled: false
+  # -- The ingress traffic
+  # Should match the webhook and (optionally) metrics port
+  ingress:
+  - ports:
+    - port: 8080  # metrics port
+      protcol: TCP
+    - port: 9443  # webhook port
+      protcol: TCP
+  # -- The egress traffic
+  # This uses DNS (53/udp, 53/tcp) and the API server (80/tcp, 443/tcp, 6443/tcp)
+  # OKD and Openshift use 6443/tcp
+  egress:
+  - ports:
+    - port: 80
+      protocol: TCP
+    - port: 443
+      protocol: TCP
+    - port: 53
+      protocol: TCP
+    - port: 53
+      protocol: UDP
+    - port: 6443
+      protocol: TCP
+
 # Operator configuration.
 config:
   # -- Specifies whether the secret should be created.


### PR DESCRIPTION
This adds an optional network policy based on https://github.com/cloudnative-pg/cloudnative-pg/blob/main/docs/src/samples/networkpolicy-example.yaml