### PR TITLE
Add support for cnpg-i plugins

### DIFF
--- a/charts/cluster/templates/cluster.yaml
+++ b/charts/cluster/templates/cluster.yaml
@@ -141,6 +141,10 @@ spec:
       {{- toYaml . | nindent 6 }}
     {{ end }}
     {{- end }}
+  {{- with .Values.cluster.plugins }}
+  plugins:
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
   {{ include "cluster.bootstrap" . | nindent 2 }}
   {{ include "cluster.externalClusters" . | nindent 2 }}
   {{ include "cluster.backup" . | nindent 2 }}

--- a/charts/cluster/values.schema.json
+++ b/charts/cluster/values.schema.json
@@ -220,6 +220,9 @@
                 "logLevel": {
                     "type": "string"
                 },
+                "plugins": {
+                    "type": "array"
+                },
                 "monitoring": {
                     "type": "object",
                     "properties": {

--- a/charts/cluster/values.yaml
+++ b/charts/cluster/values.yaml
@@ -303,6 +303,9 @@ cluster:
     #     - pg_monitor
     #     - pg_signal_backend
 
+  # -- List of CNPG-I plugins
+  plugins: []
+
   monitoring:
     # -- Whether to enable monitoring
     enabled: false


### PR DESCRIPTION
The chart should support the barman-cloud plugin, if the built-in barman support is being removed soon.