### PR TITLE
fix: plugin-barman-cloud port for readiness probe

### DIFF
--- a/charts/plugin-barman-cloud/Chart.yaml
+++ b/charts/plugin-barman-cloud/Chart.yaml
@@ -22,7 +22,7 @@ description: Helm Chart for CloudNativePG's CNPG-I backup plugin using Barman Cl
 kubeVersion: ">=1.29.0-0"
 icon: https://raw.githubusercontent.com/cloudnative-pg/artwork/main/cloudnativepg-logo.svg
 type: application
-version: "0.7.0"
+version: "0.7.1"
 appVersion: "v0.13.0"
 sources:
   - https://github.com/cloudnative-pg/plugin-barman-cloud

--- a/charts/plugin-barman-cloud/Chart.yaml
+++ b/charts/plugin-barman-cloud/Chart.yaml
@@ -22,7 +22,7 @@ description: Helm Chart for CloudNativePG's CNPG-I backup plugin using Barman Cl
 kubeVersion: ">=1.29.0-0"
 icon: https://raw.githubusercontent.com/cloudnative-pg/artwork/main/cloudnativepg-logo.svg
 type: application
-version: "0.7.1"
+version: "0.7.0"
 appVersion: "v0.13.0"
 sources:
   - https://github.com/cloudnative-pg/plugin-barman-cloud

--- a/charts/plugin-barman-cloud/templates/deployment.yaml
+++ b/charts/plugin-barman-cloud/templates/deployment.yaml
@@ -79,6 +79,11 @@ spec:
           periodSeconds: 10
           tcpSocket:
             port: 9090
+        livenessProbe:
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          tcpSocket:
+            port: 9090
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
         securityContext:

--- a/charts/plugin-barman-cloud/templates/deployment.yaml
+++ b/charts/plugin-barman-cloud/templates/deployment.yaml
@@ -78,12 +78,12 @@ spec:
           initialDelaySeconds: 10
           periodSeconds: 10
           tcpSocket:
-            port: 9090
+            port: 8081
         livenessProbe:
           initialDelaySeconds: 10
           periodSeconds: 10
           tcpSocket:
-            port: 9090
+            port: 8081
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
         securityContext:

--- a/charts/plugin-barman-cloud/test/simple-deployment/01-simple_deployment-assert.yaml
+++ b/charts/plugin-barman-cloud/test/simple-deployment/01-simple_deployment-assert.yaml
@@ -23,7 +23,12 @@ spec:
           initialDelaySeconds: 10
           periodSeconds: 10
           tcpSocket:
-            port: 9090
+            port: 8081
+        livenessProbe:
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          tcpSocket:
+            port: 8081
         resources:
           limits:
             cpu: 100m


### PR DESCRIPTION
## Description

At the moment the port `9090` is used for the readiness probe which is the application port which only get opened / used by the leader. For an HA setup with multiple pods this fails because none leaders only open the health/metrics port `8081`.

Fixes #710