### PR TITLE
chore(cloudnative-pg): Add hostUsers flag

### DIFF
--- a/charts/cloudnative-pg/templates/deployment.yaml
+++ b/charts/cloudnative-pg/templates/deployment.yaml
@@ -59,6 +59,9 @@ spec:
       {{- if .Values.hostNetwork }}
       hostNetwork: {{ .Values.hostNetwork }}
       {{- end }}
+      {{- if (semverCompare ">= 1.33-0" .Capabilities.KubeVersion.Version) }}
+      hostUsers: {{ .Values.hostUsers }}
+      {{- end }}
       {{- if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy }}
       {{- end }}

--- a/charts/cloudnative-pg/values.schema.json
+++ b/charts/cloudnative-pg/values.schema.json
@@ -90,6 +90,9 @@
         "hostNetwork": {
             "type": "boolean"
         },
+        "hostUsers": {
+            "type": "boolean"
+        },
         "image": {
             "type": "object",
             "properties": {

--- a/charts/cloudnative-pg/values.yaml
+++ b/charts/cloudnative-pg/values.yaml
@@ -36,6 +36,9 @@ namespaceOverride: ""
 hostNetwork: false
 dnsPolicy: ""
 
+# NOTE: if hostNetwork is true hostUsers should be too
+hostUsers: true
+
 # -- Update strategy for the operator.
 # ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
 # For example:


### PR DESCRIPTION
This PR adds a place to set hostUsers for the CNPG operator. It also includes a note that `hostNetwork:true` nearly always expects `hostUsers: true`.

Closes #761 