### PR TITLE
Customized region for S3 object storage

### DIFF
--- a/charts/cluster/templates/_barman_object_store.tpl
+++ b/charts/cluster/templates/_barman_object_store.tpl
@@ -32,6 +32,11 @@
     secretAccessKey:
       name: {{ $secretName }}
       key: ACCESS_SECRET_KEY
+    {{- if .scope.s3.region }}
+    region:
+      name: {{ $secretName }}
+      key: REGION
+    {{- end }}
   {{- end }}
 {{- else if eq .scope.provider "azure" }}
   {{- if empty .scope.destinationPath }}

--- a/charts/cluster/templates/backup-s3-creds.yaml
+++ b/charts/cluster/templates/backup-s3-creds.yaml
@@ -7,4 +7,7 @@ metadata:
 data:
   ACCESS_KEY_ID: {{ required ".Values.backups.s3.accessKey is required, but not specified." .Values.backups.s3.accessKey | b64enc | quote }}
   ACCESS_SECRET_KEY: {{ required ".Values.backups.s3.secretKey is required, but not specified." .Values.backups.s3.secretKey | b64enc | quote }}
+  {{- if .Values.backups.s3.region }}
+  REGION: {{ .Values.backups.s3.region | b64enc | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/cluster/templates/origin-s3-creds.yaml
+++ b/charts/cluster/templates/origin-s3-creds.yaml
@@ -7,4 +7,7 @@ metadata:
 data:
   ACCESS_KEY_ID: {{ required ".Values.replica.origin.objectStore.s3.accessKey is required, but not specified." .Values.replica.origin.objectStore.s3.accessKey | b64enc | quote }}
   ACCESS_SECRET_KEY: {{ required ".Values.replica.origin.objectStore.s3.secretKey is required, but not specified." .Values.replica.origin.objectStore.s3.secretKey | b64enc | quote }}
+  {{- if .Values.replica.origin.objectStore.s3.region }}
+  REGION: {{ .Values.replica.origin.objectStore.s3.region | b64enc | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/cluster/templates/recovery-s3-creds.yaml
+++ b/charts/cluster/templates/recovery-s3-creds.yaml
@@ -7,4 +7,7 @@ metadata:
 data:
   ACCESS_KEY_ID: {{ required ".Values.recovery.s3.accessKey is required, but not specified." .Values.recovery.s3.accessKey | b64enc | quote }}
   ACCESS_SECRET_KEY: {{ required ".Values.recovery.s3.secretKey is required, but not specified." .Values.recovery.s3.secretKey | b64enc | quote }}
+  {{- if .Values.recovery.s3.region }}
+  REGION: {{ .Values.recovery.s3.region | b64enc | quote }}
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
Some time the S3 region property must be explicitly configured. There is similar [PR](https://github.com/cloudnative-pg/charts/pull/758/files) with region configuration. Actually, I'm not sure if region parameter should be explicitly required