### PR TITLE
feat(cluster): Support additional Pooler configuration fields

### DIFF
--- a/charts/cluster/templates/pooler.yaml
+++ b/charts/cluster/templates/pooler.yaml
@@ -62,4 +62,8 @@ spec:
   template:
     {{- . | toYaml | nindent 4 }}
   {{- end }}
+  {{- with .serviceTemplate }}
+  serviceTemplate:
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
Fixes #785 

* Support setting the `pooler.spec.pgbouncer` TLS configuration fields.
* Support setting the `pooler.serviceTemplate` field to override the Service configuration for the pooler.

Combining these options allows the chart to deploy a Pooler with a LoadBalancer service, using a TLS certificate that will be valid for clients connecting from outside of the kubernetes cluster.

Example:
```
poolers:
  - name: external
    type: rw
    poolMode: session
    instances: 1
    clientTLSSecret:
      name: letsencrypt-testdb
    serviceTemplate:
      spec:
        type: LoadBalancer
        loadBalancerIP: .........
```

The other client/service TLS/CA secret fields are added to the template for completeness.