### PR TITLE
chore( cluster): Longer test asserts

### DIFF
--- a/charts/cluster/test/console-statefulset/chainsaw-test.yaml
+++ b/charts/cluster/test/console-statefulset/chainsaw-test.yaml
@@ -9,7 +9,7 @@ spec:
     apply: 1s
     assert: 10s
     cleanup: 1m
-    exec: 2m
+    exec: 5m
   steps:
     - name: Install a cluster with a console enabled
       try:

--- a/charts/cluster/test/postgresql-pg_basebackup/chainsaw-test.yaml
+++ b/charts/cluster/test/postgresql-pg_basebackup/chainsaw-test.yaml
@@ -28,7 +28,7 @@ spec:
             file: ./01-data_write-assert.yaml
     - name: Install the pg_basebackup cluster
       timeouts:
-        assert: 5m
+        assert: 8m
       try:
         - script:
             content: |

--- a/charts/cluster/test/timescale-minio-backup-restore/chainsaw-test.yaml
+++ b/charts/cluster/test/timescale-minio-backup-restore/chainsaw-test.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   timeouts:
     apply: 1s
-    assert: 5m
+    assert: 8m
     cleanup: 1m
   steps:
     - name: Clear the MinIO bucket


### PR DESCRIPTION
I've caught a few tests in our fork @paradedb that fail due to timeouts. Increasing them slightly results in all tests passing consistently. Enjoy.