### PR TITLE
add custom labels and annotations for crds

### DIFF
--- a/charts/cloudnative-pg/templates/crds/crds.yaml
+++ b/charts/cloudnative-pg/templates/crds/crds.yaml
@@ -5,6 +5,13 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.0
     helm.sh/resource-policy: keep
+{{- with .Values.crds.annotations }}
+{{- toYaml . | nindent 4 }}
+{{- end }}
+{{- with .Values.crds.labels }}
+  labels:
+{{- toYaml . | nindent 4 }}
+{{- end }}
   name: backups.postgresql.cnpg.io
 spec:
   group: postgresql.cnpg.io
@@ -468,6 +475,13 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.0
     helm.sh/resource-policy: keep
+{{- with .Values.crds.annotations }}
+{{- toYaml . | nindent 4 }}
+{{- end }}
+{{- with .Values.crds.labels }}
+  labels:
+{{- toYaml . | nindent 4 }}
+{{- end }}
   name: clusterimagecatalogs.postgresql.cnpg.io
 spec:
   group: postgresql.cnpg.io
@@ -550,6 +564,13 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.0
     helm.sh/resource-policy: keep
+{{- with .Values.crds.annotations }}
+{{- toYaml . | nindent 4 }}
+{{- end }}
+{{- with .Values.crds.labels }}
+  labels:
+{{- toYaml . | nindent 4 }}
+{{- end }}
   name: clusters.postgresql.cnpg.io
 spec:
   group: postgresql.cnpg.io
@@ -7789,6 +7810,13 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.0
     helm.sh/resource-policy: keep
+{{- with .Values.crds.annotations }}
+{{- toYaml . | nindent 4 }}
+{{- end }}
+{{- with .Values.crds.labels }}
+  labels:
+{{- toYaml . | nindent 4 }}
+{{- end }}
   name: databases.postgresql.cnpg.io
 spec:
   group: postgresql.cnpg.io
@@ -8384,6 +8412,13 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.0
     helm.sh/resource-policy: keep
+{{- with .Values.crds.annotations }}
+{{- toYaml . | nindent 4 }}
+{{- end }}
+{{- with .Values.crds.labels }}
+  labels:
+{{- toYaml . | nindent 4 }}
+{{- end }}
   name: failoverquorums.postgresql.cnpg.io
 spec:
   group: postgresql.cnpg.io
@@ -8462,6 +8497,13 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.0
     helm.sh/resource-policy: keep
+{{- with .Values.crds.annotations }}
+{{- toYaml . | nindent 4 }}
+{{- end }}
+{{- with .Values.crds.labels }}
+  labels:
+{{- toYaml . | nindent 4 }}
+{{- end }}
   name: imagecatalogs.postgresql.cnpg.io
 spec:
   group: postgresql.cnpg.io
@@ -8543,6 +8585,13 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.0
     helm.sh/resource-policy: keep
+{{- with .Values.crds.annotations }}
+{{- toYaml . | nindent 4 }}
+{{- end }}
+{{- with .Values.crds.labels }}
+  labels:
+{{- toYaml . | nindent 4 }}
+{{- end }}
   name: poolers.postgresql.cnpg.io
 spec:
   group: postgresql.cnpg.io
@@ -17912,6 +17961,13 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.0
     helm.sh/resource-policy: keep
+{{- with .Values.crds.annotations }}
+{{- toYaml . | nindent 4 }}
+{{- end }}
+{{- with .Values.crds.labels }}
+  labels:
+{{- toYaml . | nindent 4 }}
+{{- end }}
   name: publications.postgresql.cnpg.io
 spec:
   group: postgresql.cnpg.io
@@ -18108,6 +18164,13 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.0
     helm.sh/resource-policy: keep
+{{- with .Values.crds.annotations }}
+{{- toYaml . | nindent 4 }}
+{{- end }}
+{{- with .Values.crds.labels }}
+  labels:
+{{- toYaml . | nindent 4 }}
+{{- end }}
   name: scheduledbackups.postgresql.cnpg.io
 spec:
   group: postgresql.cnpg.io
@@ -18300,6 +18363,13 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.0
     helm.sh/resource-policy: keep
+{{- with .Values.crds.annotations }}
+{{- toYaml . | nindent 4 }}
+{{- end }}
+{{- with .Values.crds.labels }}
+  labels:
+{{- toYaml . | nindent 4 }}
+{{- end }}
   name: subscriptions.postgresql.cnpg.io
 spec:
   group: postgresql.cnpg.io

--- a/charts/cloudnative-pg/values.schema.json
+++ b/charts/cloudnative-pg/values.schema.json
@@ -78,6 +78,12 @@
             "properties": {
                 "create": {
                     "type": "boolean"
+                },
+                "labels": {
+                    "type": "object"
+                },
+                "annotations": {
+                    "type": "object"
                 }
             }
         },

--- a/charts/cloudnative-pg/values.yaml
+++ b/charts/cloudnative-pg/values.yaml
@@ -48,6 +48,12 @@ updateStrategy: {}
 crds:
   # -- Specifies whether the CRDs should be created when installing the chart.
   create: true
+  # -- Labels to be added to the CRDs.
+  labels: {}
+  # -- Annotations to be added to the CRDs.
+  # Useful for ArgoCD to enable server-side apply for CRDs managed by ArgoCD.
+  annotations: {}
+  # argocd.argoproj.io/sync-options: ServerSideApply=true
 
 # -- The webhook configuration.
 webhook:
@@ -200,7 +206,9 @@ monitoring:
     # -- Labels that ConfigMaps should have to get configured in Grafana.
     labels: {}
     # -- Annotations that ConfigMaps can have to get configured in Grafana.
+    # Useful for ArgoCD server-side apply
     annotations: {}
+    # argocd.argoproj.io/sync-options: ServerSideApply=true
 
 # Default monitoring queries
 monitoringQueriesConfigMap:


### PR DESCRIPTION
## Add custom labels and annotations support for CRDs

### Summary
This PR adds the ability to configure custom labels and annotations for CloudNativePG CRDs through Helm values. This enhancement is particularly useful for ArgoCD users who need to enable server-side apply for CRDs managed by ArgoCD.

### Changes
- Added `crds.labels` and `crds.annotations` configuration options in `values.yaml`
- Updated `values.schema.json` to include validation for the new fields
- Modified CRD templates to apply custom labels and annotations to all CRDs:
  - `backups.postgresql.cnpg.io`
  - `clusterimagecatalogs.postgresql.cnpg.io`
  - `clusters.postgresql.cnpg.io`
  - `databases.postgresql.cnpg.io`
  - `failoverquorums.postgresql.cnpg.io`
  - `imagecatalogs.postgresql.cnpg.io`
  - `poolers.postgresql.cnpg.io`

### Use Case
This feature enables ArgoCD users to add annotations like `argocd.argoproj.io/sync-options: ServerSideApply=true` to CRDs, which is required for proper CRD management in ArgoCD environments.

### Example Usage
```yaml
crds:
  create: true
  labels:
    app.kubernetes.io/managed-by: argocd
  annotations:
    argocd.argoproj.io/sync-options: ServerSideApply=true
```

### Tests
This commit locally tested in k3d+argocd