### PR TITLE
feat(cluster): Adding topologySpreadConstraints support to the cluster

### DIFF
--- a/charts/cluster/README.md
+++ b/charts/cluster/README.md
@@ -151,6 +151,7 @@ refer to  the [CloudNativePG Documentation](https://cloudnative-pg.io/documentat
 | backups.wal.maxParallel | int | `1` | Number of WAL files to be archived or restored in parallel. |
 | cluster.additionalLabels | object | `{}` |  |
 | cluster.affinity | object | `{"topologyKey":"topology.kubernetes.io/zone"}` | Affinity/Anti-affinity rules for Pods. See: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-AffinityConfiguration |
+| cluster.topologySpreadConstraints | list | `[]` | TopologySpreadConstraints rules for the cluster. See: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#ClusterSpec |
 | cluster.annotations | object | `{}` |  |
 | cluster.certificates | object | `{}` | The configuration for the CA and related certificates. See: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-CertificatesConfiguration |
 | cluster.console.enabled | bool | `false` | Deploys a console StatefulSet to run long-running commands against the cluster (e.g. `CREATE INDEX`). |

--- a/charts/cluster/templates/cluster.yaml
+++ b/charts/cluster/templates/cluster.yaml
@@ -42,6 +42,10 @@ spec:
   affinity:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.cluster.topologySpreadConstraints }}
+  topologySpreadConstraints:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.cluster.env }}
   env:
     {{- toYaml . | nindent 4 }}

--- a/charts/cluster/values.schema.json
+++ b/charts/cluster/values.schema.json
@@ -181,6 +181,65 @@
                         }
                     }
                 },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "maxSkew": {
+                                "type": "integer"
+                            },
+                            "minDomains": {
+                                "type": "integer"
+                            },
+                            "topologyKey": {
+                                "type": "string"
+                            },
+                            "whenUnsatisfiable": {
+                                "type": "string"
+                            },
+                            "labelSelector": {
+                                "type": "object",
+                                "properties": {
+                                    "matchLabels": {
+                                        "type": "object"
+                                    },
+                                    "matchExpressions": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "key": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "matchLabelKeys": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "nodeAffinityPolicy": {
+                                "type": "string",
+                                "enum": [
+                                    "Honor",
+                                    "Ignore"
+                                ]
+                            },
+                            "nodeTaintsPolicy": {
+                                "type": "string",
+                                "enum": [
+                                    "Honor",
+                                    "Ignore"
+                                ]
+                            }
+                        }
+                    }
+                },
                 "annotations": {
                     "type": "object"
                 },

--- a/charts/cluster/values.yaml
+++ b/charts/cluster/values.yaml
@@ -249,6 +249,16 @@ cluster:
   affinity:
     topologyKey: topology.kubernetes.io/zone
 
+  # -- TopologySpreadConstraints for cluster.
+  # See: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#ClusterSpec
+  topologySpreadConstraints: []
+    # - maxSkew: 1
+    #   topologyKey: topology.kubernetes.io/zone
+    #   whenUnsatisfiable: DoNotSchedule
+    #   labelSelector:
+    #     matchLabels:
+    #       cnpg.io/cluster: my-cluster
+
   # -- Env follows the Env format to pass environment variables to the pods created in the cluster
   env: []
     # - name: MY_CUSTOM_FLAG


### PR DESCRIPTION
This adds support for specifying
[`topologySpreadConstraints`](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) for the cloudnative-pg cluster.

Resolves [cloudnative-pg#817](https://github.com/cloudnative-pg/charts/issues/817)