### PR TITLE
chore: updating the prometheus rules to remove errors

### DIFF
--- a/charts/cluster/prometheus_rules/cluster-logical_replication_errors-critical.yaml
+++ b/charts/cluster/prometheus_rules/cluster-logical_replication_errors-critical.yaml
@@ -9,7 +9,7 @@ annotations:
     CRITICAL: High error rate indicates persistent replication issues requiring immediate attention. This could lead to significant data inconsistency or complete replication failure. Errors include both apply errors and sync errors. The subscription may stop working if errors continue.
   runbook_url: https://github.com/cloudnative-pg/charts/blob/main/charts/cluster/docs/runbooks/CNPGClusterLogicalReplicationErrors.md
 expr: |
-  label_replace(increase(max by (namespace, job, subname) (cnpg_pg_stat_subscription_apply_error_count + cnpg_pg_stat_subscription_sync_error_count)[5m]), "cluster", "$1", "job", ".+/(.+)") >= 5
+  label_replace(max by (namespace, job, subname) (increase(cnpg_pg_stat_subscription_apply_error_count[5m]) + increase(cnpg_pg_stat_subscription_sync_error_count[5m])), "cluster", "$1", "job", ".+/(.+)") >= 5
 for: 0m
 labels:
   severity: critical

--- a/charts/cluster/prometheus_rules/cluster-logical_replication_errors.yaml
+++ b/charts/cluster/prometheus_rules/cluster-logical_replication_errors.yaml
@@ -9,7 +9,7 @@ annotations:
     This includes both apply errors (during normal replication) and sync errors (during initial table sync). Errors indicate data consistency issues that need immediate attention to prevent data divergence.
   runbook_url: https://github.com/cloudnative-pg/charts/blob/main/charts/cluster/docs/runbooks/{{ $alert }}.md
 expr: |
-  label_replace(increase(max by (namespace, job, subname) (cnpg_pg_stat_subscription_apply_error_count + cnpg_pg_stat_subscription_sync_error_count)[5m]), "cluster", "$1", "job", ".+/(.+)") > 0
+  label_replace(max by (namespace, job, subname) (increase(cnpg_pg_stat_subscription_apply_error_count[5m]) + increase(cnpg_pg_stat_subscription_sync_error_count[5m])), "cluster", "$1", "job", ".+/(.+)") > 0
 for: 1m
 labels:
   severity: warning

--- a/charts/cluster/prometheus_rules/cluster-logical_replication_stopped-critical.yaml
+++ b/charts/cluster/prometheus_rules/cluster-logical_replication_stopped-critical.yaml
@@ -18,7 +18,7 @@ expr: |
   ) or (
     # Subscription is enabled but stuck (no worker process with significant lag)
     label_replace(max by (namespace, job, subname) (cnpg_pg_stat_subscription_enabled), "cluster", "$1", "job", ".+/(.+)") == 1
-    and label_replace(max by (namespace, job, subname) (cnpg_pg_stat_subscription_pid), "cluster", "$1", "job", ".+/(.+)") == ""
+    and label_replace(max by (namespace, job, subname) (cnpg_pg_stat_subscription_pid), "cluster", "$1", "job", ".+/(.+)") == 0
     and label_replace(max by (namespace, job, subname) (cnpg_pg_stat_subscription_buffered_lag_bytes), "cluster", "$1", "job", ".+/(.+)") / 1024^3 > 0.1
   )
 for: 15m

--- a/charts/cluster/prometheus_rules/cluster-logical_replication_stopped.yaml
+++ b/charts/cluster/prometheus_rules/cluster-logical_replication_stopped.yaml
@@ -17,7 +17,7 @@ expr: |
   ) or (
     # Subscription is enabled but stuck (no worker process with significant lag)
     label_replace(max by (namespace, job, subname) (cnpg_pg_stat_subscription_enabled), "cluster", "$1", "job", ".+/(.+)") == 1
-    and label_replace(max by (namespace, job, subname) (cnpg_pg_stat_subscription_pid), "cluster", "$1", "job", ".+/(.+)") == ""
+    and label_replace(max by (namespace, job, subname) (cnpg_pg_stat_subscription_pid), "cluster", "$1", "job", ".+/(.+)") == 0
     and label_replace(max by (namespace, job, subname) (cnpg_pg_stat_subscription_buffered_lag_bytes), "cluster", "$1", "job", ".+/(.+)") / 1024^3 > 0.1
   )
 for: 5m


### PR DESCRIPTION
The prometheus rules are causing validating errors when trying to apply them (in my case via GitOps tooling - ArgoCD). 

`one or more objects failed to apply, reason: admission webhook "prometheusrulemutate.monitoring.coreos.com" denied the request: Rules are not valid (retried 5 times).`

To check what was going on, I've templated out the helm chart and grabbed the rules from the PrometheusRule. I've then fed this into `promtool check rules` to find out why it is erroring.  

```
promtool check rules tmp.yaml
Checking tmp.yaml
  FAILED:
tmp.yaml: 180:15: group "cloudnative-pg/postgres-cluster", rule 7, "CNPGClusterLogicalReplicationErrorsCritical": could not parse expression: 1:147: parse error: ranges only allowed for vector selectors
tmp.yaml: 204:15: group "cloudnative-pg/postgres-cluster", rule 8, "CNPGClusterLogicalReplicationErrors": could not parse expression: 1:147: parse error: ranges only allowed for vector selectors
tmp.yaml: 291:15: group "cloudnative-pg/postgres-cluster", rule 11, "CNPGClusterLogicalReplicationStoppedCritical": could not parse expression: 5:125: parse error: binary expression must contain only scalar and instant vector types
tmp.yaml: 320:15: group "cloudnative-pg/postgres-cluster", rule 12, "CNPGClusterLogicalReplicationStopped": could not parse expression: 5:125: parse error: binary expression must contain only scalar and instant vector types
```

I've applied changes in the PR and now the rules are coming back clean.
```
promtool check rules tmp.yaml
Checking tmp.yaml
  SUCCESS: 18 rules found
```

Argo now syncs the rules correctly and the PrometheusRule is valid.