### PR TITLE
chore(cluster): cleanup trailing spaces and template consistency

### DIFF
--- a/charts/cluster/examples/custom-queries.yaml
+++ b/charts/cluster/examples/custom-queries.yaml
@@ -8,7 +8,7 @@ cluster:
     customQueries:
       - name: "pg_cache_hit"
         query: |
-          SELECT 
+          SELECT
             current_database() as datname,
             sum(heap_blks_hit) / (sum(heap_blks_hit) + sum(heap_blks_read)) as ratio
           FROM pg_statio_user_tables;

--- a/charts/cluster/templates/scheduled-backups.yaml
+++ b/charts/cluster/templates/scheduled-backups.yaml
@@ -5,9 +5,10 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:
-  name: {{ include "cluster.fullname" $context  }}-{{ .name }}
-  namespace: {{ include "cluster.namespace" $ }}
-  labels: {{ include "cluster.labels" $context | nindent 4 }}
+  name: {{ include "cluster.fullname" $context }}-{{ .name }}
+  namespace: {{ include "cluster.namespace" $context }}
+  labels:
+    {{- include "cluster.labels" $context | nindent 4 }}
 spec:
   immediate: true
   schedule: {{ .schedule | quote }}

--- a/charts/cluster/values.yaml
+++ b/charts/cluster/values.yaml
@@ -493,7 +493,7 @@ backups:
   retentionPolicy: "30d"
 
 replica:
-  # --  Defines the name of this cluster. It is used to determine if this is a primary or a replica cluster, comparing it with primary. Leave empty by default.
+  # -- Defines the name of this cluster. It is used to determine if this is a primary or a replica cluster, comparing it with primary. Leave empty by default.
   self: ""
   # -- Primary defines which Cluster is defined to be the primary in the distributed PostgreSQL cluster, based on the topology specified in externalClusters
   primary: ""
@@ -502,7 +502,7 @@ replica:
   # -- When replica mode is enabled, this parameter allows you to replay transactions only when the system time is at least the configured time past the commit time. This provides an opportunity to correct data loss errors. Note that when this parameter is set, a promotion token cannot be used.
   minApplyDelay: ""
   bootstrap:
-    # --  One of `object_store` or `pg_basebackup`. Method to use for bootstrap.
+    # -- One of `object_store` or `pg_basebackup`. Method to use for bootstrap.
     source: ""
     # -- Name of the database used by the application
     database: ""


### PR DESCRIPTION
I caught these while working on the @paradedb fork. Figured these changes would benefit upstream and reduce our diff:

- Trailing whitespace after `SELECT` in the custom-queries example
- Extra whitespace and inconsistent context variable (`$` vs `$context`) in `scheduled-backups.yaml`, plus `labels` not properly using `nindent`
- Double spaces after `--` in two `values.yaml` comments

Enjoy!