### PR TITLE
fix(cluster): fix alert templating and replica secret config

### DIFF
--- a/charts/cluster/prometheus_rules/cluster-logical_replication_errors-critical.yaml
+++ b/charts/cluster/prometheus_rules/cluster-logical_replication_errors-critical.yaml
@@ -4,7 +4,7 @@ alert: {{ $alert }}
 annotations:
   summary: CNPG Cluster critical logical replication errors
   description: |-
-    CloudNativePG Cluster's "{{ .namespace }}/{{ .cluster }}" "{{ "{{ .subname }}" }}" subscription has experienced {{ .value }} errors in the last 5 minutes.
+    CloudNativePG Cluster's "{{ .namespace }}/{{ .cluster }}" "{{ .labels.subname }}" subscription has experienced {{ .value }} errors in the last 5 minutes.
 
     CRITICAL: High error rate indicates persistent replication issues requiring immediate attention. This could lead to significant data inconsistency or complete replication failure. Errors include both apply errors and sync errors. The subscription may stop working if errors continue.
   runbook_url: https://github.com/cloudnative-pg/charts/blob/main/charts/cluster/docs/runbooks/CNPGClusterLogicalReplicationErrors.md

--- a/charts/cluster/prometheus_rules/cluster-logical_replication_errors.yaml
+++ b/charts/cluster/prometheus_rules/cluster-logical_replication_errors.yaml
@@ -4,7 +4,7 @@ alert: {{ $alert }}
 annotations:
   summary: CNPG Cluster logical replication errors detected
   description: |-
-    CloudNativePG Cluster's "{{ .namespace }}/{{ .cluster }}" "{{ "{{ .subname }}" }}" subscription has experienced {{ .value }} errors.
+    CloudNativePG Cluster's "{{ .namespace }}/{{ .cluster }}" "{{ .labels.subname }}" subscription has experienced {{ .value }} errors.
 
     This includes both apply errors (during normal replication) and sync errors (during initial table sync). Errors indicate data consistency issues that need immediate attention to prevent data divergence.
   runbook_url: https://github.com/cloudnative-pg/charts/blob/main/charts/cluster/docs/runbooks/{{ $alert }}.md

--- a/charts/cluster/prometheus_rules/cluster-logical_replication_lagging-critical.yaml
+++ b/charts/cluster/prometheus_rules/cluster-logical_replication_lagging-critical.yaml
@@ -4,7 +4,7 @@ alert: {{ $alert }}
 annotations:
   summary: CNPG Cluster critical logical replication lag
   description: |-
-    CloudNativePG Cluster's "{{ .namespace }}/{{ .cluster }}" "{{ "{{ .subname }}" }}" subscription is experiencing critical replication lag!
+    CloudNativePG Cluster's "{{ .namespace }}/{{ .cluster }}" "{{ .labels.subname }}" subscription is experiencing critical replication lag!
 
     {{- if .labels.lag_type }}
     Lag type: {{ .labels.lag_type }}

--- a/charts/cluster/prometheus_rules/cluster-logical_replication_lagging.yaml
+++ b/charts/cluster/prometheus_rules/cluster-logical_replication_lagging.yaml
@@ -4,7 +4,7 @@ alert: {{ $alert }}
 annotations:
   summary: CNPG Cluster logical replication lagging
   description: |-
-    CloudNativePG Cluster's "{{ .namespace }}/{{ .cluster }}" "{{ "{{ .subname }}" }}" subscription is experiencing replication lag.
+    CloudNativePG Cluster's "{{ .namespace }}/{{ .cluster }}" "{{ .labels.subname }}" subscription is experiencing replication lag.
 
     {{- if .labels.lag_type }}
     Lag type: {{ .labels.lag_type }}

--- a/charts/cluster/prometheus_rules/cluster-logical_replication_stopped-critical.yaml
+++ b/charts/cluster/prometheus_rules/cluster-logical_replication_stopped-critical.yaml
@@ -4,7 +4,7 @@ alert: {{ $alert }}
 annotations:
   summary: CNPG Cluster logical replication subscription CRITICAL
   description: |-
-    CloudNativePG Cluster's "{{ .namespace }}/{{ .cluster }}" "{{ "{{ .subname }}" }}" subscription is in a critical state.
+    CloudNativePG Cluster's "{{ .namespace }}/{{ .cluster }}" "{{ .labels.subname }}" subscription is in a critical state.
 
     CRITICAL: The subscription has been stopped for more than 15 minutes. This will lead to significant data divergence and requires immediate intervention.
 

--- a/charts/cluster/prometheus_rules/cluster-logical_replication_stopped.yaml
+++ b/charts/cluster/prometheus_rules/cluster-logical_replication_stopped.yaml
@@ -4,7 +4,7 @@ alert: {{ $alert }}
 annotations:
   summary: CNPG Cluster logical replication subscription stopped
   description: |-
-    CloudNativePG Cluster's "{{ .namespace }}/{{ .cluster }}" "{{ "{{ .subname }}" }}" subscription is stopped.
+    CloudNativePG Cluster's "{{ .namespace }}/{{ .cluster }}" "{{ .labels.subname }}" subscription is stopped.
 
     Status: {{ .labels.stop_reason }}
 

--- a/charts/cluster/templates/prometheus-rule.yaml
+++ b/charts/cluster/templates/prometheus-rule.yaml
@@ -17,7 +17,7 @@ spec:
         {{- $_ := set $dict "value"       "{{ $value }}" -}}
         {{- $_ := set $dict "namespace"   .Release.Namespace -}}
         {{- $_ := set $dict "cluster"     (include "cluster.fullname" .) -}}
-        {{- $_ := set $dict "labels"      (dict "job" "{{ $labels.job }}" "node" "{{ $labels.node }}" "pod" "{{ $labels.pod }}") -}}
+        {{- $_ := set $dict "labels"      (dict "job" "{{ $labels.job }}" "node" "{{ $labels.node }}" "pod" "{{ $labels.pod }}" "subname" "{{ $labels.subname }}" "lag_type" "{{ $labels.lag_type }}" "stop_reason" "{{ $labels.stop_reason }}") -}}
         {{- $_ := set $dict "podSelector" (printf "%s-([1-9][0-9]*)$" (include "cluster.fullname" .)) -}}
         {{- $_ := set $dict "Values"      .Values -}}
         {{- $_ := set $dict "Template"    .Template -}}

--- a/charts/cluster/values.schema.json
+++ b/charts/cluster/values.schema.json
@@ -859,10 +859,16 @@
                                 "passwordSecret": {
                                     "type": "object",
                                     "properties": {
+                                        "create": {
+                                            "type": "boolean"
+                                        },
                                         "key": {
                                             "type": "string"
                                         },
                                         "name": {
+                                            "type": "string"
+                                        },
+                                        "value": {
                                             "type": "string"
                                         }
                                     }

--- a/charts/cluster/values.schema.json
+++ b/charts/cluster/values.schema.json
@@ -1294,12 +1294,22 @@
                 },
                 "passwordSecret": {
                   "properties": {
+                    "create": {
+                      "default": false,
+                      "description": "Whether to create a secret for the password",
+                      "type": "boolean"
+                    },
                     "key": {
                       "default": "",
                       "type": "string"
                     },
                     "name": {
                       "default": "",
+                      "type": "string"
+                    },
+                    "value": {
+                      "default": "",
+                      "description": "The password value to use when creating the secret",
                       "type": "string"
                     }
                   },

--- a/charts/cluster/values.yaml
+++ b/charts/cluster/values.yaml
@@ -571,8 +571,12 @@ replica:
         name: ""
         key: ""
       passwordSecret:
+        # -- Whether to create a secret for the password
+        create: false
         name: ""
         key: ""
+        # -- The password value to use when creating the secret
+        value: ""
 ##
 # Database management configuration
 databases: []

--- a/charts/cluster/values.yaml
+++ b/charts/cluster/values.yaml
@@ -603,8 +603,12 @@ replica:
         name: ""
         key: ""
       passwordSecret:
+        # -- Whether to create a secret for the password
+        create: false
         name: ""
         key: ""
+        # -- The password value to use when creating the secret
+        value: ""
 
 # -- Database management configuration.
 databases: []


### PR DESCRIPTION
I caught these while working on the @paradedb fork. Figured these changes would benefit upstream and reduce our diff:

- Fix broken `subname` templating in all 6 logical replication alert descriptions: `{{ "{{ .subname }}" }}` renders as a literal `{{ .subname }}` string instead of the actual subscription name. Changed to `{{ .labels.subname }}` which correctly references the label value from the dict
- Add missing `subname`, `lag_type`, and `stop_reason` labels to the prometheus-rule template dict so alert descriptions can actually reference them
- Add missing `create` and `value` fields to the replica `passwordSecret` config in values.yaml and schema, matching the pattern already used by the other `externalClusters` password secrets

Enjoy!