### PR TITLE
update liveness probe path from /readyz to /healthz

### DIFF
--- a/charts/cloudnative-pg/templates/deployment.yaml
+++ b/charts/cloudnative-pg/templates/deployment.yaml
@@ -100,7 +100,7 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         livenessProbe:
           httpGet:
-            path: /readyz
+            path: /healthz
             port: webhook-server
             scheme: HTTPS
           {{- if .Values.webhook.livenessProbe.initialDelaySeconds }}


### PR DESCRIPTION
According to the [CNPG doucmention](https://cloudnative-pg.io/docs/1.28/operator_capability_levels/#customizable-startup-liveness-and-readiness-probes), it have the following:

CloudNativePG configures startup, liveness, and readiness probes for PostgreSQL containers, which are managed by the Kubernetes kubelet. These probes interact with the /startupz, /healthz, and /readyz endpoints exposed by the instance manager's web server to monitor the Pod's health and readiness.

But in the Helm chart, it's using /readyz for both liveness and readiness probes.

This PR will update liveness probe path from /readyz to /healthz

Fix: https://github.com/cloudnative-pg/charts/issues/837