### PR TITLE
chore: add kubeVersion in charts metadata

### DIFF
--- a/charts/cloudnative-pg/Chart.yaml
+++ b/charts/cloudnative-pg/Chart.yaml
@@ -19,6 +19,7 @@
 apiVersion: v2
 name: cloudnative-pg
 description: CloudNativePG Operator Helm Chart
+kubeVersion: '>= 1.29.0-0'
 icon: https://raw.githubusercontent.com/cloudnative-pg/artwork/main/cloudnativepg-logo.svg
 type: application
 version: "0.27.1"

--- a/charts/cloudnative-pg/Chart.yaml
+++ b/charts/cloudnative-pg/Chart.yaml
@@ -19,7 +19,7 @@
 apiVersion: v2
 name: cloudnative-pg
 description: CloudNativePG Operator Helm Chart
-kubeVersion: '>= 1.29.0-0'
+kubeVersion: ">=1.29.0-0"
 icon: https://raw.githubusercontent.com/cloudnative-pg/artwork/main/cloudnativepg-logo.svg
 type: application
 version: "0.27.1"

--- a/charts/cluster/Chart.yaml
+++ b/charts/cluster/Chart.yaml
@@ -19,6 +19,7 @@
 apiVersion: v2
 name: cluster
 description: Deploys and manages a CloudNativePG cluster and its associated resources.
+kubeVersion: '>= 1.29.0-0'
 icon: https://raw.githubusercontent.com/cloudnative-pg/artwork/main/cloudnativepg-logo.svg
 type: application
 version: 0.6.0

--- a/charts/cluster/Chart.yaml
+++ b/charts/cluster/Chart.yaml
@@ -19,7 +19,7 @@
 apiVersion: v2
 name: cluster
 description: Deploys and manages a CloudNativePG cluster and its associated resources.
-kubeVersion: '>= 1.29.0-0'
+kubeVersion: ">=1.29.0-0"
 icon: https://raw.githubusercontent.com/cloudnative-pg/artwork/main/cloudnativepg-logo.svg
 type: application
 version: 0.6.0

--- a/charts/plugin-barman-cloud/Chart.yaml
+++ b/charts/plugin-barman-cloud/Chart.yaml
@@ -19,6 +19,7 @@
 apiVersion: v2
 name: plugin-barman-cloud
 description: Helm Chart for CloudNativePG's CNPG-I backup plugin using Barman Cloud
+kubeVersion: '>= 1.29.0-0'
 icon: https://raw.githubusercontent.com/cloudnative-pg/artwork/main/cloudnativepg-logo.svg
 type: application
 version: "0.5.0"

--- a/charts/plugin-barman-cloud/Chart.yaml
+++ b/charts/plugin-barman-cloud/Chart.yaml
@@ -19,7 +19,7 @@
 apiVersion: v2
 name: plugin-barman-cloud
 description: Helm Chart for CloudNativePG's CNPG-I backup plugin using Barman Cloud
-kubeVersion: '>= 1.29.0-0'
+kubeVersion: ">=1.29.0-0"
 icon: https://raw.githubusercontent.com/cloudnative-pg/artwork/main/cloudnativepg-logo.svg
 type: application
 version: "0.5.0"


### PR DESCRIPTION
#843

Adding `kubeVersion: '>= 1.29.0-0'` to charts meta data.