### PR TITLE
Add support for ImageVolume extensions

### DIFF
--- a/charts/cluster/README.md
+++ b/charts/cluster/README.md
@@ -179,6 +179,7 @@ refer to the [CloudNativePG Documentation](https://cloudnative-pg.io/documentati
 | cluster.podSecurityContext | object | `{}` | Configure the Pod Security Context. See: https://cloudnative-pg.io/documentation/preview/security/ |
 | cluster.postgresGID | int | `-1` | The GID of the postgres user inside the image, defaults to 26 |
 | cluster.postgresUID | int | `-1` | The UID of the postgres user inside the image, defaults to 26 |
+| cluster.postgresql.extensions | list | `[]` | List of [image volume extensions](https://cloudnative-pg.io/docs/1.29/imagevolume_extensions/) to load in the cluster pod |
 | cluster.postgresql.ldap | object | `{}` | PostgreSQL LDAP configuration (see https://cloudnative-pg.io/documentation/current/postgresql_conf/#ldap-configuration) |
 | cluster.postgresql.parameters | object | `{}` | PostgreSQL configuration options (postgresql.conf) |
 | cluster.postgresql.pg_hba | list | `[]` | PostgreSQL Host Based Authentication rules (lines to be appended to the pg_hba.conf file) |

--- a/charts/cluster/templates/NOTES.txt
+++ b/charts/cluster/templates/NOTES.txt
@@ -2,7 +2,7 @@
   {{ fail ".Values.pooler has been deprecated. Use .Values.poolers instead." }}
 {{- end -}}
 
-{{- if gt (omit .Values.cluster.postgresql "parameters" "synchronous" "pg_hba" "pg_ident" "syncReplicaElectionConstraint" "shared_preload_libraries" "ldap" "promotionTimeout" "enableAlterSystem" | keys | len) 0 -}}
+{{- if gt (omit .Values.cluster.postgresql "parameters" "synchronous" "pg_hba" "pg_ident" "syncReplicaElectionConstraint" "shared_preload_libraries" "ldap" "promotionTimeout" "enableAlterSystem" "extensions" | keys | len) 0 -}}
   {{ fail ".Values.cluster.postgresql has been deprecated. Use .Values.cluster.postgresql.parameters instead." }}
 {{- end -}}
 

--- a/charts/cluster/templates/cluster.yaml
+++ b/charts/cluster/templates/cluster.yaml
@@ -97,6 +97,10 @@ spec:
     parameters:
       {{- toYaml . | nindent 6 }}
     {{- end }}
+    {{- with .Values.cluster.postgresql.extensions }}
+    extensions:
+      {{- toYaml . | nindent 6 }}
+    {{ end }}
 
   {{- if not (and (empty .Values.cluster.roles) (empty .Values.cluster.services)) }}
   managed:

--- a/charts/cluster/values.schema.json
+++ b/charts/cluster/values.schema.json
@@ -293,6 +293,9 @@
                 "postgresql": {
                     "type": "object",
                     "properties": {
+                        "extensions": {
+                            "type": "array"
+                        },
                         "ldap": {
                             "type": "object"
                         },

--- a/charts/cluster/values.yaml
+++ b/charts/cluster/values.yaml
@@ -367,6 +367,8 @@ cluster:
     # -- Lists of shared preload libraries to add to the default ones
     shared_preload_libraries: []
       # - pgaudit
+    # -- List of [image volume extensions](https://cloudnative-pg.io/docs/1.29/imagevolume_extensions/) to load in the cluster pod
+    extensions: []
     # -- PostgreSQL LDAP configuration (see https://cloudnative-pg.io/documentation/current/postgresql_conf/#ldap-configuration)
     ldap: {}
       # https://cloudnative-pg.io/documentation/current/postgresql_conf/#ldap-configuration


### PR DESCRIPTION
The Cluster resource defines the `.spec.postgresql.extensions` list of objects to import an extension as an [image volume](https://cloudnative-pg.io/docs/1.29/imagevolume_extensions
).

However the chart doesn't recognise this setting and throws an error if set.

Add support for the setting, which can be used for example as:

```yaml
cluster:
  postgresql:
    extensions:
      - name: pg-oidc-validator
        image:
          reference: registry.codicelieve.com/pg-oidc-validator:v0.2-pg18-trixie
          pullPolicy: IfNotPresent
```