### PR TITLE
fix(cloudnative-pg): drop stray trailing quote in pg_replication query

### DIFF
--- a/charts/cloudnative-pg/values.yaml
+++ b/charts/cloudnative-pg/values.yaml
@@ -319,7 +319,7 @@ monitoringQueriesConfigMap:
           END AS lag,
           pg_catalog.pg_is_in_recovery() AS in_recovery,
           EXISTS (TABLE pg_catalog.pg_stat_wal_receiver) AS is_wal_receiver_up,
-          (SELECT pg_catalog.count(*) FROM pg_catalog.pg_stat_replication) AS streaming_replicas"
+          (SELECT pg_catalog.count(*) FROM pg_catalog.pg_stat_replication) AS streaming_replicas
       metrics:
         - lag:
             usage: "GAUGE"


### PR DESCRIPTION
The query used to be a YAML double-quoted scalar where the closing `"` was the YAML delimiter. PR #650 reformatted it as a literal block (`query: |`) but kept the trailing `"`, which then reached PostgreSQL verbatim and produced "unterminated quoted identifier" (SQLSTATE 42601).

Closes #869
Closes cloudnative-pg/cloudnative-pg#10675