### PR TITLE
feat(cluster): Add TLS management for monitoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,11 @@ charts/**/charts/*.tgz
 .idea
 *.swp
 *.swo
+.vscode
 *~
 
 # macOS
 .DS_Store
+
+# Tooling for local development
+mise.local.toml

--- a/charts/cluster/README.md
+++ b/charts/cluster/README.md
@@ -180,6 +180,8 @@ Kubernetes: `>=1.29.0-0`
 | cluster.monitoring.podMonitor.relabelings | list | `[]` | The list of relabelings for the PodMonitor. Applied to samples before scraping. |
 | cluster.monitoring.prometheusRule.enabled | bool | `true` | Whether to enable the PrometheusRule automated alerts |
 | cluster.monitoring.prometheusRule.excludeRules | list | `[]` | Exclude specified rules |
+| cluster.monitoring.tls | object | `{"enabled":false}` | TLS usage for monitoring |
+| cluster.monitoring.tls.enabled | bool | `false` | Whether to enable TLS on the metrics port. |
 | cluster.podSecurityContext | object | `{}` | Configure the Pod Security Context. See: https://cloudnative-pg.io/documentation/preview/security/ |
 | cluster.postgresGID | int | `-1` | The GID of the postgres user inside the image, defaults to 26 |
 | cluster.postgresUID | int | `-1` | The UID of the postgres user inside the image, defaults to 26 |

--- a/charts/cluster/templates/cluster.yaml
+++ b/charts/cluster/templates/cluster.yaml
@@ -138,6 +138,8 @@ spec:
       {{- toYaml . | nindent 6 }}
     {{ end }}
     {{- end }}
+    tls:
+      enabled: {{ .Values.cluster.monitoring.tls.enabled }}
   {{ include "cluster.bootstrap" . | nindent 2 }}
   {{ include "cluster.externalClusters" . | nindent 2 }}
   {{ include "cluster.backup" . | nindent 2 }}

--- a/charts/cluster/templates/podmonitor-cluster.yaml
+++ b/charts/cluster/templates/podmonitor-cluster.yaml
@@ -21,6 +21,15 @@ spec:
       cnpg.io/podRole: instance
   podMetricsEndpoints:
     - port: metrics
+      {{- if .Values.cluster.monitoring.tls.enabled }}
+      scheme: https
+      tlsConfig:
+        ca:
+          secret:
+            name: {{ include "cluster.fullname" . }}-ca
+            key: ca.crt
+        serverName: {{ include "cluster.fullname" . }}-rw
+      {{- end }}
       {{- with .Values.cluster.monitoring.podMonitor.relabelings }}
       relabelings:
         {{- toYaml . | nindent 8 }}

--- a/charts/cluster/test/monitoring/01-monitoring_cluster-assert.yaml
+++ b/charts/cluster/test/monitoring/01-monitoring_cluster-assert.yaml
@@ -12,6 +12,8 @@ spec:
     size: 256Mi
     storageClass: standard
   monitoring:
+      tls:
+        enabled: true
       disableDefaultQueries: true
       customQueriesConfigMap:
         - name: monitoring-cluster-monitoring
@@ -31,7 +33,15 @@ spec:
       cnpg.io/cluster: monitoring-cluster
       cnpg.io/podRole: instance
   podMetricsEndpoints:
-    - relabelings:
+    - port: metrics
+      scheme: https
+      tlsConfig:
+        ca:
+          secret:
+            name: monitoring-cluster-ca
+            key: ca.crt
+        serverName: monitoring-cluster-rw
+      relabelings:
         - targetLabel: environment
           replacement: test
         - targetLabel: team

--- a/charts/cluster/test/monitoring/01-monitoring_cluster.yaml
+++ b/charts/cluster/test/monitoring/01-monitoring_cluster.yaml
@@ -8,6 +8,8 @@ cluster:
   monitoring:
     enabled: true
     disableDefaultQueries: true
+    tls:
+      enabled: true
     customQueries:
       - name: "pg_cache_hit_ratio"
         query: "SELECT current_database() as datname, sum(heap_blks_hit) / (sum(heap_blks_hit) + sum(heap_blks_read)) as ratio FROM pg_statio_user_tables;"

--- a/charts/cluster/values.schema.json
+++ b/charts/cluster/values.schema.json
@@ -422,6 +422,18 @@
               },
               "required": [],
               "type": "object"
+            },
+            "tls": {
+              "description": "TLS usage for monitoring",
+              "properties": {
+                "enabled": {
+                  "default": false,
+                  "description": "Whether to enable TLS on the metrics port.",
+                  "type": "boolean"
+                }
+              },
+              "required": [],
+              "type": "object"
             }
           },
           "required": [],

--- a/charts/cluster/values.yaml
+++ b/charts/cluster/values.yaml
@@ -345,6 +345,10 @@ cluster:
     #          usage: GAUGE
     #          description: "Cache hit ratio"
 
+    # -- TLS usage for monitoring
+    tls:
+      # -- Whether to enable TLS on the metrics port.
+      enabled: false
     # -- The list of secrets containing the custom queries
     customQueriesSecret: []
     #  - name: custom-queries-secret


### PR DESCRIPTION
fix #878 

## What

Add TLS optional management for monitoring, as mentioned in [doc](https://cloudnative-pg.io/docs/1.29/monitoring#enabling-tls-on-the-metrics-port)

## Test

- `helm lint charts/cluster`
- The chainsaw `monitoring` test now asserts the rendered tls management for cluster and podMonitor for instances.