### PR TITLE
feat: support namespaced webhook configurations for multi-operator deployments

### DIFF
--- a/charts/cloudnative-pg/README.md
+++ b/charts/cloudnative-pg/README.md
@@ -34,6 +34,7 @@ Kubernetes: `>=1.29.0-0`
 | commonAnnotations | object | `{}` | Annotations to be added to all other resources. |
 | config.clusterWide | bool | `true` | This option determines if the operator is responsible for observing events across the entire Kubernetes cluster or if its focus should be narrowed down to the specific namespace within which it has been deployed. |
 | config.create | bool | `true` | Specifies whether the secret should be created. |
+| config.namespacedWebhooks | bool | `false` | When set to true, appends the operator namespace to webhook configuration names to avoid collisions when running multiple operators in namespaced mode. |
 | config.data | object | `{}` | The content of the configmap/secret, see https://cloudnative-pg.io/documentation/current/operator_conf/#available-options for all the available options. |
 | config.maxConcurrentReconciles | int | `10` | The maximum number of concurrent reconciles. Defaults to 10. |
 | config.name | string | `"cnpg-controller-manager-config"` | The name of the configmap/secret to use. |

--- a/charts/cloudnative-pg/templates/_helpers.tpl
+++ b/charts/cloudnative-pg/templates/_helpers.tpl
@@ -62,6 +62,17 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Cluster-scoped resource name, unique per namespace when namespacedWebhooks is enabled.
+*/}}
+{{- define "cloudnative-pg.clusterResourceName" -}}
+{{- if .Values.config.namespacedWebhooks -}}
+{{- printf "%s-%s" (include "cloudnative-pg.fullname" .) (include "cloudnative-pg.namespace" .) | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- include "cloudnative-pg.fullname" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "cloudnative-pg.serviceAccountName" -}}

--- a/charts/cloudnative-pg/templates/deployment.yaml
+++ b/charts/cloudnative-pg/templates/deployment.yaml
@@ -93,6 +93,10 @@ spec:
         - name: WATCH_NAMESPACE
           value: "{{ include "cloudnative-pg.namespace" . }}"
         {{- end }}
+        {{- if .Values.config.namespacedWebhooks }}
+        - name: ENABLE_WEBHOOK_NAMESPACE_SUFFIX
+          value: "true"
+        {{- end }}
         {{- if .Values.additionalEnv }}
         {{- tpl (.Values.additionalEnv | toYaml) . | nindent 8 }}
         {{- end }}

--- a/charts/cloudnative-pg/templates/mutatingwebhookconfiguration.yaml
+++ b/charts/cloudnative-pg/templates/mutatingwebhookconfiguration.yaml
@@ -21,7 +21,7 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: cnpg-mutating-webhook-configuration
+  name: cnpg-mutating-webhook-configuration{{- if .Values.config.namespacedWebhooks }}-{{ include "cloudnative-pg.namespace" . }}{{- end }}
   {{- with .Values.commonAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -39,6 +39,11 @@ webhooks:
       port: {{ .Values.service.port }}
   failurePolicy: {{ .Values.webhook.mutating.failurePolicy }}
   name: mbackup.cnpg.io
+  {{- if .Values.config.namespacedWebhooks }}
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: {{ include "cloudnative-pg.namespace" . }}
+  {{- end }}
   rules:
   - apiGroups:
     - postgresql.cnpg.io
@@ -60,6 +65,11 @@ webhooks:
       port: {{ .Values.service.port }}
   failurePolicy: {{ .Values.webhook.mutating.failurePolicy }}
   name: mcluster.cnpg.io
+  {{- if .Values.config.namespacedWebhooks }}
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: {{ include "cloudnative-pg.namespace" . }}
+  {{- end }}
   rules:
   - apiGroups:
     - postgresql.cnpg.io
@@ -81,6 +91,11 @@ webhooks:
       port: {{ .Values.service.port }}
   failurePolicy: {{ .Values.webhook.mutating.failurePolicy }}
   name: mdatabase.cnpg.io
+  {{- if .Values.config.namespacedWebhooks }}
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: {{ include "cloudnative-pg.namespace" . }}
+  {{- end }}
   rules:
   - apiGroups:
     - postgresql.cnpg.io
@@ -102,6 +117,11 @@ webhooks:
       port: {{ .Values.service.port }}
   failurePolicy: {{ .Values.webhook.mutating.failurePolicy }}
   name: mscheduledbackup.cnpg.io
+  {{- if .Values.config.namespacedWebhooks }}
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: {{ include "cloudnative-pg.namespace" . }}
+  {{- end }}
   rules:
   - apiGroups:
     - postgresql.cnpg.io

--- a/charts/cloudnative-pg/templates/rbac.yaml
+++ b/charts/cloudnative-pg/templates/rbac.yaml
@@ -36,7 +36,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "cloudnative-pg.fullname" . }}
+  name: {{ include "cloudnative-pg.clusterResourceName" . }}
   labels:
     {{- include "cloudnative-pg.labels" . | nindent 4 }}
   {{- with .Values.commonAnnotations }}
@@ -56,7 +56,7 @@ we add ALL the necessary rules for the operator to the ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "cloudnative-pg.fullname" . }}
+  name: {{ include "cloudnative-pg.clusterResourceName" . }}
   labels:
     {{- include "cloudnative-pg.labels" . | nindent 4 }}
   {{- with .Values.commonAnnotations }}
@@ -66,7 +66,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "cloudnative-pg.fullname" . }}
+  name: {{ include "cloudnative-pg.clusterResourceName" . }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "cloudnative-pg.serviceAccountName" . }}
@@ -117,7 +117,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "cloudnative-pg.fullname" . }}-view
+  name: {{ include "cloudnative-pg.clusterResourceName" . }}-view
   labels:
     {{- include "cloudnative-pg.labels" . | nindent 4 }}
     {{- if .Values.rbac.aggregateClusterRoles }}
@@ -148,7 +148,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "cloudnative-pg.fullname" . }}-edit
+  name: {{ include "cloudnative-pg.clusterResourceName" . }}-edit
   labels:
     {{- include "cloudnative-pg.labels" . | nindent 4 }}
     {{- if .Values.rbac.aggregateClusterRoles }}

--- a/charts/cloudnative-pg/templates/validatingwebhookconfiguration.yaml
+++ b/charts/cloudnative-pg/templates/validatingwebhookconfiguration.yaml
@@ -21,7 +21,7 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: cnpg-validating-webhook-configuration
+  name: cnpg-validating-webhook-configuration{{- if .Values.config.namespacedWebhooks }}-{{ include "cloudnative-pg.namespace" . }}{{- end }}
   labels:
     {{- include "cloudnative-pg.labels" . | nindent 4 }}
   {{- with .Values.rbac.annotations }}
@@ -39,6 +39,11 @@ webhooks:
       port: {{ .Values.service.port }}
   failurePolicy: {{ .Values.webhook.validating.failurePolicy }}
   name: vbackup.cnpg.io
+  {{- if .Values.config.namespacedWebhooks }}
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: {{ include "cloudnative-pg.namespace" . }}
+  {{- end }}
   rules:
   - apiGroups:
     - postgresql.cnpg.io
@@ -60,6 +65,11 @@ webhooks:
       port: {{ .Values.service.port }}
   failurePolicy: {{ .Values.webhook.validating.failurePolicy }}
   name: vcluster.cnpg.io
+  {{- if .Values.config.namespacedWebhooks }}
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: {{ include "cloudnative-pg.namespace" . }}
+  {{- end }}
   rules:
   - apiGroups:
     - postgresql.cnpg.io
@@ -81,6 +91,11 @@ webhooks:
       port: {{ .Values.service.port }}
   failurePolicy: {{ .Values.webhook.validating.failurePolicy }}
   name: vscheduledbackup.cnpg.io
+  {{- if .Values.config.namespacedWebhooks }}
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: {{ include "cloudnative-pg.namespace" . }}
+  {{- end }}
   rules:
   - apiGroups:
     - postgresql.cnpg.io
@@ -102,6 +117,11 @@ webhooks:
       port: {{ .Values.service.port }}
   failurePolicy: {{ .Values.webhook.validating.failurePolicy }}
   name: vdatabase.cnpg.io
+  {{- if .Values.config.namespacedWebhooks }}
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: {{ include "cloudnative-pg.namespace" . }}
+  {{- end }}
   rules:
   - apiGroups:
     - postgresql.cnpg.io
@@ -123,6 +143,11 @@ webhooks:
       port: {{ .Values.service.port }}
   failurePolicy: {{ .Values.webhook.validating.failurePolicy }}
   name: vpooler.cnpg.io
+  {{- if .Values.config.namespacedWebhooks }}
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: {{ include "cloudnative-pg.namespace" . }}
+  {{- end }}
   rules:
     - apiGroups:
         - postgresql.cnpg.io

--- a/charts/cloudnative-pg/values.yaml
+++ b/charts/cloudnative-pg/values.yaml
@@ -78,6 +78,9 @@ config:
   # events across the entire Kubernetes cluster or if its focus should be
   # narrowed down to the specific namespace within which it has been deployed.
   clusterWide: true
+  # -- When set to true, appends the operator namespace to webhook configuration
+  # names to avoid collisions when running multiple operators in namespaced mode.
+  namespacedWebhooks: false
   # -- The content of the configmap/secret, see
   # https://cloudnative-pg.io/documentation/current/operator_conf/#available-options
   # for all the available options.


### PR DESCRIPTION
Add config.namespacedWebhooks option that, when enabled:
- Appends the operator namespace to webhook configuration names
- Sets ENABLE_WEBHOOK_NAMESPACE_SUFFIX env var on the operator
- Adds namespaceSelector to webhook entries to scope them to the operator's namespace

This allows multiple CloudNativePG operators to run in single-namespace mode on the same cluster without webhook name collisions.