### PR TITLE
docs: split the installation readme to individual charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,68 +16,22 @@ Helm chart to install the
 running in private, public, or hybrid cloud environments.
 
 **NOTE**: supports only the latest point release of the CloudNativePG operator.
-```console
-helm repo add cnpg https://cloudnative-pg.github.io/charts
-helm upgrade --install cnpg \
-  --namespace cnpg-system \
-  --create-namespace \
-  cnpg/cloudnative-pg
-```
 
-#### Single namespace installation
-
-It is possible to limit the operator's capabilities to solely the namespace in
-which it has been installed. With this restriction, the cluster-level
-permissions required by the operator will be substantially reduced, and
-the security profile of the installation will be enhanced.
-
-You can install the operator in single-namespace mode by setting the
-`config.clusterWide` flag to false, as in the following example:
-
-```console
-helm upgrade --install cnpg \
-  --namespace cnpg-system \
-  --create-namespace \
-  --set config.clusterWide=false \
-  cnpg/cloudnative-pg
-```
-
-**IMPORTANT**: the single-namespace installation mode can't coexist
-with the cluster-wide operator. Otherwise there would be collisions when
-managing the resources in the namespace watched by the single-namespace
-operator.
-It is up to the user to ensure there is no collision between operators.
-
-Refer to the [Operator Chart documentation](charts/cloudnative-pg/README.md) for advanced configuration and monitoring.
+Refer to the [Operator Chart documentation](charts/cloudnative-pg/README.md) for installation advanced 
+configuration and monitoring.
 
 ## Barman Cloud CNPG-I plugin chart
 
 Helm chart to install the CNPG-I Barman Cloud Plugin.
 
-**IMPORTANT**: this chart requires a working installation of [cert-manager](https://cert-manager.io/).
-Please refer to the cert-manager [installation page](https://cert-manager.io/docs/installation/helm/)
-for more information about that.
-
-```console
-helm repo add cnpg https://cloudnative-pg.github.io/charts
-helm upgrade --install plugin-barman-cloud \
-  --namespace cnpg-system \
-  cnpg/plugin-barman-cloud
-```
+Refer to the [Barman Cloud Plugin Chart documentation](charts/plugin-barman-cloud/README.md) for installation 
+and advanced configuration.
 
 ## Cluster chart
 
 Helm chart to install a CloudNativePG database cluster.
 
-```console
-helm repo add cnpg https://cloudnative-pg.github.io/charts
-helm upgrade --install database \
-  --namespace database \
-  --create-namespace \
-  cnpg/cluster
-```
-
-Refer to the [Cluster Chart documentation](charts/cluster/README.md) for advanced configuration options.
+Refer to the [Cluster Chart documentation](charts/cluster/README.md) for Installtion and advanced configuration options.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -17,21 +17,21 @@ running in private, public, or hybrid cloud environments.
 
 **NOTE**: supports only the latest point release of the CloudNativePG operator.
 
-Refer to the [Operator Chart documentation](charts/cloudnative-pg/README.md) for installation advanced 
-configuration and monitoring.
+Refer to the [Operator Chart documentation](charts/cloudnative-pg/README.md) for installation,
+advanced configuration and monitoring.
 
 ## Barman Cloud CNPG-I plugin chart
 
 Helm chart to install the CNPG-I Barman Cloud Plugin.
 
-Refer to the [Barman Cloud Plugin Chart documentation](charts/plugin-barman-cloud/README.md) for installation 
+Refer to the [Barman Cloud Plugin Chart documentation](charts/plugin-barman-cloud/README.md) for installation
 and advanced configuration.
 
 ## Cluster chart
 
 Helm chart to install a CloudNativePG database cluster.
 
-Refer to the [Cluster Chart documentation](charts/cluster/README.md) for Installtion and advanced configuration options.
+Refer to the [Cluster Chart documentation](charts/cluster/README.md) for installation and advanced configuration options.
 
 ## Contributing
 

--- a/charts/cloudnative-pg/README.md
+++ b/charts/cloudnative-pg/README.md
@@ -95,8 +95,9 @@ helm uninstall cnpg --namespace cnpg-system
 ```
 
 > **Warning**
-> Uninstalling the chart does not remove the CRDs. Delete them manually only if you are sure no `Cluster`
-> resources remain.
+> Uninstalling the chart does not remove the CRDs. Deleting them cascade-deletes every `Cluster` (and other
+> CloudNativePG) resource across the whole cluster, together with the PostgreSQL data stored in their PVCs.
+> This is irreversible, so only delete the CRDs if you intend to permanently remove all managed databases.
 
 ## Source Code
 
@@ -178,10 +179,10 @@ Kubernetes: `>=1.29.0-0`
 Contributing
 ------------
 
-Please read the [code of conduct](../../CODE-OF-CONDUCT.md) and the
-[guidelines](../../CONTRIBUTING.md) to contribute to the project.
+Please read the [code of conduct](https://github.com/cloudnative-pg/charts/blob/main/CODE-OF-CONDUCT.md) and the
+[guidelines](https://github.com/cloudnative-pg/charts/blob/main/CONTRIBUTING.md) to contribute to the project.
 
 Copyright
 ---------
 
-Helm charts for CloudNativePG are distributed under [Apache License 2.0](../../LICENSE).
+Helm charts for CloudNativePG are distributed under [Apache License 2.0](./LICENSE).

--- a/charts/cloudnative-pg/README.md
+++ b/charts/cloudnative-pg/README.md
@@ -52,6 +52,10 @@ helm upgrade --install cnpg \
   cnpg/cloudnative-pg
 ```
 
+> **Note**
+> Enabling the `PodMonitor` requires the Prometheus Operator CRDs to be installed in the cluster.
+> Without them the install fails with `no matches for kind "PodMonitor"`.
+
 See the [Values](#values) section below for the full list of configurable parameters.
 
 ### Verify the installation

--- a/charts/cloudnative-pg/README.md
+++ b/charts/cloudnative-pg/README.md
@@ -6,11 +6,93 @@ CloudNativePG Operator Helm Chart
 
 **Homepage:** <https://cloudnative-pg.io>
 
-## Maintainers
+About this chart
+----------------
 
-| Name | Email | Url |
-| ---- | ------ | --- |
-| phisco | <p.scorsolini@gmail.com> |  |
+Helm chart to install the [CloudNativePG operator](https://cloudnative-pg.io), originally created and sponsored
+by [EDB](https://www.enterprisedb.com/) to manage PostgreSQL workloads on any supported Kubernetes cluster
+running in private, public, or hybrid cloud environments.
+
+**NOTE**: this chart supports only the latest point release of the CloudNativePG operator.
+
+The chart installs only the operator (controller manager, webhooks, RBAC and CRDs). To provision a PostgreSQL
+`Cluster` resource, use the companion [`cluster`](https://github.com/cloudnative-pg/charts/tree/main/charts/cluster) chart
+(see the [Cluster chart README](https://github.com/cloudnative-pg/charts/blob/main/charts/cluster/README.md) for details)
+or apply your own `Cluster` manifest.
+
+Getting Started
+---------------
+
+### Add the chart repository
+
+```console
+helm repo add cnpg https://cloudnative-pg.github.io/charts
+helm repo update
+```
+
+### Install the operator
+
+```console
+helm upgrade --install cnpg \
+  --namespace cnpg-system \
+  --create-namespace \
+  cnpg/cloudnative-pg
+```
+
+### Install with custom parameters
+
+You can override individual chart values from the command line with `--set`.
+For example, to enable the Prometheus `PodMonitor`:
+
+```console
+helm upgrade --install cnpg \
+  --namespace cnpg-system \
+  --create-namespace \
+  --set monitoring.podMonitorEnabled=true \
+  cnpg/cloudnative-pg
+```
+
+See the [Values](#values) section below for the full list of configurable parameters.
+
+### Verify the installation
+
+```console
+kubectl -n cnpg-system get deploy
+kubectl -n cnpg-system rollout status deploy/cnpg-cloudnative-pg
+```
+
+Single namespace installation
+-----------------------------
+
+It is possible to limit the operator's capabilities to solely the namespace in which it has been installed.
+With this restriction, the cluster-level permissions required by the operator will be substantially reduced,
+and the security profile of the installation will be enhanced.
+
+You can install the operator in single-namespace mode by setting the `config.clusterWide` flag to `false`,
+as in the following example:
+
+```console
+helm upgrade --install cnpg \
+  --namespace cnpg-system \
+  --create-namespace \
+  --set config.clusterWide=false \
+  cnpg/cloudnative-pg
+```
+
+**IMPORTANT**: the single-namespace installation mode can't coexist with the cluster-wide operator. Otherwise
+there would be collisions when managing the resources in the namespace watched by the single-namespace
+operator. It is up to the user to ensure there is no collision between operators.
+
+Uninstalling
+------------
+
+```console
+helm uninstall cnpg --namespace cnpg-system
+```
+
+> **Warning**
+> Uninstalling the chart does not remove the CRDs. Delete them manually only if you are sure no `Cluster`
+> resources remain.
 
 ## Source Code
 
@@ -82,3 +164,20 @@ Kubernetes: `>=1.29.0-0`
 | topologySpreadConstraints | list | `[]` | Topology Spread Constraints for the operator to be installed. |
 | updateStrategy | object | `{}` | Update strategy for the operator. ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy |
 | webhook | object | `{"livenessProbe":{"initialDelaySeconds":3},"mutating":{"create":true,"failurePolicy":"Fail"},"port":9443,"readinessProbe":{"initialDelaySeconds":3},"startupProbe":{"failureThreshold":6,"periodSeconds":5},"validating":{"create":true,"failurePolicy":"Fail"}}` | The webhook configuration. |
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| phisco | <p.scorsolini@gmail.com> |  |
+
+Contributing
+------------
+
+Please read the [code of conduct](../../CODE-OF-CONDUCT.md) and the
+[guidelines](../../CONTRIBUTING.md) to contribute to the project.
+
+Copyright
+---------
+
+Helm charts for CloudNativePG are distributed under [Apache License 2.0](../../LICENSE).

--- a/charts/cloudnative-pg/README.md.gotmpl
+++ b/charts/cloudnative-pg/README.md.gotmpl
@@ -1,0 +1,134 @@
+{{ template "chart.header" . }}
+
+
+{{ template "chart.deprecationWarning" . }}
+
+
+{{ template "chart.badgesSection" . }}
+
+
+{{ template "chart.description" . }}
+
+
+{{ template "chart.homepageLine" . }}
+
+
+About this chart
+----------------
+
+Helm chart to install the [CloudNativePG operator](https://cloudnative-pg.io), originally created and sponsored
+by [EDB](https://www.enterprisedb.com/) to manage PostgreSQL workloads on any supported Kubernetes cluster
+running in private, public, or hybrid cloud environments.
+
+**NOTE**: this chart supports only the latest point release of the CloudNativePG operator.
+
+The chart installs only the operator (controller manager, webhooks, RBAC and CRDs). To provision a PostgreSQL
+`Cluster` resource, use the companion [`cluster`](https://github.com/cloudnative-pg/charts/tree/main/charts/cluster) chart
+(see the [Cluster chart README](https://github.com/cloudnative-pg/charts/blob/main/charts/cluster/README.md) for details)
+or apply your own `Cluster` manifest.
+
+
+Getting Started
+---------------
+
+### Add the chart repository
+
+```console
+helm repo add cnpg https://cloudnative-pg.github.io/charts
+helm repo update
+```
+
+### Install the operator
+
+```console
+helm upgrade --install cnpg \
+  --namespace cnpg-system \
+  --create-namespace \
+  cnpg/cloudnative-pg
+```
+
+### Install with custom parameters
+
+You can override individual chart values from the command line with `--set`.
+For example, to enable the Prometheus `PodMonitor`:
+
+```console
+helm upgrade --install cnpg \
+  --namespace cnpg-system \
+  --create-namespace \
+  --set monitoring.podMonitorEnabled=true \
+  cnpg/cloudnative-pg
+```
+
+See the [Values](#values) section below for the full list of configurable parameters.
+
+### Verify the installation
+
+```console
+kubectl -n cnpg-system get deploy
+kubectl -n cnpg-system rollout status deploy/cnpg-cloudnative-pg
+```
+
+
+Single namespace installation
+-----------------------------
+
+It is possible to limit the operator's capabilities to solely the namespace in which it has been installed.
+With this restriction, the cluster-level permissions required by the operator will be substantially reduced,
+and the security profile of the installation will be enhanced.
+
+You can install the operator in single-namespace mode by setting the `config.clusterWide` flag to `false`,
+as in the following example:
+
+```console
+helm upgrade --install cnpg \
+  --namespace cnpg-system \
+  --create-namespace \
+  --set config.clusterWide=false \
+  cnpg/cloudnative-pg
+```
+
+**IMPORTANT**: the single-namespace installation mode can't coexist with the cluster-wide operator. Otherwise
+there would be collisions when managing the resources in the namespace watched by the single-namespace
+operator. It is up to the user to ensure there is no collision between operators.
+
+
+Uninstalling
+------------
+
+```console
+helm uninstall cnpg --namespace cnpg-system
+```
+
+> **Warning**
+> Uninstalling the chart does not remove the CRDs. Delete them manually only if you are sure no `Cluster`
+> resources remain.
+
+
+{{ template "chart.sourcesSection" . }}
+
+
+{{ template "chart.requirementsSection" . }}
+
+
+{{ template "chart.valuesSection" . }}
+
+
+{{ template "chart.maintainersSection" . }}
+
+Contributing
+------------
+
+Please read the [code of conduct](../../CODE-OF-CONDUCT.md) and the
+[guidelines](../../CONTRIBUTING.md) to contribute to the project.
+
+
+Copyright
+---------
+
+Helm charts for CloudNativePG are distributed under [Apache License 2.0](../../LICENSE).
+
+
+{{- if not .SkipVersionFooter }}
+{{ template "helm-docs.versionFooter" . }}
+{{- end }}

--- a/charts/cloudnative-pg/README.md.gotmpl
+++ b/charts/cloudnative-pg/README.md.gotmpl
@@ -60,6 +60,10 @@ helm upgrade --install cnpg \
   cnpg/cloudnative-pg
 ```
 
+> **Note**
+> Enabling the `PodMonitor` requires the Prometheus Operator CRDs to be installed in the cluster.
+> Without them the install fails with `no matches for kind "PodMonitor"`.
+
 See the [Values](#values) section below for the full list of configurable parameters.
 
 ### Verify the installation

--- a/charts/cloudnative-pg/README.md.gotmpl
+++ b/charts/cloudnative-pg/README.md.gotmpl
@@ -105,8 +105,9 @@ helm uninstall cnpg --namespace cnpg-system
 ```
 
 > **Warning**
-> Uninstalling the chart does not remove the CRDs. Delete them manually only if you are sure no `Cluster`
-> resources remain.
+> Uninstalling the chart does not remove the CRDs. Deleting them cascade-deletes every `Cluster` (and other
+> CloudNativePG) resource across the whole cluster, together with the PostgreSQL data stored in their PVCs.
+> This is irreversible, so only delete the CRDs if you intend to permanently remove all managed databases.
 
 
 {{ template "chart.sourcesSection" . }}
@@ -123,14 +124,14 @@ helm uninstall cnpg --namespace cnpg-system
 Contributing
 ------------
 
-Please read the [code of conduct](../../CODE-OF-CONDUCT.md) and the
-[guidelines](../../CONTRIBUTING.md) to contribute to the project.
+Please read the [code of conduct](https://github.com/cloudnative-pg/charts/blob/main/CODE-OF-CONDUCT.md) and the
+[guidelines](https://github.com/cloudnative-pg/charts/blob/main/CONTRIBUTING.md) to contribute to the project.
 
 
 Copyright
 ---------
 
-Helm charts for CloudNativePG are distributed under [Apache License 2.0](../../LICENSE).
+Helm charts for CloudNativePG are distributed under [Apache License 2.0](./LICENSE).
 
 
 {{- if not .SkipVersionFooter }}

--- a/charts/plugin-barman-cloud/README.md
+++ b/charts/plugin-barman-cloud/README.md
@@ -19,8 +19,8 @@ the [CloudNativePG](https://cloudnative-pg.io) plugin that adds backup and resto
 Please refer to the cert-manager
 [installation page](https://cert-manager.io/docs/installation/helm/) for more information.
 
-The chart deploys the plugin only. It does **not** install the CloudNativePG operator — use the companion
-[`cloudnative-pg`](https://github.com/cloudnative-pg/charts/tree/main/charts/cloudnative-pg) chart for that —
+The chart deploys the plugin only. It does **not** install the CloudNativePG operator (use the companion
+[`cloudnative-pg`](https://github.com/cloudnative-pg/charts/tree/main/charts/cloudnative-pg) chart for that),
 and it does not create any `Cluster` resource. To provision a PostgreSQL cluster that uses this plugin, use
 the [`cluster`](https://github.com/cloudnative-pg/charts/tree/main/charts/cluster) chart
 (see the [Cluster chart README](https://github.com/cloudnative-pg/charts/blob/main/charts/cluster/README.md) for details)
@@ -28,6 +28,12 @@ or apply your own `Cluster` manifest.
 
 Getting Started
 ---------------
+
+### Prerequisites
+
+This chart requires [cert-manager](https://cert-manager.io/) to issue the plugin's TLS certificates.
+Install it and wait until it is ready **before** installing this chart, otherwise the install fails because
+the certificates cannot be issued.
 
 ### Add the chart repository
 
@@ -43,6 +49,27 @@ helm upgrade --install plugin-barman-cloud \
   --namespace cnpg-system \
   cnpg/plugin-barman-cloud
 ```
+
+See the [Values](#values) section below for the full list of configurable parameters.
+
+### Verify the installation
+
+```console
+kubectl -n cnpg-system get deploy
+kubectl -n cnpg-system rollout status deploy/plugin-barman-cloud
+```
+
+Uninstalling
+------------
+
+```console
+helm uninstall plugin-barman-cloud --namespace cnpg-system
+```
+
+> **Warning**
+> Uninstalling the chart does not remove the plugin's CRDs (for example `ObjectStore`). Deleting them removes
+> every `ObjectStore` resource and the backup configuration it holds, so only delete the CRDs if you are sure
+> no resource depends on them.
 
 ## Source Code
 
@@ -96,7 +123,7 @@ Kubernetes: `>=1.29.0-0`
 | sidecarImage.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | tolerations | list | `[]` | Tolerations for the operator to be installed. |
 | topologySpreadConstraints | list | `[]` | Topology Spread Constraints for the operator to be installed. |
-| updateStrategy | object | `{}` | Update strategy for the operator. ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy For example:  type: RollingUpdate  rollingUpdate:    maxSurge: 25%    maxUnavailable: 25%  WARNING: the RollingUpdate strategy is not supported by the operator yet so it can currently only use the Recreate strategy. |
+| updateStrategy | object | `{}` | Update strategy for the operator. ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy |
 
 ## Maintainers
 
@@ -106,8 +133,13 @@ Kubernetes: `>=1.29.0-0`
 | quantumenigmaa | <thibaud.vaisseau@gmail.com> |  |
 | quentinbisson | <quentin.bisson@gmail.com> |  |
 
+Contributing
+------------
+
+Please read the [code of conduct](https://github.com/cloudnative-pg/charts/blob/main/CODE-OF-CONDUCT.md) and the
+[guidelines](https://github.com/cloudnative-pg/charts/blob/main/CONTRIBUTING.md) to contribute to the project.
+
 Copyright
 ---------
 
-Helm charts for CloudNativePG are distributed under [Apache License 2.0](../../LICENSE).
-
+Helm charts for CloudNativePG are distributed under [Apache License 2.0](./LICENSE).

--- a/charts/plugin-barman-cloud/README.md
+++ b/charts/plugin-barman-cloud/README.md
@@ -6,13 +6,43 @@ Helm Chart for CloudNativePG's CNPG-I backup plugin using Barman Cloud
 
 **Homepage:** <https://cloudnative-pg.io>
 
-## Maintainers
+About this chart
+----------------
 
-| Name | Email | Url |
-| ---- | ------ | --- |
-| itay-grudev | <itay@verito.digital> |  |
-| quantumenigmaa | <thibaud.vaisseau@gmail.com> |  |
-| quentinbisson | <quentin.bisson@gmail.com> |  |
+Helm chart to install the [CNPG-I Barman Cloud Plugin](https://github.com/cloudnative-pg/plugin-barman-cloud),
+the [CloudNativePG](https://cloudnative-pg.io) plugin that adds backup and restore capabilities to PostgreSQL
+`Cluster` resources via [Barman Cloud](https://pgbarman.org/).
+
+**NOTE**: this chart supports only the latest point release of the plugin.
+
+**IMPORTANT**: this chart requires a working installation of [cert-manager](https://cert-manager.io/).
+Please refer to the cert-manager
+[installation page](https://cert-manager.io/docs/installation/helm/) for more information.
+
+The chart deploys the plugin only. It does **not** install the CloudNativePG operator — use the companion
+[`cloudnative-pg`](https://github.com/cloudnative-pg/charts/tree/main/charts/cloudnative-pg) chart for that —
+and it does not create any `Cluster` resource. To provision a PostgreSQL cluster that uses this plugin, use
+the [`cluster`](https://github.com/cloudnative-pg/charts/tree/main/charts/cluster) chart
+(see the [Cluster chart README](https://github.com/cloudnative-pg/charts/blob/main/charts/cluster/README.md) for details)
+or apply your own `Cluster` manifest.
+
+Getting Started
+---------------
+
+### Add the chart repository
+
+```console
+helm repo add cnpg https://cloudnative-pg.github.io/charts
+helm repo update
+```
+
+### Install the plugin
+
+```console
+helm upgrade --install plugin-barman-cloud \
+  --namespace cnpg-system \
+  cnpg/plugin-barman-cloud
+```
 
 ## Source Code
 
@@ -66,4 +96,18 @@ Kubernetes: `>=1.29.0-0`
 | sidecarImage.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | tolerations | list | `[]` | Tolerations for the operator to be installed. |
 | topologySpreadConstraints | list | `[]` | Topology Spread Constraints for the operator to be installed. |
-| updateStrategy | object | `{}` | Update strategy for the operator. ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy |
+| updateStrategy | object | `{}` | Update strategy for the operator. ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy For example:  type: RollingUpdate  rollingUpdate:    maxSurge: 25%    maxUnavailable: 25%  WARNING: the RollingUpdate strategy is not supported by the operator yet so it can currently only use the Recreate strategy. |
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| itay-grudev | <itay@verito.digital> |  |
+| quantumenigmaa | <thibaud.vaisseau@gmail.com> |  |
+| quentinbisson | <quentin.bisson@gmail.com> |  |
+
+Copyright
+---------
+
+Helm charts for CloudNativePG are distributed under [Apache License 2.0](../../LICENSE).
+

--- a/charts/plugin-barman-cloud/README.md.gotmpl
+++ b/charts/plugin-barman-cloud/README.md.gotmpl
@@ -26,8 +26,8 @@ the [CloudNativePG](https://cloudnative-pg.io) plugin that adds backup and resto
 Please refer to the cert-manager
 [installation page](https://cert-manager.io/docs/installation/helm/) for more information.
 
-The chart deploys the plugin only. It does **not** install the CloudNativePG operator — use the companion
-[`cloudnative-pg`](https://github.com/cloudnative-pg/charts/tree/main/charts/cloudnative-pg) chart for that —
+The chart deploys the plugin only. It does **not** install the CloudNativePG operator (use the companion
+[`cloudnative-pg`](https://github.com/cloudnative-pg/charts/tree/main/charts/cloudnative-pg) chart for that),
 and it does not create any `Cluster` resource. To provision a PostgreSQL cluster that uses this plugin, use
 the [`cluster`](https://github.com/cloudnative-pg/charts/tree/main/charts/cluster) chart
 (see the [Cluster chart README](https://github.com/cloudnative-pg/charts/blob/main/charts/cluster/README.md) for details)
@@ -36,6 +36,12 @@ or apply your own `Cluster` manifest.
 
 Getting Started
 ---------------
+
+### Prerequisites
+
+This chart requires [cert-manager](https://cert-manager.io/) to issue the plugin's TLS certificates.
+Install it and wait until it is ready **before** installing this chart, otherwise the install fails because
+the certificates cannot be issued.
 
 ### Add the chart repository
 
@@ -52,6 +58,28 @@ helm upgrade --install plugin-barman-cloud \
   cnpg/plugin-barman-cloud
 ```
 
+See the [Values](#values) section below for the full list of configurable parameters.
+
+### Verify the installation
+
+```console
+kubectl -n cnpg-system get deploy
+kubectl -n cnpg-system rollout status deploy/plugin-barman-cloud
+```
+
+
+Uninstalling
+------------
+
+```console
+helm uninstall plugin-barman-cloud --namespace cnpg-system
+```
+
+> **Warning**
+> Uninstalling the chart does not remove the plugin's CRDs (for example `ObjectStore`). Deleting them removes
+> every `ObjectStore` resource and the backup configuration it holds, so only delete the CRDs if you are sure
+> no resource depends on them.
+
 {{ template "chart.sourcesSection" . }}
 
 
@@ -62,14 +90,19 @@ helm upgrade --install plugin-barman-cloud \
 
 {{ template "chart.maintainersSection" . }}
 
+Contributing
+------------
+
+Please read the [code of conduct](https://github.com/cloudnative-pg/charts/blob/main/CODE-OF-CONDUCT.md) and the
+[guidelines](https://github.com/cloudnative-pg/charts/blob/main/CONTRIBUTING.md) to contribute to the project.
+
 
 Copyright
 ---------
 
-Helm charts for CloudNativePG are distributed under [Apache License 2.0](../../LICENSE).
+Helm charts for CloudNativePG are distributed under [Apache License 2.0](./LICENSE).
 
 
 {{- if not .SkipVersionFooter }}
 {{ template "helm-docs.versionFooter" . }}
 {{- end }}
-

--- a/charts/plugin-barman-cloud/README.md.gotmpl
+++ b/charts/plugin-barman-cloud/README.md.gotmpl
@@ -1,0 +1,75 @@
+{{ template "chart.header" . }}
+
+
+{{ template "chart.deprecationWarning" . }}
+
+
+{{ template "chart.badgesSection" . }}
+
+
+{{ template "chart.description" . }}
+
+
+{{ template "chart.homepageLine" . }}
+
+
+About this chart
+----------------
+
+Helm chart to install the [CNPG-I Barman Cloud Plugin](https://github.com/cloudnative-pg/plugin-barman-cloud),
+the [CloudNativePG](https://cloudnative-pg.io) plugin that adds backup and restore capabilities to PostgreSQL
+`Cluster` resources via [Barman Cloud](https://pgbarman.org/).
+
+**NOTE**: this chart supports only the latest point release of the plugin.
+
+**IMPORTANT**: this chart requires a working installation of [cert-manager](https://cert-manager.io/).
+Please refer to the cert-manager
+[installation page](https://cert-manager.io/docs/installation/helm/) for more information.
+
+The chart deploys the plugin only. It does **not** install the CloudNativePG operator — use the companion
+[`cloudnative-pg`](https://github.com/cloudnative-pg/charts/tree/main/charts/cloudnative-pg) chart for that —
+and it does not create any `Cluster` resource. To provision a PostgreSQL cluster that uses this plugin, use
+the [`cluster`](https://github.com/cloudnative-pg/charts/tree/main/charts/cluster) chart
+(see the [Cluster chart README](https://github.com/cloudnative-pg/charts/blob/main/charts/cluster/README.md) for details)
+or apply your own `Cluster` manifest.
+
+
+Getting Started
+---------------
+
+### Add the chart repository
+
+```console
+helm repo add cnpg https://cloudnative-pg.github.io/charts
+helm repo update
+```
+
+### Install the plugin
+
+```console
+helm upgrade --install plugin-barman-cloud \
+  --namespace cnpg-system \
+  cnpg/plugin-barman-cloud
+```
+
+{{ template "chart.sourcesSection" . }}
+
+
+{{ template "chart.requirementsSection" . }}
+
+
+{{ template "chart.valuesSection" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+
+Copyright
+---------
+
+Helm charts for CloudNativePG are distributed under [Apache License 2.0](../../LICENSE).
+
+
+{{- if not .SkipVersionFooter }}
+{{ template "helm-docs.versionFooter" . }}
+{{- end }}
+


### PR DESCRIPTION
Added go template readme for cloudnative-pg and plugin-barman-cloud. Now the installation part are shifted to individual charts directory. Root Readme.md is also trimmed and linked to individual readme's.

Closes #884