### PR TITLE
fix(charts): updating not maintained karuppiah7890/helm-schema-gen with dadav/helm-schema

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -18,6 +18,15 @@
       depNameTemplate: 'ghcr.io/cloudnative-pg/cloudnative-pg',
       versioningTemplate: 'loose',
     },
+    {
+      customType: 'regex',
+      managerFilePatterns: [
+        '/^Makefile$/',
+      ],
+      matchStrings: [
+        '# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s+[A-Za-z0-9_]+?_VERSION\\s*\\??=\\s*["\']?(?<currentValue>.+?)["\']?\\s',
+      ],
+    },
   ],
   packageRules: [
     {

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ help: ## Prints help command output
 ## Update chart's README.md
 .PHONY: docs
 docs: ## Generate charts' docs using helm-docs
-	helm-docs --skip-version-footer || \
+	@helm-docs --skip-version-footer || \
 		(echo "Please, install https://github.com/norwoodj/helm-docs first" && exit 1)
 
 .PHONY: schema

--- a/Makefile
+++ b/Makefile
@@ -11,17 +11,19 @@ docs: ## Generate charts' docs using helm-docs
 	@helm-docs --skip-version-footer || \
 		(echo "Please, install https://github.com/norwoodj/helm-docs first" && exit 1)
 
+HELM_SCHEMA_FLAGS := -a --no-dependencies --skip-auto-generation title,required,additionalProperties
+
 .PHONY: schema
-schema: cloudnative-pg-schema cluster-schema plugin-barman-cloud ## Generate charts' schema using helm-schema
+schema: cloudnative-pg-schema cluster-schema plugin-barman-cloud-schema ## Generate charts' schema using helm-schema
 
 cloudnative-pg-schema:
-	@helm schema -a --no-dependencies --skip-auto-generation title,required,additionalProperties -c charts/cloudnative-pg || \
+	@helm schema $(HELM_SCHEMA_FLAGS) -c charts/cloudnative-pg || \
 		(echo "Please, run: helm plugin install https://github.com/dadav/helm-schema" && exit 1)
 
 cluster-schema:
-	@helm schema -a --no-dependencies --skip-auto-generation title,required,additionalProperties -c charts/cluster || \
+	@helm schema $(HELM_SCHEMA_FLAGS) -c charts/cluster || \
 		(echo "Please, run: helm plugin install https://github.com/dadav/helm-schema" && exit 1)
 
-plugin-barman-cloud:
-	@helm schema -a --no-dependencies --skip-auto-generation title,required,additionalProperties -c charts/plugin-barman-cloud || \
+plugin-barman-cloud-schema:
+	@helm schema $(HELM_SCHEMA_FLAGS) -c charts/plugin-barman-cloud || \
 		(echo "Please, run: helm plugin install https://github.com/dadav/helm-schema" && exit 1)

--- a/Makefile
+++ b/Makefile
@@ -15,13 +15,13 @@ docs: ## Generate charts' docs using helm-docs
 schema: cloudnative-pg-schema cluster-schema plugin-barman-cloud ## Generate charts' schema using helm-schema
 
 cloudnative-pg-schema:
-	@helm schema --skip-auto-generation additionalProperties -c charts/cloudnative-pg || \
+	@helm schema -a --no-dependencies --skip-auto-generation title,required,additionalProperties -c charts/cloudnative-pg || \
 		(echo "Please, run: helm plugin install https://github.com/dadav/helm-schema" && exit 1)
 
 cluster-schema:
-	@helm schema --skip-auto-generation additionalProperties -c charts/cluster || \
+	@helm schema -a --no-dependencies --skip-auto-generation title,required,additionalProperties -c charts/cluster || \
 		(echo "Please, run: helm plugin install https://github.com/dadav/helm-schema" && exit 1)
 
 plugin-barman-cloud:
-	@helm schema --skip-auto-generation additionalProperties -c charts/plugin-barman-cloud || \
+	@helm schema -a --no-dependencies --skip-auto-generation title,required,additionalProperties -c charts/plugin-barman-cloud || \
 		(echo "Please, run: helm plugin install https://github.com/dadav/helm-schema" && exit 1)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,12 @@
 .DEFAULT_GOAL := help
 
+LOCALBIN ?= $(shell pwd)/bin
+# renovate: datasource=github-releases depName=norwoodj/helm-docs
+HELM_DOCS_VERSION ?= v1.14.2
+# renovate: datasource=github-releases depName=dadav/helm-schema
+HELM_SCHEMA_VERSION ?= 0.23.4
+HELM_SCHEMA_FLAGS ?= -a --no-dependencies --skip-auto-generation title,required,additionalProperties
+
 # Credits: https://gist.github.com/prwhite/8168133
 .PHONY: help
 help: ## Prints help command output
@@ -7,23 +14,37 @@ help: ## Prints help command output
 
 ## Update chart's README.md
 .PHONY: docs
-docs: ## Generate charts' docs using helm-docs
-	@helm-docs --skip-version-footer || \
-		(echo "Please, install https://github.com/norwoodj/helm-docs first" && exit 1)
-
-HELM_SCHEMA_FLAGS := -a --no-dependencies --skip-auto-generation title,required,additionalProperties
+docs: helm-docs ## Generate charts' docs using helm-docs
+	@$(HELM_DOCS) --skip-version-footer
 
 .PHONY: schema
 schema: cloudnative-pg-schema cluster-schema plugin-barman-cloud-schema ## Generate charts' schema using helm-schema
 
-cloudnative-pg-schema:
-	@helm schema $(HELM_SCHEMA_FLAGS) -c charts/cloudnative-pg || \
-		(echo "Please, run: helm plugin install https://github.com/dadav/helm-schema" && exit 1)
+cloudnative-pg-schema: helm-schema
+	@$(HELM_SCHEMA) $(HELM_SCHEMA_FLAGS) -c charts/cloudnative-pg
 
-cluster-schema:
-	@helm schema $(HELM_SCHEMA_FLAGS) -c charts/cluster || \
-		(echo "Please, run: helm plugin install https://github.com/dadav/helm-schema" && exit 1)
+cluster-schema: helm-schema
+	@$(HELM_SCHEMA) $(HELM_SCHEMA_FLAGS) -c charts/cluster
 
-plugin-barman-cloud-schema:
-	@helm schema $(HELM_SCHEMA_FLAGS) -c charts/plugin-barman-cloud || \
-		(echo "Please, run: helm plugin install https://github.com/dadav/helm-schema" && exit 1)
+plugin-barman-cloud-schema: helm-schema
+	@$(HELM_SCHEMA) $(HELM_SCHEMA_FLAGS) -c charts/plugin-barman-cloud
+
+.PHONY: helm-schema
+HELM_SCHEMA = $(LOCALBIN)/helm-schema
+helm-schema: ## Download helm-schema locally if necessary.
+	$(call go-install-tool,$(HELM_SCHEMA),github.com/dadav/helm-schema/cmd/helm-schema@$(HELM_SCHEMA_VERSION))
+
+.PHONY: helm-docs
+HELM_DOCS = $(LOCALBIN)/helm-docs
+helm-docs: ## Download helm-docs locally if necessary.
+	$(call go-install-tool,$(HELM_DOCS),github.com/norwoodj/helm-docs/cmd/helm-docs@$(HELM_DOCS_VERSION))
+
+PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
+# go-install-tool will 'go install' any package $2 and install it to $1.
+define go-install-tool
+@[ -f $(1) ] || { \
+set -e ;\
+echo "Downloading $(2)" ;\
+GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
+}
+endef

--- a/Makefile
+++ b/Makefile
@@ -12,15 +12,15 @@ docs: ## Generate charts' docs using helm-docs
 		(echo "Please, install https://github.com/norwoodj/helm-docs first" && exit 1)
 
 .PHONY: schema
-schema: cloudnative-pg-schema cluster-schema plugin-barman-cloud ## Generate charts' schema using helm-schema-gen
+schema: cloudnative-pg-schema cluster-schema plugin-barman-cloud ## Generate charts' schema using helm-schema
 
 cloudnative-pg-schema:
-	@helm schema-gen charts/cloudnative-pg/values.yaml | cat > charts/cloudnative-pg/values.schema.json || \
-		(echo "Please, run: helm plugin install https://github.com/karuppiah7890/helm-schema-gen.git" && exit 1)
+	@helm schema --skip-auto-generation additionalProperties -c charts/cloudnative-pg || \
+		(echo "Please, run: helm plugin install https://github.com/dadav/helm-schema" && exit 1)
 
 cluster-schema:
-	@helm schema-gen charts/cluster/values.yaml | cat > charts/cluster/values.schema.json || \
-		(echo "Please, run: helm plugin install https://github.com/karuppiah7890/helm-schema-gen.git" && exit 1)
+	@helm schema --skip-auto-generation additionalProperties -c charts/cluster || \
+		(echo "Please, run: helm plugin install https://github.com/dadav/helm-schema" && exit 1)
 
 plugin-barman-cloud:
 	@helm schema --skip-auto-generation additionalProperties -c charts/plugin-barman-cloud || \

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
 .DEFAULT_GOAL := help
 
-LOCALBIN ?= $(shell pwd)/bin
+# behave identically regardless of the caller's working directory
+PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
+LOCALBIN    ?= $(PROJECT_DIR)/bin
 # renovate: datasource=github-releases depName=norwoodj/helm-docs
 HELM_DOCS_VERSION ?= v1.14.2
 # renovate: datasource=github-releases depName=dadav/helm-schema
 HELM_SCHEMA_VERSION ?= 0.23.4
-HELM_SCHEMA_FLAGS ?= -a --no-dependencies --skip-auto-generation title,required,additionalProperties
+HELM_SCHEMA_FLAGS ?= -a -p --no-dependencies --skip-auto-generation title,required,additionalProperties
 
 # Credits: https://gist.github.com/prwhite/8168133
 .PHONY: help
@@ -39,12 +41,11 @@ HELM_DOCS = $(LOCALBIN)/helm-docs
 helm-docs: ## Download helm-docs locally if necessary.
 	$(call go-install-tool,$(HELM_DOCS),github.com/norwoodj/helm-docs/cmd/helm-docs@$(HELM_DOCS_VERSION))
 
-PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 # go-install-tool will 'go install' any package $2 and install it to $1.
 define go-install-tool
 @[ -f $(1) ] || { \
 set -e ;\
 echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
+GOBIN=$(LOCALBIN) go install $(2) ;\
 }
 endef

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ LOCALBIN    ?= $(PROJECT_DIR)/bin
 HELM_DOCS_VERSION ?= v1.14.2
 # renovate: datasource=github-releases depName=dadav/helm-schema
 HELM_SCHEMA_VERSION ?= 0.23.4
-HELM_SCHEMA_FLAGS ?= -a -p --no-dependencies --skip-auto-generation title,required,additionalProperties
+HELM_SCHEMA_FLAGS ?= -a --no-dependencies --skip-auto-generation title,required,additionalProperties
 
 # Credits: https://gist.github.com/prwhite/8168133
 .PHONY: help

--- a/charts/cloudnative-pg/README.md
+++ b/charts/cloudnative-pg/README.md
@@ -29,7 +29,7 @@ Kubernetes: `>=1.29.0-0`
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | additionalArgs | list | `[]` | Additional arguments to be added to the operator's args list. |
-| additionalEnv | list | `[]` | Array containing extra environment variables which can be templated. For example:  - name: RELEASE_NAME    value: "{{ .Release.Name }}"  - name: MY_VAR    value: "mySpecialKey" |
+| additionalEnv | list | `[]` | Array containing extra environment variables which can be templated. |
 | affinity | object | `{}` | Affinity for the operator to be installed. |
 | commonAnnotations | object | `{}` | Annotations to be added to all other resources. |
 | config.clusterWide | bool | `true` | This option determines if the operator is responsible for observing events across the entire Kubernetes cluster or if its focus should be narrowed down to the specific namespace within which it has been deployed. |
@@ -52,8 +52,8 @@ Kubernetes: `>=1.29.0-0`
 | monitoring.grafanaDashboard.create | bool | `false` |  |
 | monitoring.grafanaDashboard.labels | object | `{}` | Labels that ConfigMaps should have to get configured in Grafana. |
 | monitoring.grafanaDashboard.namespace | string | `""` | Allows overriding the namespace where the ConfigMap will be created, defaulting to the same one as the Release. |
-| monitoring.grafanaDashboard.sidecarLabel | string | `"grafana_dashboard"` | Label that ConfigMaps should have to be loaded as dashboards.  DEPRECATED: Use labels instead. |
-| monitoring.grafanaDashboard.sidecarLabelValue | string | `"1"` | Label value that ConfigMaps should have to be loaded as dashboards.  DEPRECATED: Use labels instead. |
+| monitoring.grafanaDashboard.sidecarLabel | string | `"grafana_dashboard"` | Label that ConfigMaps should have to be loaded as dashboards. DEPRECATED: Use labels instead. |
+| monitoring.grafanaDashboard.sidecarLabelValue | string | `"1"` | Label value that ConfigMaps should have to be loaded as dashboards. DEPRECATED: Use labels instead. |
 | monitoring.podMonitorAdditionalLabels | object | `{}` | Additional labels for the podMonitor |
 | monitoring.podMonitorEnabled | bool | `false` | Specifies whether the monitoring should be enabled. Requires Prometheus Operator CRDs. |
 | monitoring.podMonitorMetricRelabelings | list | `[]` | Metrics relabel configurations to apply to samples before ingestion. |
@@ -73,12 +73,12 @@ Kubernetes: `>=1.29.0-0`
 | resources | object | `{}` |  |
 | service.ipFamilies | list | `[]` | Sets the families that should be supported and the order in which they should be applied to ClusterIP as well. Can be IPv4 and/or IPv6. |
 | service.ipFamilyPolicy | string | `""` | Set the ip family policy to configure dual-stack see [Configure dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services) |
-| service.name | string | `"cnpg-webhook-service"` | DO NOT CHANGE THE SERVICE NAME as it is currently used to generate the certificate and can not be configured |
+| service.name | string | `"cnpg-webhook-service"` | The name of the Webhook Service. |
 | service.port | int | `443` |  |
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.create | bool | `true` | Specifies whether the service account should be created. |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template. |
 | tolerations | list | `[]` | Tolerations for the operator to be installed. |
 | topologySpreadConstraints | list | `[]` | Topology Spread Constraints for the operator to be installed. |
-| updateStrategy | object | `{}` | Update strategy for the operator. ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy For example:  type: RollingUpdate  rollingUpdate:    maxSurge: 25%    maxUnavailable: 25% |
+| updateStrategy | object | `{}` | Update strategy for the operator. ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy |
 | webhook | object | `{"livenessProbe":{"initialDelaySeconds":3},"mutating":{"create":true,"failurePolicy":"Fail"},"port":9443,"readinessProbe":{"initialDelaySeconds":3},"startupProbe":{"failureThreshold":6,"periodSeconds":5},"validating":{"create":true,"failurePolicy":"Fail"}}` | The webhook configuration. |

--- a/charts/cloudnative-pg/values.schema.json
+++ b/charts/cloudnative-pg/values.schema.json
@@ -9,7 +9,7 @@
       "type": "array"
     },
     "additionalEnv": {
-      "description": "Array containing extra environment variables which can be templated.\nFor example:\n - name: RELEASE_NAME\n   value: \"{{ .Release.Name }}\"\n - name: MY_VAR\n   value: \"mySpecialKey\"",
+      "description": "Array containing extra environment variables which can be templated.",
       "items": {
         "required": []
       },
@@ -195,12 +195,12 @@
             },
             "sidecarLabel": {
               "default": "grafana_dashboard",
-              "description": "Label that ConfigMaps should have to be loaded as dashboards.  DEPRECATED: Use labels instead.",
+              "description": "Label that ConfigMaps should have to be loaded as dashboards. DEPRECATED: Use labels instead.",
               "type": "string"
             },
             "sidecarLabelValue": {
               "default": "1",
-              "description": "Label value that ConfigMaps should have to be loaded as dashboards.  DEPRECATED: Use labels instead.",
+              "description": "Label value that ConfigMaps should have to be loaded as dashboards. DEPRECATED: Use labels instead.",
               "type": "string"
             }
           },
@@ -341,7 +341,7 @@
         },
         "name": {
           "default": "cnpg-webhook-service",
-          "description": "DO NOT CHANGE THE SERVICE NAME as it is currently used to generate the certificate\nand can not be configured",
+          "description": "The name of the Webhook Service.",
           "type": "string"
         },
         "port": {
@@ -387,7 +387,7 @@
       "type": "array"
     },
     "updateStrategy": {
-      "description": "Update strategy for the operator.\nref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy\nFor example:\n type: RollingUpdate\n rollingUpdate:\n   maxSurge: 25%\n   maxUnavailable: 25%",
+      "description": "Update strategy for the operator.\nref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy",
       "required": [],
       "type": "object"
     },

--- a/charts/cloudnative-pg/values.schema.json
+++ b/charts/cloudnative-pg/values.schema.json
@@ -1,313 +1,668 @@
 {
-    "$schema": "http://json-schema.org/schema#",
-    "type": "object",
-    "properties": {
-        "additionalArgs": {
-            "type": "array"
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "additionalArgs": {
+      "description": "Additional arguments to be added to the operator's args list.",
+      "items": {
+        "required": []
+      },
+      "title": "additionalArgs",
+      "type": "array"
+    },
+    "additionalEnv": {
+      "description": "Array containing extra environment variables which can be templated.\nFor example:\n - name: RELEASE_NAME\n   value: \"{{ .Release.Name }}\"\n - name: MY_VAR\n   value: \"mySpecialKey\"",
+      "items": {
+        "required": []
+      },
+      "title": "additionalEnv",
+      "type": "array"
+    },
+    "affinity": {
+      "description": "Affinity for the operator to be installed.",
+      "required": [],
+      "title": "affinity",
+      "type": "object"
+    },
+    "commonAnnotations": {
+      "description": "Annotations to be added to all other resources.",
+      "required": [],
+      "title": "commonAnnotations",
+      "type": "object"
+    },
+    "config": {
+      "description": "Operator configuration.",
+      "properties": {
+        "clusterWide": {
+          "default": true,
+          "description": "This option determines if the operator is responsible for observing\nevents across the entire Kubernetes cluster or if its focus should be\nnarrowed down to the specific namespace within which it has been deployed.",
+          "title": "clusterWide",
+          "type": "boolean"
         },
-        "additionalEnv": {
-            "type": "array"
+        "create": {
+          "default": true,
+          "description": "Specifies whether the secret should be created.",
+          "title": "create",
+          "type": "boolean"
         },
-        "affinity": {
-            "type": "object"
+        "data": {
+          "description": "The content of the configmap/secret, see\nhttps://cloudnative-pg.io/documentation/current/operator_conf/#available-options\nfor all the available options.",
+          "required": [],
+          "title": "data",
+          "type": "object"
         },
-        "commonAnnotations": {
-            "type": "object"
+        "maxConcurrentReconciles": {
+          "default": 10,
+          "description": "INHERITED_ANNOTATIONS: categories\nINHERITED_LABELS: environment, workload, app\nWATCH_NAMESPACE: namespace-a,namespace-b\nThe maximum number of concurrent reconciles. Defaults to 10.",
+          "title": "maxConcurrentReconciles",
+          "type": "integer"
         },
-        "config": {
-            "type": "object",
-            "properties": {
-                "clusterWide": {
-                    "type": "boolean"
-                },
-                "create": {
-                    "type": "boolean"
-                },
-                "data": {
-                    "type": "object"
-                },
-                "maxConcurrentReconciles": {
-                    "type": "integer"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "secret": {
-                    "type": "boolean"
-                }
-            }
+        "name": {
+          "default": "cnpg-controller-manager-config",
+          "description": "The name of the configmap/secret to use.",
+          "title": "name",
+          "type": "string"
         },
-        "containerSecurityContext": {
-            "type": "object",
-            "properties": {
-                "allowPrivilegeEscalation": {
-                    "type": "boolean"
-                },
-                "capabilities": {
-                    "type": "object",
-                    "properties": {
-                        "drop": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "readOnlyRootFilesystem": {
-                    "type": "boolean"
-                },
-                "runAsGroup": {
-                    "type": "integer"
-                },
-                "runAsUser": {
-                    "type": "integer"
-                },
-                "seccompProfile": {
-                    "type": "object",
-                    "properties": {
-                        "type": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "crds": {
-            "type": "object",
-            "properties": {
-                "create": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "dnsPolicy": {
-            "type": "string"
-        },
-        "fullnameOverride": {
-            "type": "string"
-        },
-        "hostNetwork": {
-            "type": "boolean"
-        },
-        "image": {
-            "type": "object",
-            "properties": {
-                "pullPolicy": {
-                    "type": "string"
-                },
-                "repository": {
-                    "type": "string"
-                },
-                "tag": {
-                    "type": "string"
-                }
-            }
-        },
-        "imagePullSecrets": {
-            "type": "array"
-        },
-        "monitoring": {
-            "type": "object",
-            "properties": {
-                "grafanaDashboard": {
-                    "type": "object",
-                    "properties": {
-                        "annotations": {
-                            "type": "object"
-                        },
-                        "configMapName": {
-                            "type": "string"
-                        },
-                        "create": {
-                            "type": "boolean"
-                        },
-                        "labels": {
-                            "type": "object"
-                        },
-                        "namespace": {
-                            "type": "string"
-                        },
-                        "sidecarLabel": {
-                            "type": "string"
-                        },
-                        "sidecarLabelValue": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "podMonitorAdditionalLabels": {
-                    "type": "object"
-                },
-                "podMonitorEnabled": {
-                    "type": "boolean"
-                },
-                "podMonitorMetricRelabelings": {
-                    "type": "array"
-                },
-                "podMonitorRelabelings": {
-                    "type": "array"
-                }
-            }
-        },
-        "monitoringQueriesConfigMap": {
-            "type": "object",
-            "properties": {
-                "name": {
-                    "type": "string"
-                },
-                "queries": {
-                    "type": "string"
-                }
-            }
-        },
-        "nameOverride": {
-            "type": "string"
-        },
-        "namespaceOverride": {
-            "type": "string"
-        },
-        "nodeSelector": {
-            "type": "object"
-        },
-        "podAnnotations": {
-            "type": "object"
-        },
-        "podLabels": {
-            "type": "object"
-        },
-        "podSecurityContext": {
-            "type": "object",
-            "properties": {
-                "runAsNonRoot": {
-                    "type": "boolean"
-                },
-                "seccompProfile": {
-                    "type": "object",
-                    "properties": {
-                        "type": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "priorityClassName": {
-            "type": "string"
-        },
-        "rbac": {
-            "type": "object",
-            "properties": {
-                "aggregateClusterRoles": {
-                    "type": "boolean"
-                },
-                "create": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "replicaCount": {
-            "type": "integer"
-        },
-        "resources": {
-            "type": "object"
-        },
-        "service": {
-            "type": "object",
-            "properties": {
-                "ipFamilies": {
-                    "type": "array"
-                },
-                "ipFamilyPolicy": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "port": {
-                    "type": "integer"
-                },
-                "type": {
-                    "type": "string"
-                }
-            }
-        },
-        "serviceAccount": {
-            "type": "object",
-            "properties": {
-                "create": {
-                    "type": "boolean"
-                },
-                "name": {
-                    "type": "string"
-                }
-            }
-        },
-        "tolerations": {
-            "type": "array"
-        },
-        "topologySpreadConstraints": {
-            "type": "array"
-        },
-        "updateStrategy": {
-            "type": "object"
-        },
-        "webhook": {
-            "type": "object",
-            "properties": {
-                "livenessProbe": {
-                    "type": "object",
-                    "properties": {
-                        "initialDelaySeconds": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                "mutating": {
-                    "type": "object",
-                    "properties": {
-                        "create": {
-                            "type": "boolean"
-                        },
-                        "failurePolicy": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "port": {
-                    "type": "integer"
-                },
-                "readinessProbe": {
-                    "type": "object",
-                    "properties": {
-                        "initialDelaySeconds": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                "startupProbe": {
-                    "type": "object",
-                    "properties": {
-                        "failureThreshold": {
-                            "type": "integer"
-                        },
-                        "periodSeconds": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                "validating": {
-                    "type": "object",
-                    "properties": {
-                        "create": {
-                            "type": "boolean"
-                        },
-                        "failurePolicy": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
+        "secret": {
+          "default": false,
+          "description": "Specifies whether it should be stored in a secret, instead of a configmap.",
+          "title": "secret",
+          "type": "boolean"
         }
+      },
+      "required": [
+        "create",
+        "name",
+        "secret",
+        "clusterWide",
+        "data",
+        "maxConcurrentReconciles"
+      ],
+      "title": "config",
+      "type": "object"
+    },
+    "containerSecurityContext": {
+      "description": "Container Security Context.",
+      "properties": {
+        "allowPrivilegeEscalation": {
+          "default": false,
+          "title": "allowPrivilegeEscalation",
+          "type": "boolean"
+        },
+        "capabilities": {
+          "properties": {
+            "drop": {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  }
+                ],
+                "required": []
+              },
+              "title": "drop",
+              "type": "array"
+            }
+          },
+          "required": [
+            "drop"
+          ],
+          "title": "capabilities",
+          "type": "object"
+        },
+        "readOnlyRootFilesystem": {
+          "default": true,
+          "title": "readOnlyRootFilesystem",
+          "type": "boolean"
+        },
+        "runAsGroup": {
+          "default": 10001,
+          "title": "runAsGroup",
+          "type": "integer"
+        },
+        "runAsUser": {
+          "default": 10001,
+          "title": "runAsUser",
+          "type": "integer"
+        },
+        "seccompProfile": {
+          "properties": {
+            "type": {
+              "default": "RuntimeDefault",
+              "title": "type",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "title": "seccompProfile",
+          "type": "object"
+        }
+      },
+      "required": [
+        "allowPrivilegeEscalation",
+        "readOnlyRootFilesystem",
+        "runAsUser",
+        "runAsGroup",
+        "seccompProfile",
+        "capabilities"
+      ],
+      "title": "containerSecurityContext",
+      "type": "object"
+    },
+    "crds": {
+      "properties": {
+        "create": {
+          "default": true,
+          "description": "Specifies whether the CRDs should be created when installing the chart.",
+          "title": "create",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "create"
+      ],
+      "title": "crds",
+      "type": "object"
+    },
+    "dnsPolicy": {
+      "default": "",
+      "title": "dnsPolicy",
+      "type": "string"
+    },
+    "fullnameOverride": {
+      "default": "",
+      "title": "fullnameOverride",
+      "type": "string"
+    },
+    "global": {
+      "description": "Global values are values that can be accessed from any chart or subchart by exactly the same name.",
+      "required": [],
+      "title": "global",
+      "type": "object"
+    },
+    "hostNetwork": {
+      "default": false,
+      "title": "hostNetwork",
+      "type": "boolean"
+    },
+    "image": {
+      "properties": {
+        "pullPolicy": {
+          "default": "IfNotPresent",
+          "title": "pullPolicy",
+          "type": "string"
+        },
+        "repository": {
+          "default": "ghcr.io/cloudnative-pg/cloudnative-pg",
+          "title": "repository",
+          "type": "string"
+        },
+        "tag": {
+          "default": "",
+          "description": "Overrides the image tag whose default is the chart appVersion.",
+          "title": "tag",
+          "type": "string"
+        }
+      },
+      "required": [
+        "repository",
+        "pullPolicy",
+        "tag"
+      ],
+      "title": "image",
+      "type": "object"
+    },
+    "imagePullSecrets": {
+      "items": {
+        "required": []
+      },
+      "title": "imagePullSecrets",
+      "type": "array"
+    },
+    "monitoring": {
+      "properties": {
+        "grafanaDashboard": {
+          "properties": {
+            "annotations": {
+              "description": "Annotations that ConfigMaps can have to get configured in Grafana.",
+              "required": [],
+              "title": "annotations",
+              "type": "object"
+            },
+            "configMapName": {
+              "default": "cnpg-grafana-dashboard",
+              "description": "The name of the ConfigMap containing the dashboard.",
+              "title": "configMapName",
+              "type": "string"
+            },
+            "create": {
+              "default": false,
+              "title": "create",
+              "type": "boolean"
+            },
+            "labels": {
+              "description": "Labels that ConfigMaps should have to get configured in Grafana.",
+              "required": [],
+              "title": "labels",
+              "type": "object"
+            },
+            "namespace": {
+              "default": "",
+              "description": "Allows overriding the namespace where the ConfigMap will be created, defaulting to the same one as the Release.",
+              "title": "namespace",
+              "type": "string"
+            },
+            "sidecarLabel": {
+              "default": "grafana_dashboard",
+              "description": "Label that ConfigMaps should have to be loaded as dashboards.  DEPRECATED: Use labels instead.",
+              "title": "sidecarLabel",
+              "type": "string"
+            },
+            "sidecarLabelValue": {
+              "default": "1",
+              "description": "Label value that ConfigMaps should have to be loaded as dashboards.  DEPRECATED: Use labels instead.",
+              "title": "sidecarLabelValue",
+              "type": "string"
+            }
+          },
+          "required": [
+            "create",
+            "namespace",
+            "configMapName",
+            "sidecarLabel",
+            "sidecarLabelValue",
+            "labels",
+            "annotations"
+          ],
+          "title": "grafanaDashboard",
+          "type": "object"
+        },
+        "podMonitorAdditionalLabels": {
+          "description": "Additional labels for the podMonitor",
+          "required": [],
+          "title": "podMonitorAdditionalLabels",
+          "type": "object"
+        },
+        "podMonitorEnabled": {
+          "default": false,
+          "description": "Specifies whether the monitoring should be enabled. Requires Prometheus Operator CRDs.",
+          "title": "podMonitorEnabled",
+          "type": "boolean"
+        },
+        "podMonitorMetricRelabelings": {
+          "description": "Metrics relabel configurations to apply to samples before ingestion.",
+          "items": {
+            "required": []
+          },
+          "title": "podMonitorMetricRelabelings",
+          "type": "array"
+        },
+        "podMonitorRelabelings": {
+          "description": "Relabel configurations to apply to samples before scraping.",
+          "items": {
+            "required": []
+          },
+          "title": "podMonitorRelabelings",
+          "type": "array"
+        }
+      },
+      "required": [
+        "podMonitorEnabled",
+        "podMonitorMetricRelabelings",
+        "podMonitorRelabelings",
+        "podMonitorAdditionalLabels",
+        "grafanaDashboard"
+      ],
+      "title": "monitoring",
+      "type": "object"
+    },
+    "monitoringQueriesConfigMap": {
+      "description": "Default monitoring queries",
+      "properties": {
+        "name": {
+          "default": "cnpg-default-monitoring",
+          "description": "The name of the default monitoring configmap.",
+          "title": "name",
+          "type": "string"
+        },
+        "queries": {
+          "default": "backends:\n  query: |\n    SELECT sa.datname\n      , sa.usename\n      , sa.application_name\n      , states.state\n      , COALESCE(sa.count, 0) AS total\n      , COALESCE(sa.max_tx_secs, 0) AS max_tx_duration_seconds\n    FROM ( VALUES ('active')\n      , ('idle')\n      , ('idle in transaction')\n      , ('idle in transaction (aborted)')\n      , ('fastpath function call')\n      , ('disabled')\n      ) AS states(state)\n    LEFT JOIN (\n      SELECT datname\n        , state\n        , usename\n        , COALESCE(application_name, '') AS application_name\n        , pg_catalog.count(*)\n        , COALESCE(EXTRACT (EPOCH FROM (pg_catalog.max(pg_catalog.now() OPERATOR(pg_catalog.-) xact_start))), 0) AS max_tx_secs\n      FROM pg_catalog.pg_stat_activity\n      GROUP BY datname, state, usename, application_name\n    ) sa ON states.state OPERATOR(pg_catalog.=) sa.state\n    WHERE sa.usename IS NOT NULL\n  metrics:\n    - datname:\n        usage: \"LABEL\"\n        description: \"Name of the database\"\n    - usename:\n        usage: \"LABEL\"\n        description: \"Name of the user\"\n    - application_name:\n        usage: \"LABEL\"\n        description: \"Name of the application\"\n    - state:\n        usage: \"LABEL\"\n        description: \"State of the backend\"\n    - total:\n        usage: \"GAUGE\"\n        description: \"Number of backends\"\n    - max_tx_duration_seconds:\n        usage: \"GAUGE\"\n        description: \"Maximum duration of a transaction in seconds\"\n\nbackends_waiting:\n  query: |\n    SELECT pg_catalog.count(*) AS total\n    FROM pg_catalog.pg_locks blocked_locks\n    JOIN pg_catalog.pg_locks blocking_locks\n      ON blocking_locks.locktype OPERATOR(pg_catalog.=) blocked_locks.locktype\n      AND blocking_locks.database IS NOT DISTINCT FROM blocked_locks.database\n      AND blocking_locks.relation IS NOT DISTINCT FROM blocked_locks.relation\n      AND blocking_locks.page IS NOT DISTINCT FROM blocked_locks.page\n      AND blocking_locks.tuple IS NOT DISTINCT FROM blocked_locks.tuple\n      AND blocking_locks.virtualxid IS NOT DISTINCT FROM blocked_locks.virtualxid\n      AND blocking_locks.transactionid IS NOT DISTINCT FROM blocked_locks.transactionid\n      AND blocking_locks.classid IS NOT DISTINCT FROM blocked_locks.classid\n      AND blocking_locks.objid IS NOT DISTINCT FROM blocked_locks.objid\n      AND blocking_locks.objsubid IS NOT DISTINCT FROM blocked_locks.objsubid\n      AND blocking_locks.pid OPERATOR(pg_catalog.\u003c\u003e) blocked_locks.pid\n    JOIN pg_catalog.pg_stat_activity blocking_activity ON blocking_activity.pid OPERATOR(pg_catalog.=) blocking_locks.pid\n    WHERE NOT blocked_locks.granted\n  metrics:\n    - total:\n        usage: \"GAUGE\"\n        description: \"Total number of backends that are currently waiting on other queries\"\n\npg_database:\n  query: |\n    SELECT datname\n      , pg_catalog.pg_database_size(datname) AS size_bytes\n      , pg_catalog.age(datfrozenxid) AS xid_age\n      , pg_catalog.mxid_age(datminmxid) AS mxid_age\n    FROM pg_catalog.pg_database\n    WHERE datallowconn\n  metrics:\n    - datname:\n        usage: \"LABEL\"\n        description: \"Name of the database\"\n    - size_bytes:\n        usage: \"GAUGE\"\n        description: \"Disk space used by the database\"\n    - xid_age:\n        usage: \"GAUGE\"\n        description: \"Number of transactions from the frozen XID to the current one\"\n    - mxid_age:\n        usage: \"GAUGE\"\n        description: \"Number of multiple transactions (Multixact) from the frozen XID to the current one\"\n\npg_postmaster:\n  query: |\n    SELECT EXTRACT(EPOCH FROM pg_postmaster_start_time) AS start_time\n    FROM pg_catalog.pg_postmaster_start_time()\n  metrics:\n    - start_time:\n        usage: \"GAUGE\"\n        description: \"Time at which postgres started (based on epoch)\"\n\npg_replication:\n  query: |\n    SELECT CASE WHEN (\n        NOT pg_catalog.pg_is_in_recovery()\n        OR pg_catalog.pg_last_wal_receive_lsn() OPERATOR(pg_catalog.=) pg_catalog.pg_last_wal_replay_lsn())\n      THEN 0\n      ELSE GREATEST (0,\n        EXTRACT(EPOCH FROM (pg_catalog.now() OPERATOR(pg_catalog.-) pg_catalog.pg_last_xact_replay_timestamp())))\n      END AS lag,\n      pg_catalog.pg_is_in_recovery() AS in_recovery,\n      EXISTS (TABLE pg_catalog.pg_stat_wal_receiver) AS is_wal_receiver_up,\n      (SELECT pg_catalog.count(*) FROM pg_catalog.pg_stat_replication) AS streaming_replicas\n  metrics:\n    - lag:\n        usage: \"GAUGE\"\n        description: \"Replication lag behind primary in seconds\"\n    - in_recovery:\n        usage: \"GAUGE\"\n        description: \"Whether the instance is in recovery\"\n    - is_wal_receiver_up:\n        usage: \"GAUGE\"\n        description: \"Whether the instance wal_receiver is up\"\n    - streaming_replicas:\n        usage: \"GAUGE\"\n        description: \"Number of streaming replicas connected to the instance\"\n\npg_replication_slots:\n  query: |\n    SELECT slot_name,\n      slot_type,\n      database,\n      active,\n      (CASE pg_catalog.pg_is_in_recovery()\n        WHEN TRUE THEN pg_catalog.pg_wal_lsn_diff(pg_catalog.pg_last_wal_receive_lsn(), restart_lsn)\n        ELSE pg_catalog.pg_wal_lsn_diff(pg_catalog.pg_current_wal_lsn(), restart_lsn)\n      END) as pg_wal_lsn_diff\n    FROM pg_catalog.pg_replication_slots\n    WHERE NOT temporary\n  metrics:\n    - slot_name:\n        usage: \"LABEL\"\n        description: \"Name of the replication slot\"\n    - slot_type:\n        usage: \"LABEL\"\n        description: \"Type of the replication slot\"\n    - database:\n        usage: \"LABEL\"\n        description: \"Name of the database\"\n    - active:\n        usage: \"GAUGE\"\n        description: \"Flag indicating whether the slot is active\"\n    - pg_wal_lsn_diff:\n        usage: \"GAUGE\"\n        description: \"Replication lag in bytes\"\n\npg_stat_archiver:\n  query: |\n    SELECT archived_count\n      , failed_count\n      , COALESCE(EXTRACT(EPOCH FROM (pg_catalog.now() OPERATOR(pg_catalog.-) last_archived_time)), -1) AS seconds_since_last_archival\n      , COALESCE(EXTRACT(EPOCH FROM (pg_catalog.now() OPERATOR(pg_catalog.-) last_failed_time)), -1) AS seconds_since_last_failure\n      , COALESCE(EXTRACT(EPOCH FROM last_archived_time), -1) AS last_archived_time\n      , COALESCE(EXTRACT(EPOCH FROM last_failed_time), -1) AS last_failed_time\n      , COALESCE(CAST(CAST('x' OPERATOR(pg_catalog.||) pg_catalog.right(pg_catalog.split_part(last_archived_wal, '.', 1), 16) AS pg_catalog.bit(64)) AS pg_catalog.int8), -1) AS last_archived_wal_start_lsn\n      , COALESCE(CAST(CAST('x' OPERATOR(pg_catalog.||) pg_catalog.right(pg_catalog.split_part(last_failed_wal, '.', 1), 16) AS pg_catalog.bit(64)) AS pg_catalog.int8), -1) AS last_failed_wal_start_lsn\n      , EXTRACT(EPOCH FROM stats_reset) AS stats_reset_time\n    FROM pg_catalog.pg_stat_archiver\n  predicate_query: |\n    SELECT NOT pg_catalog.pg_is_in_recovery()\n      OR pg_catalog.current_setting('archive_mode') OPERATOR(pg_catalog.=) 'always'\n  metrics:\n    - archived_count:\n        usage: \"COUNTER\"\n        description: \"Number of WAL files that have been successfully archived\"\n    - failed_count:\n        usage: \"COUNTER\"\n        description: \"Number of failed attempts for archiving WAL files\"\n    - seconds_since_last_archival:\n        usage: \"GAUGE\"\n        description: \"Seconds since the last successful archival operation\"\n    - seconds_since_last_failure:\n        usage: \"GAUGE\"\n        description: \"Seconds since the last failed archival operation\"\n    - last_archived_time:\n        usage: \"GAUGE\"\n        description: \"Epoch of the last time WAL archiving succeeded\"\n    - last_failed_time:\n        usage: \"GAUGE\"\n        description: \"Epoch of the last time WAL archiving failed\"\n    - last_archived_wal_start_lsn:\n        usage: \"GAUGE\"\n        description: \"Archived WAL start LSN\"\n    - last_failed_wal_start_lsn:\n        usage: \"GAUGE\"\n        description: \"Last failed WAL LSN\"\n    - stats_reset_time:\n        usage: \"GAUGE\"\n        description: \"Time at which these statistics were last reset\"\n\npg_stat_bgwriter:\n  runonserver: \"\u003c17.0.0\"\n  query: |\n    SELECT checkpoints_timed\n      , checkpoints_req\n      , checkpoint_write_time\n      , checkpoint_sync_time\n      , buffers_checkpoint\n      , buffers_clean\n      , maxwritten_clean\n      , buffers_backend\n      , buffers_backend_fsync\n      , buffers_alloc\n    FROM pg_catalog.pg_stat_bgwriter\n  metrics:\n    - checkpoints_timed:\n        usage: \"COUNTER\"\n        description: \"Number of scheduled checkpoints that have been performed\"\n    - checkpoints_req:\n        usage: \"COUNTER\"\n        description: \"Number of requested checkpoints that have been performed\"\n    - checkpoint_write_time:\n        usage: \"COUNTER\"\n        description: \"Total amount of time that has been spent in the portion of checkpoint processing where files are written to disk, in milliseconds\"\n    - checkpoint_sync_time:\n        usage: \"COUNTER\"\n        description: \"Total amount of time that has been spent in the portion of checkpoint processing where files are synchronized to disk, in milliseconds\"\n    - buffers_checkpoint:\n        usage: \"COUNTER\"\n        description: \"Number of buffers written during checkpoints\"\n    - buffers_clean:\n        usage: \"COUNTER\"\n        description: \"Number of buffers written by the background writer\"\n    - maxwritten_clean:\n        usage: \"COUNTER\"\n        description: \"Number of times the background writer stopped a cleaning scan because it had written too many buffers\"\n    - buffers_backend:\n        usage: \"COUNTER\"\n        description: \"Number of buffers written directly by a backend\"\n    - buffers_backend_fsync:\n        usage: \"COUNTER\"\n        description: \"Number of times a backend had to execute its own fsync call (normally the background writer handles those even when the backend does its own write)\"\n    - buffers_alloc:\n        usage: \"COUNTER\"\n        description: \"Number of buffers allocated\"\n\npg_stat_bgwriter_17:\n  runonserver: \"\u003e=17.0.0\"\n  name: pg_stat_bgwriter\n  query: |\n    SELECT buffers_clean\n      , maxwritten_clean\n      , buffers_alloc\n      , EXTRACT(EPOCH FROM stats_reset) AS stats_reset_time\n    FROM pg_catalog.pg_stat_bgwriter\n  metrics:\n    - buffers_clean:\n        usage: \"COUNTER\"\n        description: \"Number of buffers written by the background writer\"\n    - maxwritten_clean:\n        usage: \"COUNTER\"\n        description: \"Number of times the background writer stopped a cleaning scan because it had written too many buffers\"\n    - buffers_alloc:\n        usage: \"COUNTER\"\n        description: \"Number of buffers allocated\"\n    - stats_reset_time:\n        usage: \"GAUGE\"\n        description: \"Time at which these statistics were last reset\"\n\npg_stat_checkpointer:\n  runonserver: \"\u003e=17.0.0\"\n  query: |\n    SELECT num_timed AS checkpoints_timed\n      , num_requested AS checkpoints_req\n      , restartpoints_timed\n      , restartpoints_req\n      , restartpoints_done\n      , write_time\n      , sync_time\n      , buffers_written\n      , EXTRACT(EPOCH FROM stats_reset) AS stats_reset_time\n    FROM pg_catalog.pg_stat_checkpointer\n  metrics:\n    - checkpoints_timed:\n        usage: \"COUNTER\"\n        description: \"Number of scheduled checkpoints that have been performed\"\n    - checkpoints_req:\n        usage: \"COUNTER\"\n        description: \"Number of requested checkpoints that have been performed\"\n    - restartpoints_timed:\n        usage: \"COUNTER\"\n        description: \"Number of scheduled restartpoints due to timeout or after a failed attempt to perform it\"\n    - restartpoints_req:\n        usage: \"COUNTER\"\n        description: \"Number of requested restartpoints that have been performed\"\n    - restartpoints_done:\n        usage: \"COUNTER\"\n        description: \"Number of restartpoints that have been performed\"\n    - write_time:\n        usage: \"COUNTER\"\n        description: \"Total amount of time that has been spent in the portion of processing checkpoints and restartpoints where files are written to disk, in milliseconds\"\n    - sync_time:\n        usage: \"COUNTER\"\n        description: \"Total amount of time that has been spent in the portion of processing checkpoints and restartpoints where files are synchronized to disk, in milliseconds\"\n    - buffers_written:\n        usage: \"COUNTER\"\n        description: \"Number of buffers written during checkpoints and restartpoints\"\n    - stats_reset_time:\n        usage: \"GAUGE\"\n        description: \"Time at which these statistics were last reset\"\n\npg_stat_database:\n  query: |\n    SELECT datname\n      , xact_commit\n      , xact_rollback\n      , blks_read\n      , blks_hit\n      , tup_returned\n      , tup_fetched\n      , tup_inserted\n      , tup_updated\n      , tup_deleted\n      , conflicts\n      , temp_files\n      , temp_bytes\n      , deadlocks\n      , blk_read_time\n      , blk_write_time\n    FROM pg_catalog.pg_stat_database\n  metrics:\n    - datname:\n        usage: \"LABEL\"\n        description: \"Name of this database\"\n    - xact_commit:\n        usage: \"COUNTER\"\n        description: \"Number of transactions in this database that have been committed\"\n    - xact_rollback:\n        usage: \"COUNTER\"\n        description: \"Number of transactions in this database that have been rolled back\"\n    - blks_read:\n        usage: \"COUNTER\"\n        description: \"Number of disk blocks read in this database\"\n    - blks_hit:\n        usage: \"COUNTER\"\n        description: \"Number of times disk blocks were found already in the buffer cache, so that a read was not necessary (this only includes hits in the PostgreSQL buffer cache, not the operating system's file system cache)\"\n    - tup_returned:\n        usage: \"COUNTER\"\n        description: \"Number of rows returned by queries in this database\"\n    - tup_fetched:\n        usage: \"COUNTER\"\n        description: \"Number of rows fetched by queries in this database\"\n    - tup_inserted:\n        usage: \"COUNTER\"\n        description: \"Number of rows inserted by queries in this database\"\n    - tup_updated:\n        usage: \"COUNTER\"\n        description: \"Number of rows updated by queries in this database\"\n    - tup_deleted:\n        usage: \"COUNTER\"\n        description: \"Number of rows deleted by queries in this database\"\n    - conflicts:\n        usage: \"COUNTER\"\n        description: \"Number of queries canceled due to conflicts with recovery in this database\"\n    - temp_files:\n        usage: \"COUNTER\"\n        description: \"Number of temporary files created by queries in this database\"\n    - temp_bytes:\n        usage: \"COUNTER\"\n        description: \"Total amount of data written to temporary files by queries in this database\"\n    - deadlocks:\n        usage: \"COUNTER\"\n        description: \"Number of deadlocks detected in this database\"\n    - blk_read_time:\n        usage: \"COUNTER\"\n        description: \"Time spent reading data file blocks by backends in this database, in milliseconds\"\n    - blk_write_time:\n        usage: \"COUNTER\"\n        description: \"Time spent writing data file blocks by backends in this database, in milliseconds\"\n\npg_stat_replication:\n  primary: true\n  query: |\n    SELECT usename\n      , COALESCE(application_name, '') AS application_name\n      , COALESCE(client_addr::text, '') AS client_addr\n      , COALESCE(client_port::text, '') AS client_port\n      , EXTRACT(EPOCH FROM backend_start) AS backend_start\n      , COALESCE(pg_catalog.age(backend_xmin), 0) AS backend_xmin_age\n      , pg_catalog.pg_wal_lsn_diff(pg_catalog.pg_current_wal_lsn(), sent_lsn) AS sent_diff_bytes\n      , pg_catalog.pg_wal_lsn_diff(pg_catalog.pg_current_wal_lsn(), write_lsn) AS write_diff_bytes\n      , pg_catalog.pg_wal_lsn_diff(pg_catalog.pg_current_wal_lsn(), flush_lsn) AS flush_diff_bytes\n      , COALESCE(pg_catalog.pg_wal_lsn_diff(pg_catalog.pg_current_wal_lsn(), replay_lsn),0) AS replay_diff_bytes\n      , COALESCE((EXTRACT(EPOCH FROM write_lag)),0)::float AS write_lag_seconds\n      , COALESCE((EXTRACT(EPOCH FROM flush_lag)),0)::float AS flush_lag_seconds\n      , COALESCE((EXTRACT(EPOCH FROM replay_lag)),0)::float AS replay_lag_seconds\n    FROM pg_catalog.pg_stat_replication\n  metrics:\n    - usename:\n        usage: \"LABEL\"\n        description: \"Name of the replication user\"\n    - application_name:\n        usage: \"LABEL\"\n        description: \"Name of the application\"\n    - client_addr:\n        usage: \"LABEL\"\n        description: \"Client IP address\"\n    - client_port:\n        usage: \"LABEL\"\n        description: \"Client TCP port\"\n    - backend_start:\n        usage: \"COUNTER\"\n        description: \"Time when this process was started\"\n    - backend_xmin_age:\n        usage: \"COUNTER\"\n        description: \"The age of this standby's xmin horizon\"\n    - sent_diff_bytes:\n        usage: \"GAUGE\"\n        description: \"Difference in bytes from the last write-ahead log location sent on this connection\"\n    - write_diff_bytes:\n        usage: \"GAUGE\"\n        description: \"Difference in bytes from the last write-ahead log location written to disk by this standby server\"\n    - flush_diff_bytes:\n        usage: \"GAUGE\"\n        description: \"Difference in bytes from the last write-ahead log location flushed to disk by this standby server\"\n    - replay_diff_bytes:\n        usage: \"GAUGE\"\n        description: \"Difference in bytes from the last write-ahead log location replayed into the database on this standby server\"\n    - write_lag_seconds:\n        usage: \"GAUGE\"\n        description: \"Time elapsed between flushing recent WAL locally and receiving notification that this standby server has written it\"\n    - flush_lag_seconds:\n        usage: \"GAUGE\"\n        description: \"Time elapsed between flushing recent WAL locally and receiving notification that this standby server has written and flushed it\"\n    - replay_lag_seconds:\n        usage: \"GAUGE\"\n        description: \"Time elapsed between flushing recent WAL locally and receiving notification that this standby server has written, flushed and applied it\"\n\npg_settings:\n  query: |\n    SELECT name,\n    CASE setting WHEN 'on' THEN '1' WHEN 'off' THEN '0' ELSE setting END AS setting\n    FROM pg_catalog.pg_settings\n    WHERE vartype IN ('integer', 'real', 'bool')\n    ORDER BY 1\n  metrics:\n    - name:\n        usage: \"LABEL\"\n        description: \"Name of the setting\"\n    - setting:\n        usage: \"GAUGE\"\n        description: \"Setting value\"\n\npg_extensions:\n  query: |\n    SELECT\n      pg_catalog.current_database() as datname,\n      name as extname,\n      default_version,\n      installed_version,\n      CASE\n        WHEN default_version OPERATOR(pg_catalog.=) installed_version THEN 0\n        ELSE 1\n    END AS update_available\n    FROM pg_catalog.pg_available_extensions\n    WHERE installed_version IS NOT NULL\n  metrics:\n    - datname:\n        usage: \"LABEL\"\n        description: \"Name of the database\"\n    - extname:\n        usage: \"LABEL\"\n        description: \"Extension name\"\n    - default_version:\n        usage: \"LABEL\"\n        description: \"Default version\"\n    - installed_version:\n        usage: \"LABEL\"\n        description: \"Installed version\"\n    - update_available:\n        usage: \"GAUGE\"\n        description: \"An update is available\"\n  target_databases:\n    - '*'\n",
+          "description": "A string representation of a YAML defining monitoring queries.",
+          "title": "queries",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "queries"
+      ],
+      "title": "monitoringQueriesConfigMap",
+      "type": "object"
+    },
+    "nameOverride": {
+      "default": "",
+      "title": "nameOverride",
+      "type": "string"
+    },
+    "namespaceOverride": {
+      "default": "",
+      "title": "namespaceOverride",
+      "type": "string"
+    },
+    "nodeSelector": {
+      "description": "Nodeselector for the operator to be installed.",
+      "required": [],
+      "title": "nodeSelector",
+      "type": "object"
+    },
+    "podAnnotations": {
+      "description": "Annotations to be added to the pod.",
+      "required": [],
+      "title": "podAnnotations",
+      "type": "object"
+    },
+    "podLabels": {
+      "description": "Labels to be added to the pod.",
+      "required": [],
+      "title": "podLabels",
+      "type": "object"
+    },
+    "podSecurityContext": {
+      "description": "Security Context for the whole pod.",
+      "properties": {
+        "runAsNonRoot": {
+          "default": true,
+          "title": "runAsNonRoot",
+          "type": "boolean"
+        },
+        "seccompProfile": {
+          "properties": {
+            "type": {
+              "default": "RuntimeDefault",
+              "title": "type",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "title": "seccompProfile",
+          "type": "object"
+        }
+      },
+      "required": [
+        "runAsNonRoot",
+        "seccompProfile"
+      ],
+      "title": "podSecurityContext",
+      "type": "object"
+    },
+    "priorityClassName": {
+      "default": "",
+      "description": "Priority indicates the importance of a Pod relative to other Pods.",
+      "title": "priorityClassName",
+      "type": "string"
+    },
+    "rbac": {
+      "properties": {
+        "aggregateClusterRoles": {
+          "default": false,
+          "description": "Aggregate ClusterRoles to Kubernetes default user-facing roles.\nRef: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles",
+          "title": "aggregateClusterRoles",
+          "type": "boolean"
+        },
+        "create": {
+          "default": true,
+          "description": "Specifies whether ClusterRole and ClusterRoleBinding should be created.",
+          "title": "create",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "create",
+        "aggregateClusterRoles"
+      ],
+      "title": "rbac",
+      "type": "object"
+    },
+    "replicaCount": {
+      "default": 1,
+      "title": "replicaCount",
+      "type": "integer"
+    },
+    "resources": {
+      "required": [],
+      "title": "resources",
+      "type": "object"
+    },
+    "service": {
+      "properties": {
+        "ipFamilies": {
+          "description": "Sets the families that should be supported and the order in which they should be applied to ClusterIP as well. Can be IPv4 and/or IPv6.",
+          "items": {
+            "required": []
+          },
+          "title": "ipFamilies",
+          "type": "array"
+        },
+        "ipFamilyPolicy": {
+          "default": "",
+          "description": "Set the ip family policy to configure dual-stack see [Configure dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services)",
+          "title": "ipFamilyPolicy",
+          "type": "string"
+        },
+        "name": {
+          "default": "cnpg-webhook-service",
+          "description": "DO NOT CHANGE THE SERVICE NAME as it is currently used to generate the certificate\nand can not be configured",
+          "title": "name",
+          "type": "string"
+        },
+        "port": {
+          "default": 443,
+          "title": "port",
+          "type": "integer"
+        },
+        "type": {
+          "default": "ClusterIP",
+          "title": "type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "name",
+        "port",
+        "ipFamilyPolicy",
+        "ipFamilies"
+      ],
+      "title": "service",
+      "type": "object"
+    },
+    "serviceAccount": {
+      "properties": {
+        "create": {
+          "default": true,
+          "description": "Specifies whether the service account should be created.",
+          "title": "create",
+          "type": "boolean"
+        },
+        "name": {
+          "default": "",
+          "description": "The name of the service account to use.\nIf not set and create is true, a name is generated using the fullname template.",
+          "title": "name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "create",
+        "name"
+      ],
+      "title": "serviceAccount",
+      "type": "object"
+    },
+    "tolerations": {
+      "description": "Tolerations for the operator to be installed.",
+      "items": {
+        "required": []
+      },
+      "title": "tolerations",
+      "type": "array"
+    },
+    "topologySpreadConstraints": {
+      "description": "Topology Spread Constraints for the operator to be installed.",
+      "items": {
+        "required": []
+      },
+      "title": "topologySpreadConstraints",
+      "type": "array"
+    },
+    "updateStrategy": {
+      "description": "Update strategy for the operator.\nref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy\nFor example:\n type: RollingUpdate\n rollingUpdate:\n   maxSurge: 25%\n   maxUnavailable: 25%",
+      "required": [],
+      "title": "updateStrategy",
+      "type": "object"
+    },
+    "webhook": {
+      "description": "The webhook configuration.",
+      "properties": {
+        "livenessProbe": {
+          "properties": {
+            "initialDelaySeconds": {
+              "default": 3,
+              "title": "initialDelaySeconds",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "initialDelaySeconds"
+          ],
+          "title": "livenessProbe",
+          "type": "object"
+        },
+        "mutating": {
+          "properties": {
+            "create": {
+              "default": true,
+              "title": "create",
+              "type": "boolean"
+            },
+            "failurePolicy": {
+              "default": "Fail",
+              "title": "failurePolicy",
+              "type": "string"
+            }
+          },
+          "required": [
+            "create",
+            "failurePolicy"
+          ],
+          "title": "mutating",
+          "type": "object"
+        },
+        "port": {
+          "default": 9443,
+          "title": "port",
+          "type": "integer"
+        },
+        "readinessProbe": {
+          "properties": {
+            "initialDelaySeconds": {
+              "default": 3,
+              "title": "initialDelaySeconds",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "initialDelaySeconds"
+          ],
+          "title": "readinessProbe",
+          "type": "object"
+        },
+        "startupProbe": {
+          "properties": {
+            "failureThreshold": {
+              "default": 6,
+              "title": "failureThreshold",
+              "type": "integer"
+            },
+            "periodSeconds": {
+              "default": 5,
+              "title": "periodSeconds",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "failureThreshold",
+            "periodSeconds"
+          ],
+          "title": "startupProbe",
+          "type": "object"
+        },
+        "validating": {
+          "properties": {
+            "create": {
+              "default": true,
+              "title": "create",
+              "type": "boolean"
+            },
+            "failurePolicy": {
+              "default": "Fail",
+              "title": "failurePolicy",
+              "type": "string"
+            }
+          },
+          "required": [
+            "create",
+            "failurePolicy"
+          ],
+          "title": "validating",
+          "type": "object"
+        }
+      },
+      "required": [
+        "port",
+        "mutating",
+        "validating",
+        "livenessProbe",
+        "readinessProbe",
+        "startupProbe"
+      ],
+      "title": "webhook",
+      "type": "object"
     }
+  },
+  "required": [
+    "replicaCount",
+    "image",
+    "imagePullSecrets",
+    "nameOverride",
+    "fullnameOverride",
+    "namespaceOverride",
+    "hostNetwork",
+    "dnsPolicy",
+    "updateStrategy",
+    "crds",
+    "webhook",
+    "config",
+    "additionalArgs",
+    "additionalEnv",
+    "serviceAccount",
+    "rbac",
+    "commonAnnotations",
+    "podAnnotations",
+    "podLabels",
+    "containerSecurityContext",
+    "podSecurityContext",
+    "priorityClassName",
+    "service",
+    "resources",
+    "nodeSelector",
+    "topologySpreadConstraints",
+    "tolerations",
+    "affinity",
+    "monitoring",
+    "monitoringQueriesConfigMap"
+  ],
+  "type": "object"
 }

--- a/charts/cloudnative-pg/values.schema.json
+++ b/charts/cloudnative-pg/values.schema.json
@@ -6,54 +6,57 @@
       "items": {
         "required": []
       },
-      "required": []
+      "type": "array"
     },
     "additionalEnv": {
-      "description": "Array containing extra environment variables which can be templated. For example:  - name: RELEASE_NAME    value: \"{{ .Release.Name }}\"  - name: MY_VAR    value: \"mySpecialKey\"",
+      "description": "Array containing extra environment variables which can be templated.\nFor example:\n - name: RELEASE_NAME\n   value: \"{{ .Release.Name }}\"\n - name: MY_VAR\n   value: \"mySpecialKey\"",
       "items": {
         "required": []
       },
-      "required": []
+      "type": "array"
     },
     "affinity": {
       "description": "Affinity for the operator to be installed.",
-      "required": []
+      "required": [],
+      "type": "object"
     },
     "commonAnnotations": {
       "description": "Annotations to be added to all other resources.",
-      "required": []
+      "required": [],
+      "type": "object"
     },
     "config": {
       "description": "Operator configuration.",
       "properties": {
         "clusterWide": {
-          "default": "true",
-          "description": "This option determines if the operator is responsible for observing events across the entire Kubernetes cluster or if its focus should be narrowed down to the specific namespace within which it has been deployed.",
-          "required": []
+          "default": true,
+          "description": "This option determines if the operator is responsible for observing\nevents across the entire Kubernetes cluster or if its focus should be\nnarrowed down to the specific namespace within which it has been deployed.",
+          "type": "boolean"
         },
         "create": {
-          "default": "true",
+          "default": true,
           "description": "Specifies whether the secret should be created.",
-          "required": []
+          "type": "boolean"
         },
         "data": {
-          "description": "The content of the configmap/secret, see https://cloudnative-pg.io/documentation/current/operator_conf/#available-options for all the available options.",
-          "required": []
+          "description": "The content of the configmap/secret, see\nhttps://cloudnative-pg.io/documentation/current/operator_conf/#available-options\nfor all the available options.",
+          "required": [],
+          "type": "object"
         },
         "maxConcurrentReconciles": {
-          "default": "10",
+          "default": 10,
           "description": "The maximum number of concurrent reconciles. Defaults to 10.",
-          "required": []
+          "type": "integer"
         },
         "name": {
           "default": "cnpg-controller-manager-config",
           "description": "The name of the configmap/secret to use.",
-          "required": []
+          "type": "string"
         },
         "secret": {
-          "default": "false",
+          "default": false,
           "description": "Specifies whether it should be stored in a secret, instead of a configmap.",
-          "required": []
+          "type": "boolean"
         }
       },
       "required": [],
@@ -106,14 +109,15 @@
           "type": "object"
         }
       },
-      "required": []
+      "required": [],
+      "type": "object"
     },
     "crds": {
       "properties": {
         "create": {
-          "default": "true",
+          "default": true,
           "description": "Specifies whether the CRDs should be created when installing the chart.",
-          "required": []
+          "type": "boolean"
         }
       },
       "required": [],
@@ -149,7 +153,7 @@
         "tag": {
           "default": "",
           "description": "Overrides the image tag whose default is the chart appVersion.",
-          "required": []
+          "type": "string"
         }
       },
       "required": [],
@@ -167,12 +171,13 @@
           "properties": {
             "annotations": {
               "description": "Annotations that ConfigMaps can have to get configured in Grafana.",
-              "required": []
+              "required": [],
+              "type": "object"
             },
             "configMapName": {
               "default": "cnpg-grafana-dashboard",
               "description": "The name of the ConfigMap containing the dashboard.",
-              "required": []
+              "type": "string"
             },
             "create": {
               "default": false,
@@ -180,22 +185,23 @@
             },
             "labels": {
               "description": "Labels that ConfigMaps should have to get configured in Grafana.",
-              "required": []
+              "required": [],
+              "type": "object"
             },
             "namespace": {
               "default": "",
               "description": "Allows overriding the namespace where the ConfigMap will be created, defaulting to the same one as the Release.",
-              "required": []
+              "type": "string"
             },
             "sidecarLabel": {
               "default": "grafana_dashboard",
               "description": "Label that ConfigMaps should have to be loaded as dashboards.  DEPRECATED: Use labels instead.",
-              "required": []
+              "type": "string"
             },
             "sidecarLabelValue": {
               "default": "1",
               "description": "Label value that ConfigMaps should have to be loaded as dashboards.  DEPRECATED: Use labels instead.",
-              "required": []
+              "type": "string"
             }
           },
           "required": [],
@@ -203,26 +209,27 @@
         },
         "podMonitorAdditionalLabels": {
           "description": "Additional labels for the podMonitor",
-          "required": []
+          "required": [],
+          "type": "object"
         },
         "podMonitorEnabled": {
-          "default": "false",
+          "default": false,
           "description": "Specifies whether the monitoring should be enabled. Requires Prometheus Operator CRDs.",
-          "required": []
+          "type": "boolean"
         },
         "podMonitorMetricRelabelings": {
           "description": "Metrics relabel configurations to apply to samples before ingestion.",
           "items": {
             "required": []
           },
-          "required": []
+          "type": "array"
         },
         "podMonitorRelabelings": {
           "description": "Relabel configurations to apply to samples before scraping.",
           "items": {
             "required": []
           },
-          "required": []
+          "type": "array"
         }
       },
       "required": [],
@@ -234,12 +241,12 @@
         "name": {
           "default": "cnpg-default-monitoring",
           "description": "The name of the default monitoring configmap.",
-          "required": []
+          "type": "string"
         },
         "queries": {
           "default": "backends:\n  query: |\n    SELECT sa.datname\n      , sa.usename\n      , sa.application_name\n      , states.state\n      , COALESCE(sa.count, 0) AS total\n      , COALESCE(sa.max_tx_secs, 0) AS max_tx_duration_seconds\n    FROM ( VALUES ('active')\n      , ('idle')\n      , ('idle in transaction')\n      , ('idle in transaction (aborted)')\n      , ('fastpath function call')\n      , ('disabled')\n      ) AS states(state)\n    LEFT JOIN (\n      SELECT datname\n        , state\n        , usename\n        , COALESCE(application_name, '') AS application_name\n        , pg_catalog.count(*)\n        , COALESCE(EXTRACT (EPOCH FROM (pg_catalog.max(pg_catalog.now() OPERATOR(pg_catalog.-) xact_start))), 0) AS max_tx_secs\n      FROM pg_catalog.pg_stat_activity\n      GROUP BY datname, state, usename, application_name\n    ) sa ON states.state OPERATOR(pg_catalog.=) sa.state\n    WHERE sa.usename IS NOT NULL\n  metrics:\n    - datname:\n        usage: \"LABEL\"\n        description: \"Name of the database\"\n    - usename:\n        usage: \"LABEL\"\n        description: \"Name of the user\"\n    - application_name:\n        usage: \"LABEL\"\n        description: \"Name of the application\"\n    - state:\n        usage: \"LABEL\"\n        description: \"State of the backend\"\n    - total:\n        usage: \"GAUGE\"\n        description: \"Number of backends\"\n    - max_tx_duration_seconds:\n        usage: \"GAUGE\"\n        description: \"Maximum duration of a transaction in seconds\"\n\nbackends_waiting:\n  query: |\n    SELECT pg_catalog.count(*) AS total\n    FROM pg_catalog.pg_locks blocked_locks\n    JOIN pg_catalog.pg_locks blocking_locks\n      ON blocking_locks.locktype OPERATOR(pg_catalog.=) blocked_locks.locktype\n      AND blocking_locks.database IS NOT DISTINCT FROM blocked_locks.database\n      AND blocking_locks.relation IS NOT DISTINCT FROM blocked_locks.relation\n      AND blocking_locks.page IS NOT DISTINCT FROM blocked_locks.page\n      AND blocking_locks.tuple IS NOT DISTINCT FROM blocked_locks.tuple\n      AND blocking_locks.virtualxid IS NOT DISTINCT FROM blocked_locks.virtualxid\n      AND blocking_locks.transactionid IS NOT DISTINCT FROM blocked_locks.transactionid\n      AND blocking_locks.classid IS NOT DISTINCT FROM blocked_locks.classid\n      AND blocking_locks.objid IS NOT DISTINCT FROM blocked_locks.objid\n      AND blocking_locks.objsubid IS NOT DISTINCT FROM blocked_locks.objsubid\n      AND blocking_locks.pid OPERATOR(pg_catalog.\u003c\u003e) blocked_locks.pid\n    JOIN pg_catalog.pg_stat_activity blocking_activity ON blocking_activity.pid OPERATOR(pg_catalog.=) blocking_locks.pid\n    WHERE NOT blocked_locks.granted\n  metrics:\n    - total:\n        usage: \"GAUGE\"\n        description: \"Total number of backends that are currently waiting on other queries\"\n\npg_database:\n  query: |\n    SELECT datname\n      , pg_catalog.pg_database_size(datname) AS size_bytes\n      , pg_catalog.age(datfrozenxid) AS xid_age\n      , pg_catalog.mxid_age(datminmxid) AS mxid_age\n    FROM pg_catalog.pg_database\n    WHERE datallowconn\n  metrics:\n    - datname:\n        usage: \"LABEL\"\n        description: \"Name of the database\"\n    - size_bytes:\n        usage: \"GAUGE\"\n        description: \"Disk space used by the database\"\n    - xid_age:\n        usage: \"GAUGE\"\n        description: \"Number of transactions from the frozen XID to the current one\"\n    - mxid_age:\n        usage: \"GAUGE\"\n        description: \"Number of multiple transactions (Multixact) from the frozen XID to the current one\"\n\npg_postmaster:\n  query: |\n    SELECT EXTRACT(EPOCH FROM pg_postmaster_start_time) AS start_time\n    FROM pg_catalog.pg_postmaster_start_time()\n  metrics:\n    - start_time:\n        usage: \"GAUGE\"\n        description: \"Time at which postgres started (based on epoch)\"\n\npg_replication:\n  query: |\n    SELECT CASE WHEN (\n        NOT pg_catalog.pg_is_in_recovery()\n        OR pg_catalog.pg_last_wal_receive_lsn() OPERATOR(pg_catalog.=) pg_catalog.pg_last_wal_replay_lsn())\n      THEN 0\n      ELSE GREATEST (0,\n        EXTRACT(EPOCH FROM (pg_catalog.now() OPERATOR(pg_catalog.-) pg_catalog.pg_last_xact_replay_timestamp())))\n      END AS lag,\n      pg_catalog.pg_is_in_recovery() AS in_recovery,\n      EXISTS (TABLE pg_catalog.pg_stat_wal_receiver) AS is_wal_receiver_up,\n      (SELECT pg_catalog.count(*) FROM pg_catalog.pg_stat_replication) AS streaming_replicas\n  metrics:\n    - lag:\n        usage: \"GAUGE\"\n        description: \"Replication lag behind primary in seconds\"\n    - in_recovery:\n        usage: \"GAUGE\"\n        description: \"Whether the instance is in recovery\"\n    - is_wal_receiver_up:\n        usage: \"GAUGE\"\n        description: \"Whether the instance wal_receiver is up\"\n    - streaming_replicas:\n        usage: \"GAUGE\"\n        description: \"Number of streaming replicas connected to the instance\"\n\npg_replication_slots:\n  query: |\n    SELECT slot_name,\n      slot_type,\n      database,\n      active,\n      (CASE pg_catalog.pg_is_in_recovery()\n        WHEN TRUE THEN pg_catalog.pg_wal_lsn_diff(pg_catalog.pg_last_wal_receive_lsn(), restart_lsn)\n        ELSE pg_catalog.pg_wal_lsn_diff(pg_catalog.pg_current_wal_lsn(), restart_lsn)\n      END) as pg_wal_lsn_diff\n    FROM pg_catalog.pg_replication_slots\n    WHERE NOT temporary\n  metrics:\n    - slot_name:\n        usage: \"LABEL\"\n        description: \"Name of the replication slot\"\n    - slot_type:\n        usage: \"LABEL\"\n        description: \"Type of the replication slot\"\n    - database:\n        usage: \"LABEL\"\n        description: \"Name of the database\"\n    - active:\n        usage: \"GAUGE\"\n        description: \"Flag indicating whether the slot is active\"\n    - pg_wal_lsn_diff:\n        usage: \"GAUGE\"\n        description: \"Replication lag in bytes\"\n\npg_stat_archiver:\n  query: |\n    SELECT archived_count\n      , failed_count\n      , COALESCE(EXTRACT(EPOCH FROM (pg_catalog.now() OPERATOR(pg_catalog.-) last_archived_time)), -1) AS seconds_since_last_archival\n      , COALESCE(EXTRACT(EPOCH FROM (pg_catalog.now() OPERATOR(pg_catalog.-) last_failed_time)), -1) AS seconds_since_last_failure\n      , COALESCE(EXTRACT(EPOCH FROM last_archived_time), -1) AS last_archived_time\n      , COALESCE(EXTRACT(EPOCH FROM last_failed_time), -1) AS last_failed_time\n      , COALESCE(CAST(CAST('x' OPERATOR(pg_catalog.||) pg_catalog.right(pg_catalog.split_part(last_archived_wal, '.', 1), 16) AS pg_catalog.bit(64)) AS pg_catalog.int8), -1) AS last_archived_wal_start_lsn\n      , COALESCE(CAST(CAST('x' OPERATOR(pg_catalog.||) pg_catalog.right(pg_catalog.split_part(last_failed_wal, '.', 1), 16) AS pg_catalog.bit(64)) AS pg_catalog.int8), -1) AS last_failed_wal_start_lsn\n      , EXTRACT(EPOCH FROM stats_reset) AS stats_reset_time\n    FROM pg_catalog.pg_stat_archiver\n  predicate_query: |\n    SELECT NOT pg_catalog.pg_is_in_recovery()\n      OR pg_catalog.current_setting('archive_mode') OPERATOR(pg_catalog.=) 'always'\n  metrics:\n    - archived_count:\n        usage: \"COUNTER\"\n        description: \"Number of WAL files that have been successfully archived\"\n    - failed_count:\n        usage: \"COUNTER\"\n        description: \"Number of failed attempts for archiving WAL files\"\n    - seconds_since_last_archival:\n        usage: \"GAUGE\"\n        description: \"Seconds since the last successful archival operation\"\n    - seconds_since_last_failure:\n        usage: \"GAUGE\"\n        description: \"Seconds since the last failed archival operation\"\n    - last_archived_time:\n        usage: \"GAUGE\"\n        description: \"Epoch of the last time WAL archiving succeeded\"\n    - last_failed_time:\n        usage: \"GAUGE\"\n        description: \"Epoch of the last time WAL archiving failed\"\n    - last_archived_wal_start_lsn:\n        usage: \"GAUGE\"\n        description: \"Archived WAL start LSN\"\n    - last_failed_wal_start_lsn:\n        usage: \"GAUGE\"\n        description: \"Last failed WAL LSN\"\n    - stats_reset_time:\n        usage: \"GAUGE\"\n        description: \"Time at which these statistics were last reset\"\n\npg_stat_bgwriter:\n  runonserver: \"\u003c17.0.0\"\n  query: |\n    SELECT checkpoints_timed\n      , checkpoints_req\n      , checkpoint_write_time\n      , checkpoint_sync_time\n      , buffers_checkpoint\n      , buffers_clean\n      , maxwritten_clean\n      , buffers_backend\n      , buffers_backend_fsync\n      , buffers_alloc\n    FROM pg_catalog.pg_stat_bgwriter\n  metrics:\n    - checkpoints_timed:\n        usage: \"COUNTER\"\n        description: \"Number of scheduled checkpoints that have been performed\"\n    - checkpoints_req:\n        usage: \"COUNTER\"\n        description: \"Number of requested checkpoints that have been performed\"\n    - checkpoint_write_time:\n        usage: \"COUNTER\"\n        description: \"Total amount of time that has been spent in the portion of checkpoint processing where files are written to disk, in milliseconds\"\n    - checkpoint_sync_time:\n        usage: \"COUNTER\"\n        description: \"Total amount of time that has been spent in the portion of checkpoint processing where files are synchronized to disk, in milliseconds\"\n    - buffers_checkpoint:\n        usage: \"COUNTER\"\n        description: \"Number of buffers written during checkpoints\"\n    - buffers_clean:\n        usage: \"COUNTER\"\n        description: \"Number of buffers written by the background writer\"\n    - maxwritten_clean:\n        usage: \"COUNTER\"\n        description: \"Number of times the background writer stopped a cleaning scan because it had written too many buffers\"\n    - buffers_backend:\n        usage: \"COUNTER\"\n        description: \"Number of buffers written directly by a backend\"\n    - buffers_backend_fsync:\n        usage: \"COUNTER\"\n        description: \"Number of times a backend had to execute its own fsync call (normally the background writer handles those even when the backend does its own write)\"\n    - buffers_alloc:\n        usage: \"COUNTER\"\n        description: \"Number of buffers allocated\"\n\npg_stat_bgwriter_17:\n  runonserver: \"\u003e=17.0.0\"\n  name: pg_stat_bgwriter\n  query: |\n    SELECT buffers_clean\n      , maxwritten_clean\n      , buffers_alloc\n      , EXTRACT(EPOCH FROM stats_reset) AS stats_reset_time\n    FROM pg_catalog.pg_stat_bgwriter\n  metrics:\n    - buffers_clean:\n        usage: \"COUNTER\"\n        description: \"Number of buffers written by the background writer\"\n    - maxwritten_clean:\n        usage: \"COUNTER\"\n        description: \"Number of times the background writer stopped a cleaning scan because it had written too many buffers\"\n    - buffers_alloc:\n        usage: \"COUNTER\"\n        description: \"Number of buffers allocated\"\n    - stats_reset_time:\n        usage: \"GAUGE\"\n        description: \"Time at which these statistics were last reset\"\n\npg_stat_checkpointer:\n  runonserver: \"\u003e=17.0.0\"\n  query: |\n    SELECT num_timed AS checkpoints_timed\n      , num_requested AS checkpoints_req\n      , restartpoints_timed\n      , restartpoints_req\n      , restartpoints_done\n      , write_time\n      , sync_time\n      , buffers_written\n      , EXTRACT(EPOCH FROM stats_reset) AS stats_reset_time\n    FROM pg_catalog.pg_stat_checkpointer\n  metrics:\n    - checkpoints_timed:\n        usage: \"COUNTER\"\n        description: \"Number of scheduled checkpoints that have been performed\"\n    - checkpoints_req:\n        usage: \"COUNTER\"\n        description: \"Number of requested checkpoints that have been performed\"\n    - restartpoints_timed:\n        usage: \"COUNTER\"\n        description: \"Number of scheduled restartpoints due to timeout or after a failed attempt to perform it\"\n    - restartpoints_req:\n        usage: \"COUNTER\"\n        description: \"Number of requested restartpoints that have been performed\"\n    - restartpoints_done:\n        usage: \"COUNTER\"\n        description: \"Number of restartpoints that have been performed\"\n    - write_time:\n        usage: \"COUNTER\"\n        description: \"Total amount of time that has been spent in the portion of processing checkpoints and restartpoints where files are written to disk, in milliseconds\"\n    - sync_time:\n        usage: \"COUNTER\"\n        description: \"Total amount of time that has been spent in the portion of processing checkpoints and restartpoints where files are synchronized to disk, in milliseconds\"\n    - buffers_written:\n        usage: \"COUNTER\"\n        description: \"Number of buffers written during checkpoints and restartpoints\"\n    - stats_reset_time:\n        usage: \"GAUGE\"\n        description: \"Time at which these statistics were last reset\"\n\npg_stat_database:\n  query: |\n    SELECT datname\n      , xact_commit\n      , xact_rollback\n      , blks_read\n      , blks_hit\n      , tup_returned\n      , tup_fetched\n      , tup_inserted\n      , tup_updated\n      , tup_deleted\n      , conflicts\n      , temp_files\n      , temp_bytes\n      , deadlocks\n      , blk_read_time\n      , blk_write_time\n    FROM pg_catalog.pg_stat_database\n  metrics:\n    - datname:\n        usage: \"LABEL\"\n        description: \"Name of this database\"\n    - xact_commit:\n        usage: \"COUNTER\"\n        description: \"Number of transactions in this database that have been committed\"\n    - xact_rollback:\n        usage: \"COUNTER\"\n        description: \"Number of transactions in this database that have been rolled back\"\n    - blks_read:\n        usage: \"COUNTER\"\n        description: \"Number of disk blocks read in this database\"\n    - blks_hit:\n        usage: \"COUNTER\"\n        description: \"Number of times disk blocks were found already in the buffer cache, so that a read was not necessary (this only includes hits in the PostgreSQL buffer cache, not the operating system's file system cache)\"\n    - tup_returned:\n        usage: \"COUNTER\"\n        description: \"Number of rows returned by queries in this database\"\n    - tup_fetched:\n        usage: \"COUNTER\"\n        description: \"Number of rows fetched by queries in this database\"\n    - tup_inserted:\n        usage: \"COUNTER\"\n        description: \"Number of rows inserted by queries in this database\"\n    - tup_updated:\n        usage: \"COUNTER\"\n        description: \"Number of rows updated by queries in this database\"\n    - tup_deleted:\n        usage: \"COUNTER\"\n        description: \"Number of rows deleted by queries in this database\"\n    - conflicts:\n        usage: \"COUNTER\"\n        description: \"Number of queries canceled due to conflicts with recovery in this database\"\n    - temp_files:\n        usage: \"COUNTER\"\n        description: \"Number of temporary files created by queries in this database\"\n    - temp_bytes:\n        usage: \"COUNTER\"\n        description: \"Total amount of data written to temporary files by queries in this database\"\n    - deadlocks:\n        usage: \"COUNTER\"\n        description: \"Number of deadlocks detected in this database\"\n    - blk_read_time:\n        usage: \"COUNTER\"\n        description: \"Time spent reading data file blocks by backends in this database, in milliseconds\"\n    - blk_write_time:\n        usage: \"COUNTER\"\n        description: \"Time spent writing data file blocks by backends in this database, in milliseconds\"\n\npg_stat_replication:\n  primary: true\n  query: |\n    SELECT usename\n      , COALESCE(application_name, '') AS application_name\n      , COALESCE(client_addr::text, '') AS client_addr\n      , COALESCE(client_port::text, '') AS client_port\n      , EXTRACT(EPOCH FROM backend_start) AS backend_start\n      , COALESCE(pg_catalog.age(backend_xmin), 0) AS backend_xmin_age\n      , pg_catalog.pg_wal_lsn_diff(pg_catalog.pg_current_wal_lsn(), sent_lsn) AS sent_diff_bytes\n      , pg_catalog.pg_wal_lsn_diff(pg_catalog.pg_current_wal_lsn(), write_lsn) AS write_diff_bytes\n      , pg_catalog.pg_wal_lsn_diff(pg_catalog.pg_current_wal_lsn(), flush_lsn) AS flush_diff_bytes\n      , COALESCE(pg_catalog.pg_wal_lsn_diff(pg_catalog.pg_current_wal_lsn(), replay_lsn),0) AS replay_diff_bytes\n      , COALESCE((EXTRACT(EPOCH FROM write_lag)),0)::float AS write_lag_seconds\n      , COALESCE((EXTRACT(EPOCH FROM flush_lag)),0)::float AS flush_lag_seconds\n      , COALESCE((EXTRACT(EPOCH FROM replay_lag)),0)::float AS replay_lag_seconds\n    FROM pg_catalog.pg_stat_replication\n  metrics:\n    - usename:\n        usage: \"LABEL\"\n        description: \"Name of the replication user\"\n    - application_name:\n        usage: \"LABEL\"\n        description: \"Name of the application\"\n    - client_addr:\n        usage: \"LABEL\"\n        description: \"Client IP address\"\n    - client_port:\n        usage: \"LABEL\"\n        description: \"Client TCP port\"\n    - backend_start:\n        usage: \"COUNTER\"\n        description: \"Time when this process was started\"\n    - backend_xmin_age:\n        usage: \"COUNTER\"\n        description: \"The age of this standby's xmin horizon\"\n    - sent_diff_bytes:\n        usage: \"GAUGE\"\n        description: \"Difference in bytes from the last write-ahead log location sent on this connection\"\n    - write_diff_bytes:\n        usage: \"GAUGE\"\n        description: \"Difference in bytes from the last write-ahead log location written to disk by this standby server\"\n    - flush_diff_bytes:\n        usage: \"GAUGE\"\n        description: \"Difference in bytes from the last write-ahead log location flushed to disk by this standby server\"\n    - replay_diff_bytes:\n        usage: \"GAUGE\"\n        description: \"Difference in bytes from the last write-ahead log location replayed into the database on this standby server\"\n    - write_lag_seconds:\n        usage: \"GAUGE\"\n        description: \"Time elapsed between flushing recent WAL locally and receiving notification that this standby server has written it\"\n    - flush_lag_seconds:\n        usage: \"GAUGE\"\n        description: \"Time elapsed between flushing recent WAL locally and receiving notification that this standby server has written and flushed it\"\n    - replay_lag_seconds:\n        usage: \"GAUGE\"\n        description: \"Time elapsed between flushing recent WAL locally and receiving notification that this standby server has written, flushed and applied it\"\n\npg_settings:\n  query: |\n    SELECT name,\n    CASE setting WHEN 'on' THEN '1' WHEN 'off' THEN '0' ELSE setting END AS setting\n    FROM pg_catalog.pg_settings\n    WHERE vartype IN ('integer', 'real', 'bool')\n    ORDER BY 1\n  metrics:\n    - name:\n        usage: \"LABEL\"\n        description: \"Name of the setting\"\n    - setting:\n        usage: \"GAUGE\"\n        description: \"Setting value\"\n\npg_extensions:\n  query: |\n    SELECT\n      pg_catalog.current_database() as datname,\n      name as extname,\n      default_version,\n      installed_version,\n      CASE\n        WHEN default_version OPERATOR(pg_catalog.=) installed_version THEN 0\n        ELSE 1\n    END AS update_available\n    FROM pg_catalog.pg_available_extensions\n    WHERE installed_version IS NOT NULL\n  metrics:\n    - datname:\n        usage: \"LABEL\"\n        description: \"Name of the database\"\n    - extname:\n        usage: \"LABEL\"\n        description: \"Extension name\"\n    - default_version:\n        usage: \"LABEL\"\n        description: \"Default version\"\n    - installed_version:\n        usage: \"LABEL\"\n        description: \"Installed version\"\n    - update_available:\n        usage: \"GAUGE\"\n        description: \"An update is available\"\n  target_databases:\n    - '*'\n",
           "description": "A string representation of a YAML defining monitoring queries.",
-          "required": []
+          "type": "string"
         }
       },
       "required": [],
@@ -255,15 +262,18 @@
     },
     "nodeSelector": {
       "description": "Nodeselector for the operator to be installed.",
-      "required": []
+      "required": [],
+      "type": "object"
     },
     "podAnnotations": {
       "description": "Annotations to be added to the pod.",
-      "required": []
+      "required": [],
+      "type": "object"
     },
     "podLabels": {
       "description": "Labels to be added to the pod.",
-      "required": []
+      "required": [],
+      "type": "object"
     },
     "podSecurityContext": {
       "description": "Security Context for the whole pod.",
@@ -283,24 +293,25 @@
           "type": "object"
         }
       },
-      "required": []
+      "required": [],
+      "type": "object"
     },
     "priorityClassName": {
       "default": "",
       "description": "Priority indicates the importance of a Pod relative to other Pods.",
-      "required": []
+      "type": "string"
     },
     "rbac": {
       "properties": {
         "aggregateClusterRoles": {
-          "default": "false",
-          "description": "Aggregate ClusterRoles to Kubernetes default user-facing roles. Ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles",
-          "required": []
+          "default": false,
+          "description": "Aggregate ClusterRoles to Kubernetes default user-facing roles.\nRef: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles",
+          "type": "boolean"
         },
         "create": {
-          "default": "true",
+          "default": true,
           "description": "Specifies whether ClusterRole and ClusterRoleBinding should be created.",
-          "required": []
+          "type": "boolean"
         }
       },
       "required": [],
@@ -321,17 +332,17 @@
           "items": {
             "required": []
           },
-          "required": []
+          "type": "array"
         },
         "ipFamilyPolicy": {
           "default": "",
           "description": "Set the ip family policy to configure dual-stack see [Configure dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services)",
-          "required": []
+          "type": "string"
         },
         "name": {
           "default": "cnpg-webhook-service",
-          "description": "DO NOT CHANGE THE SERVICE NAME as it is currently used to generate the certificate and can not be configured",
-          "required": []
+          "description": "DO NOT CHANGE THE SERVICE NAME as it is currently used to generate the certificate\nand can not be configured",
+          "type": "string"
         },
         "port": {
           "default": 443,
@@ -348,14 +359,14 @@
     "serviceAccount": {
       "properties": {
         "create": {
-          "default": "true",
+          "default": true,
           "description": "Specifies whether the service account should be created.",
-          "required": []
+          "type": "boolean"
         },
         "name": {
           "default": "",
-          "description": "The name of the service account to use. If not set and create is true, a name is generated using the fullname template.",
-          "required": []
+          "description": "The name of the service account to use.\nIf not set and create is true, a name is generated using the fullname template.",
+          "type": "string"
         }
       },
       "required": [],
@@ -366,18 +377,19 @@
       "items": {
         "required": []
       },
-      "required": []
+      "type": "array"
     },
     "topologySpreadConstraints": {
       "description": "Topology Spread Constraints for the operator to be installed.",
       "items": {
         "required": []
       },
-      "required": []
+      "type": "array"
     },
     "updateStrategy": {
-      "description": "Update strategy for the operator. ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy For example:  type: RollingUpdate  rollingUpdate:    maxSurge: 25%    maxUnavailable: 25%",
-      "required": []
+      "description": "Update strategy for the operator.\nref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy\nFor example:\n type: RollingUpdate\n rollingUpdate:\n   maxSurge: 25%\n   maxUnavailable: 25%",
+      "required": [],
+      "type": "object"
     },
     "webhook": {
       "description": "The webhook configuration.",
@@ -449,7 +461,8 @@
           "type": "object"
         }
       },
-      "required": []
+      "required": [],
+      "type": "object"
     }
   },
   "required": [],

--- a/charts/cloudnative-pg/values.schema.json
+++ b/charts/cloudnative-pg/values.schema.json
@@ -6,7 +6,6 @@
       "items": {
         "required": []
       },
-      "title": "additionalArgs",
       "type": "array"
     },
     "additionalEnv": {
@@ -14,19 +13,16 @@
       "items": {
         "required": []
       },
-      "title": "additionalEnv",
       "type": "array"
     },
     "affinity": {
       "description": "Affinity for the operator to be installed.",
       "required": [],
-      "title": "affinity",
       "type": "object"
     },
     "commonAnnotations": {
       "description": "Annotations to be added to all other resources.",
       "required": [],
-      "title": "commonAnnotations",
       "type": "object"
     },
     "config": {
@@ -35,49 +31,35 @@
         "clusterWide": {
           "default": true,
           "description": "This option determines if the operator is responsible for observing\nevents across the entire Kubernetes cluster or if its focus should be\nnarrowed down to the specific namespace within which it has been deployed.",
-          "title": "clusterWide",
           "type": "boolean"
         },
         "create": {
           "default": true,
           "description": "Specifies whether the secret should be created.",
-          "title": "create",
           "type": "boolean"
         },
         "data": {
           "description": "The content of the configmap/secret, see\nhttps://cloudnative-pg.io/documentation/current/operator_conf/#available-options\nfor all the available options.",
           "required": [],
-          "title": "data",
           "type": "object"
         },
         "maxConcurrentReconciles": {
           "default": 10,
           "description": "INHERITED_ANNOTATIONS: categories\nINHERITED_LABELS: environment, workload, app\nWATCH_NAMESPACE: namespace-a,namespace-b\nThe maximum number of concurrent reconciles. Defaults to 10.",
-          "title": "maxConcurrentReconciles",
           "type": "integer"
         },
         "name": {
           "default": "cnpg-controller-manager-config",
           "description": "The name of the configmap/secret to use.",
-          "title": "name",
           "type": "string"
         },
         "secret": {
           "default": false,
           "description": "Specifies whether it should be stored in a secret, instead of a configmap.",
-          "title": "secret",
           "type": "boolean"
         }
       },
-      "required": [
-        "create",
-        "name",
-        "secret",
-        "clusterWide",
-        "data",
-        "maxConcurrentReconciles"
-      ],
-      "title": "config",
+      "required": [],
       "type": "object"
     },
     "containerSecurityContext": {
@@ -85,7 +67,6 @@
       "properties": {
         "allowPrivilegeEscalation": {
           "default": false,
-          "title": "allowPrivilegeEscalation",
           "type": "boolean"
         },
         "capabilities": {
@@ -99,55 +80,36 @@
                 ],
                 "required": []
               },
-              "title": "drop",
               "type": "array"
             }
           },
-          "required": [
-            "drop"
-          ],
-          "title": "capabilities",
+          "required": [],
           "type": "object"
         },
         "readOnlyRootFilesystem": {
           "default": true,
-          "title": "readOnlyRootFilesystem",
           "type": "boolean"
         },
         "runAsGroup": {
           "default": 10001,
-          "title": "runAsGroup",
           "type": "integer"
         },
         "runAsUser": {
           "default": 10001,
-          "title": "runAsUser",
           "type": "integer"
         },
         "seccompProfile": {
           "properties": {
             "type": {
               "default": "RuntimeDefault",
-              "title": "type",
               "type": "string"
             }
           },
-          "required": [
-            "type"
-          ],
-          "title": "seccompProfile",
+          "required": [],
           "type": "object"
         }
       },
-      "required": [
-        "allowPrivilegeEscalation",
-        "readOnlyRootFilesystem",
-        "runAsUser",
-        "runAsGroup",
-        "seccompProfile",
-        "capabilities"
-      ],
-      "title": "containerSecurityContext",
+      "required": [],
       "type": "object"
     },
     "crds": {
@@ -155,69 +117,52 @@
         "create": {
           "default": true,
           "description": "Specifies whether the CRDs should be created when installing the chart.",
-          "title": "create",
           "type": "boolean"
         }
       },
-      "required": [
-        "create"
-      ],
-      "title": "crds",
+      "required": [],
       "type": "object"
     },
     "dnsPolicy": {
       "default": "",
-      "title": "dnsPolicy",
       "type": "string"
     },
     "fullnameOverride": {
       "default": "",
-      "title": "fullnameOverride",
       "type": "string"
     },
     "global": {
       "description": "Global values are values that can be accessed from any chart or subchart by exactly the same name.",
       "required": [],
-      "title": "global",
       "type": "object"
     },
     "hostNetwork": {
       "default": false,
-      "title": "hostNetwork",
       "type": "boolean"
     },
     "image": {
       "properties": {
         "pullPolicy": {
           "default": "IfNotPresent",
-          "title": "pullPolicy",
           "type": "string"
         },
         "repository": {
           "default": "ghcr.io/cloudnative-pg/cloudnative-pg",
-          "title": "repository",
           "type": "string"
         },
         "tag": {
           "default": "",
           "description": "Overrides the image tag whose default is the chart appVersion.",
-          "title": "tag",
           "type": "string"
         }
       },
-      "required": [
-        "repository",
-        "pullPolicy",
-        "tag"
-      ],
-      "title": "image",
+      "required": [],
       "type": "object"
     },
     "imagePullSecrets": {
       "items": {
         "required": []
       },
-      "title": "imagePullSecrets",
       "type": "array"
     },
     "monitoring": {
@@ -227,67 +172,49 @@
             "annotations": {
               "description": "Annotations that ConfigMaps can have to get configured in Grafana.",
               "required": [],
-              "title": "annotations",
               "type": "object"
             },
             "configMapName": {
               "default": "cnpg-grafana-dashboard",
               "description": "The name of the ConfigMap containing the dashboard.",
-              "title": "configMapName",
               "type": "string"
             },
             "create": {
               "default": false,
-              "title": "create",
               "type": "boolean"
             },
             "labels": {
               "description": "Labels that ConfigMaps should have to get configured in Grafana.",
               "required": [],
-              "title": "labels",
               "type": "object"
             },
             "namespace": {
               "default": "",
               "description": "Allows overriding the namespace where the ConfigMap will be created, defaulting to the same one as the Release.",
-              "title": "namespace",
               "type": "string"
             },
             "sidecarLabel": {
               "default": "grafana_dashboard",
               "description": "Label that ConfigMaps should have to be loaded as dashboards.  DEPRECATED: Use labels instead.",
-              "title": "sidecarLabel",
               "type": "string"
             },
             "sidecarLabelValue": {
               "default": "1",
               "description": "Label value that ConfigMaps should have to be loaded as dashboards.  DEPRECATED: Use labels instead.",
-              "title": "sidecarLabelValue",
               "type": "string"
             }
           },
-          "required": [
-            "create",
-            "namespace",
-            "configMapName",
-            "sidecarLabel",
-            "sidecarLabelValue",
-            "labels",
-            "annotations"
-          ],
-          "title": "grafanaDashboard",
+          "required": [],
           "type": "object"
         },
         "podMonitorAdditionalLabels": {
           "description": "Additional labels for the podMonitor",
           "required": [],
-          "title": "podMonitorAdditionalLabels",
           "type": "object"
         },
         "podMonitorEnabled": {
           "default": false,
           "description": "Specifies whether the monitoring should be enabled. Requires Prometheus Operator CRDs.",
-          "title": "podMonitorEnabled",
           "type": "boolean"
         },
         "podMonitorMetricRelabelings": {
@@ -295,7 +222,6 @@
           "items": {
             "required": []
           },
-          "title": "podMonitorMetricRelabelings",
           "type": "array"
         },
         "podMonitorRelabelings": {
@@ -303,18 +229,10 @@
           "items": {
             "required": []
           },
-          "title": "podMonitorRelabelings",
           "type": "array"
         }
       },
-      "required": [
-        "podMonitorEnabled",
-        "podMonitorMetricRelabelings",
-        "podMonitorRelabelings",
-        "podMonitorAdditionalLabels",
-        "grafanaDashboard"
-      ],
-      "title": "monitoring",
+      "required": [],
       "type": "object"
     },
     "monitoringQueriesConfigMap": {
@@ -323,49 +241,38 @@
         "name": {
           "default": "cnpg-default-monitoring",
           "description": "The name of the default monitoring configmap.",
-          "title": "name",
           "type": "string"
         },
         "queries": {
           "default": "backends:\n  query: |\n    SELECT sa.datname\n      , sa.usename\n      , sa.application_name\n      , states.state\n      , COALESCE(sa.count, 0) AS total\n      , COALESCE(sa.max_tx_secs, 0) AS max_tx_duration_seconds\n    FROM ( VALUES ('active')\n      , ('idle')\n      , ('idle in transaction')\n      , ('idle in transaction (aborted)')\n      , ('fastpath function call')\n      , ('disabled')\n      ) AS states(state)\n    LEFT JOIN (\n      SELECT datname\n        , state\n        , usename\n        , COALESCE(application_name, '') AS application_name\n        , pg_catalog.count(*)\n        , COALESCE(EXTRACT (EPOCH FROM (pg_catalog.max(pg_catalog.now() OPERATOR(pg_catalog.-) xact_start))), 0) AS max_tx_secs\n      FROM pg_catalog.pg_stat_activity\n      GROUP BY datname, state, usename, application_name\n    ) sa ON states.state OPERATOR(pg_catalog.=) sa.state\n    WHERE sa.usename IS NOT NULL\n  metrics:\n    - datname:\n        usage: \"LABEL\"\n        description: \"Name of the database\"\n    - usename:\n        usage: \"LABEL\"\n        description: \"Name of the user\"\n    - application_name:\n        usage: \"LABEL\"\n        description: \"Name of the application\"\n    - state:\n        usage: \"LABEL\"\n        description: \"State of the backend\"\n    - total:\n        usage: \"GAUGE\"\n        description: \"Number of backends\"\n    - max_tx_duration_seconds:\n        usage: \"GAUGE\"\n        description: \"Maximum duration of a transaction in seconds\"\n\nbackends_waiting:\n  query: |\n    SELECT pg_catalog.count(*) AS total\n    FROM pg_catalog.pg_locks blocked_locks\n    JOIN pg_catalog.pg_locks blocking_locks\n      ON blocking_locks.locktype OPERATOR(pg_catalog.=) blocked_locks.locktype\n      AND blocking_locks.database IS NOT DISTINCT FROM blocked_locks.database\n      AND blocking_locks.relation IS NOT DISTINCT FROM blocked_locks.relation\n      AND blocking_locks.page IS NOT DISTINCT FROM blocked_locks.page\n      AND blocking_locks.tuple IS NOT DISTINCT FROM blocked_locks.tuple\n      AND blocking_locks.virtualxid IS NOT DISTINCT FROM blocked_locks.virtualxid\n      AND blocking_locks.transactionid IS NOT DISTINCT FROM blocked_locks.transactionid\n      AND blocking_locks.classid IS NOT DISTINCT FROM blocked_locks.classid\n      AND blocking_locks.objid IS NOT DISTINCT FROM blocked_locks.objid\n      AND blocking_locks.objsubid IS NOT DISTINCT FROM blocked_locks.objsubid\n      AND blocking_locks.pid OPERATOR(pg_catalog.\u003c\u003e) blocked_locks.pid\n    JOIN pg_catalog.pg_stat_activity blocking_activity ON blocking_activity.pid OPERATOR(pg_catalog.=) blocking_locks.pid\n    WHERE NOT blocked_locks.granted\n  metrics:\n    - total:\n        usage: \"GAUGE\"\n        description: \"Total number of backends that are currently waiting on other queries\"\n\npg_database:\n  query: |\n    SELECT datname\n      , pg_catalog.pg_database_size(datname) AS size_bytes\n      , pg_catalog.age(datfrozenxid) AS xid_age\n      , pg_catalog.mxid_age(datminmxid) AS mxid_age\n    FROM pg_catalog.pg_database\n    WHERE datallowconn\n  metrics:\n    - datname:\n        usage: \"LABEL\"\n        description: \"Name of the database\"\n    - size_bytes:\n        usage: \"GAUGE\"\n        description: \"Disk space used by the database\"\n    - xid_age:\n        usage: \"GAUGE\"\n        description: \"Number of transactions from the frozen XID to the current one\"\n    - mxid_age:\n        usage: \"GAUGE\"\n        description: \"Number of multiple transactions (Multixact) from the frozen XID to the current one\"\n\npg_postmaster:\n  query: |\n    SELECT EXTRACT(EPOCH FROM pg_postmaster_start_time) AS start_time\n    FROM pg_catalog.pg_postmaster_start_time()\n  metrics:\n    - start_time:\n        usage: \"GAUGE\"\n        description: \"Time at which postgres started (based on epoch)\"\n\npg_replication:\n  query: |\n    SELECT CASE WHEN (\n        NOT pg_catalog.pg_is_in_recovery()\n        OR pg_catalog.pg_last_wal_receive_lsn() OPERATOR(pg_catalog.=) pg_catalog.pg_last_wal_replay_lsn())\n      THEN 0\n      ELSE GREATEST (0,\n        EXTRACT(EPOCH FROM (pg_catalog.now() OPERATOR(pg_catalog.-) pg_catalog.pg_last_xact_replay_timestamp())))\n      END AS lag,\n      pg_catalog.pg_is_in_recovery() AS in_recovery,\n      EXISTS (TABLE pg_catalog.pg_stat_wal_receiver) AS is_wal_receiver_up,\n      (SELECT pg_catalog.count(*) FROM pg_catalog.pg_stat_replication) AS streaming_replicas\n  metrics:\n    - lag:\n        usage: \"GAUGE\"\n        description: \"Replication lag behind primary in seconds\"\n    - in_recovery:\n        usage: \"GAUGE\"\n        description: \"Whether the instance is in recovery\"\n    - is_wal_receiver_up:\n        usage: \"GAUGE\"\n        description: \"Whether the instance wal_receiver is up\"\n    - streaming_replicas:\n        usage: \"GAUGE\"\n        description: \"Number of streaming replicas connected to the instance\"\n\npg_replication_slots:\n  query: |\n    SELECT slot_name,\n      slot_type,\n      database,\n      active,\n      (CASE pg_catalog.pg_is_in_recovery()\n        WHEN TRUE THEN pg_catalog.pg_wal_lsn_diff(pg_catalog.pg_last_wal_receive_lsn(), restart_lsn)\n        ELSE pg_catalog.pg_wal_lsn_diff(pg_catalog.pg_current_wal_lsn(), restart_lsn)\n      END) as pg_wal_lsn_diff\n    FROM pg_catalog.pg_replication_slots\n    WHERE NOT temporary\n  metrics:\n    - slot_name:\n        usage: \"LABEL\"\n        description: \"Name of the replication slot\"\n    - slot_type:\n        usage: \"LABEL\"\n        description: \"Type of the replication slot\"\n    - database:\n        usage: \"LABEL\"\n        description: \"Name of the database\"\n    - active:\n        usage: \"GAUGE\"\n        description: \"Flag indicating whether the slot is active\"\n    - pg_wal_lsn_diff:\n        usage: \"GAUGE\"\n        description: \"Replication lag in bytes\"\n\npg_stat_archiver:\n  query: |\n    SELECT archived_count\n      , failed_count\n      , COALESCE(EXTRACT(EPOCH FROM (pg_catalog.now() OPERATOR(pg_catalog.-) last_archived_time)), -1) AS seconds_since_last_archival\n      , COALESCE(EXTRACT(EPOCH FROM (pg_catalog.now() OPERATOR(pg_catalog.-) last_failed_time)), -1) AS seconds_since_last_failure\n      , COALESCE(EXTRACT(EPOCH FROM last_archived_time), -1) AS last_archived_time\n      , COALESCE(EXTRACT(EPOCH FROM last_failed_time), -1) AS last_failed_time\n      , COALESCE(CAST(CAST('x' OPERATOR(pg_catalog.||) pg_catalog.right(pg_catalog.split_part(last_archived_wal, '.', 1), 16) AS pg_catalog.bit(64)) AS pg_catalog.int8), -1) AS last_archived_wal_start_lsn\n      , COALESCE(CAST(CAST('x' OPERATOR(pg_catalog.||) pg_catalog.right(pg_catalog.split_part(last_failed_wal, '.', 1), 16) AS pg_catalog.bit(64)) AS pg_catalog.int8), -1) AS last_failed_wal_start_lsn\n      , EXTRACT(EPOCH FROM stats_reset) AS stats_reset_time\n    FROM pg_catalog.pg_stat_archiver\n  predicate_query: |\n    SELECT NOT pg_catalog.pg_is_in_recovery()\n      OR pg_catalog.current_setting('archive_mode') OPERATOR(pg_catalog.=) 'always'\n  metrics:\n    - archived_count:\n        usage: \"COUNTER\"\n        description: \"Number of WAL files that have been successfully archived\"\n    - failed_count:\n        usage: \"COUNTER\"\n        description: \"Number of failed attempts for archiving WAL files\"\n    - seconds_since_last_archival:\n        usage: \"GAUGE\"\n        description: \"Seconds since the last successful archival operation\"\n    - seconds_since_last_failure:\n        usage: \"GAUGE\"\n        description: \"Seconds since the last failed archival operation\"\n    - last_archived_time:\n        usage: \"GAUGE\"\n        description: \"Epoch of the last time WAL archiving succeeded\"\n    - last_failed_time:\n        usage: \"GAUGE\"\n        description: \"Epoch of the last time WAL archiving failed\"\n    - last_archived_wal_start_lsn:\n        usage: \"GAUGE\"\n        description: \"Archived WAL start LSN\"\n    - last_failed_wal_start_lsn:\n        usage: \"GAUGE\"\n        description: \"Last failed WAL LSN\"\n    - stats_reset_time:\n        usage: \"GAUGE\"\n        description: \"Time at which these statistics were last reset\"\n\npg_stat_bgwriter:\n  runonserver: \"\u003c17.0.0\"\n  query: |\n    SELECT checkpoints_timed\n      , checkpoints_req\n      , checkpoint_write_time\n      , checkpoint_sync_time\n      , buffers_checkpoint\n      , buffers_clean\n      , maxwritten_clean\n      , buffers_backend\n      , buffers_backend_fsync\n      , buffers_alloc\n    FROM pg_catalog.pg_stat_bgwriter\n  metrics:\n    - checkpoints_timed:\n        usage: \"COUNTER\"\n        description: \"Number of scheduled checkpoints that have been performed\"\n    - checkpoints_req:\n        usage: \"COUNTER\"\n        description: \"Number of requested checkpoints that have been performed\"\n    - checkpoint_write_time:\n        usage: \"COUNTER\"\n        description: \"Total amount of time that has been spent in the portion of checkpoint processing where files are written to disk, in milliseconds\"\n    - checkpoint_sync_time:\n        usage: \"COUNTER\"\n        description: \"Total amount of time that has been spent in the portion of checkpoint processing where files are synchronized to disk, in milliseconds\"\n    - buffers_checkpoint:\n        usage: \"COUNTER\"\n        description: \"Number of buffers written during checkpoints\"\n    - buffers_clean:\n        usage: \"COUNTER\"\n        description: \"Number of buffers written by the background writer\"\n    - maxwritten_clean:\n        usage: \"COUNTER\"\n        description: \"Number of times the background writer stopped a cleaning scan because it had written too many buffers\"\n    - buffers_backend:\n        usage: \"COUNTER\"\n        description: \"Number of buffers written directly by a backend\"\n    - buffers_backend_fsync:\n        usage: \"COUNTER\"\n        description: \"Number of times a backend had to execute its own fsync call (normally the background writer handles those even when the backend does its own write)\"\n    - buffers_alloc:\n        usage: \"COUNTER\"\n        description: \"Number of buffers allocated\"\n\npg_stat_bgwriter_17:\n  runonserver: \"\u003e=17.0.0\"\n  name: pg_stat_bgwriter\n  query: |\n    SELECT buffers_clean\n      , maxwritten_clean\n      , buffers_alloc\n      , EXTRACT(EPOCH FROM stats_reset) AS stats_reset_time\n    FROM pg_catalog.pg_stat_bgwriter\n  metrics:\n    - buffers_clean:\n        usage: \"COUNTER\"\n        description: \"Number of buffers written by the background writer\"\n    - maxwritten_clean:\n        usage: \"COUNTER\"\n        description: \"Number of times the background writer stopped a cleaning scan because it had written too many buffers\"\n    - buffers_alloc:\n        usage: \"COUNTER\"\n        description: \"Number of buffers allocated\"\n    - stats_reset_time:\n        usage: \"GAUGE\"\n        description: \"Time at which these statistics were last reset\"\n\npg_stat_checkpointer:\n  runonserver: \"\u003e=17.0.0\"\n  query: |\n    SELECT num_timed AS checkpoints_timed\n      , num_requested AS checkpoints_req\n      , restartpoints_timed\n      , restartpoints_req\n      , restartpoints_done\n      , write_time\n      , sync_time\n      , buffers_written\n      , EXTRACT(EPOCH FROM stats_reset) AS stats_reset_time\n    FROM pg_catalog.pg_stat_checkpointer\n  metrics:\n    - checkpoints_timed:\n        usage: \"COUNTER\"\n        description: \"Number of scheduled checkpoints that have been performed\"\n    - checkpoints_req:\n        usage: \"COUNTER\"\n        description: \"Number of requested checkpoints that have been performed\"\n    - restartpoints_timed:\n        usage: \"COUNTER\"\n        description: \"Number of scheduled restartpoints due to timeout or after a failed attempt to perform it\"\n    - restartpoints_req:\n        usage: \"COUNTER\"\n        description: \"Number of requested restartpoints that have been performed\"\n    - restartpoints_done:\n        usage: \"COUNTER\"\n        description: \"Number of restartpoints that have been performed\"\n    - write_time:\n        usage: \"COUNTER\"\n        description: \"Total amount of time that has been spent in the portion of processing checkpoints and restartpoints where files are written to disk, in milliseconds\"\n    - sync_time:\n        usage: \"COUNTER\"\n        description: \"Total amount of time that has been spent in the portion of processing checkpoints and restartpoints where files are synchronized to disk, in milliseconds\"\n    - buffers_written:\n        usage: \"COUNTER\"\n        description: \"Number of buffers written during checkpoints and restartpoints\"\n    - stats_reset_time:\n        usage: \"GAUGE\"\n        description: \"Time at which these statistics were last reset\"\n\npg_stat_database:\n  query: |\n    SELECT datname\n      , xact_commit\n      , xact_rollback\n      , blks_read\n      , blks_hit\n      , tup_returned\n      , tup_fetched\n      , tup_inserted\n      , tup_updated\n      , tup_deleted\n      , conflicts\n      , temp_files\n      , temp_bytes\n      , deadlocks\n      , blk_read_time\n      , blk_write_time\n    FROM pg_catalog.pg_stat_database\n  metrics:\n    - datname:\n        usage: \"LABEL\"\n        description: \"Name of this database\"\n    - xact_commit:\n        usage: \"COUNTER\"\n        description: \"Number of transactions in this database that have been committed\"\n    - xact_rollback:\n        usage: \"COUNTER\"\n        description: \"Number of transactions in this database that have been rolled back\"\n    - blks_read:\n        usage: \"COUNTER\"\n        description: \"Number of disk blocks read in this database\"\n    - blks_hit:\n        usage: \"COUNTER\"\n        description: \"Number of times disk blocks were found already in the buffer cache, so that a read was not necessary (this only includes hits in the PostgreSQL buffer cache, not the operating system's file system cache)\"\n    - tup_returned:\n        usage: \"COUNTER\"\n        description: \"Number of rows returned by queries in this database\"\n    - tup_fetched:\n        usage: \"COUNTER\"\n        description: \"Number of rows fetched by queries in this database\"\n    - tup_inserted:\n        usage: \"COUNTER\"\n        description: \"Number of rows inserted by queries in this database\"\n    - tup_updated:\n        usage: \"COUNTER\"\n        description: \"Number of rows updated by queries in this database\"\n    - tup_deleted:\n        usage: \"COUNTER\"\n        description: \"Number of rows deleted by queries in this database\"\n    - conflicts:\n        usage: \"COUNTER\"\n        description: \"Number of queries canceled due to conflicts with recovery in this database\"\n    - temp_files:\n        usage: \"COUNTER\"\n        description: \"Number of temporary files created by queries in this database\"\n    - temp_bytes:\n        usage: \"COUNTER\"\n        description: \"Total amount of data written to temporary files by queries in this database\"\n    - deadlocks:\n        usage: \"COUNTER\"\n        description: \"Number of deadlocks detected in this database\"\n    - blk_read_time:\n        usage: \"COUNTER\"\n        description: \"Time spent reading data file blocks by backends in this database, in milliseconds\"\n    - blk_write_time:\n        usage: \"COUNTER\"\n        description: \"Time spent writing data file blocks by backends in this database, in milliseconds\"\n\npg_stat_replication:\n  primary: true\n  query: |\n    SELECT usename\n      , COALESCE(application_name, '') AS application_name\n      , COALESCE(client_addr::text, '') AS client_addr\n      , COALESCE(client_port::text, '') AS client_port\n      , EXTRACT(EPOCH FROM backend_start) AS backend_start\n      , COALESCE(pg_catalog.age(backend_xmin), 0) AS backend_xmin_age\n      , pg_catalog.pg_wal_lsn_diff(pg_catalog.pg_current_wal_lsn(), sent_lsn) AS sent_diff_bytes\n      , pg_catalog.pg_wal_lsn_diff(pg_catalog.pg_current_wal_lsn(), write_lsn) AS write_diff_bytes\n      , pg_catalog.pg_wal_lsn_diff(pg_catalog.pg_current_wal_lsn(), flush_lsn) AS flush_diff_bytes\n      , COALESCE(pg_catalog.pg_wal_lsn_diff(pg_catalog.pg_current_wal_lsn(), replay_lsn),0) AS replay_diff_bytes\n      , COALESCE((EXTRACT(EPOCH FROM write_lag)),0)::float AS write_lag_seconds\n      , COALESCE((EXTRACT(EPOCH FROM flush_lag)),0)::float AS flush_lag_seconds\n      , COALESCE((EXTRACT(EPOCH FROM replay_lag)),0)::float AS replay_lag_seconds\n    FROM pg_catalog.pg_stat_replication\n  metrics:\n    - usename:\n        usage: \"LABEL\"\n        description: \"Name of the replication user\"\n    - application_name:\n        usage: \"LABEL\"\n        description: \"Name of the application\"\n    - client_addr:\n        usage: \"LABEL\"\n        description: \"Client IP address\"\n    - client_port:\n        usage: \"LABEL\"\n        description: \"Client TCP port\"\n    - backend_start:\n        usage: \"COUNTER\"\n        description: \"Time when this process was started\"\n    - backend_xmin_age:\n        usage: \"COUNTER\"\n        description: \"The age of this standby's xmin horizon\"\n    - sent_diff_bytes:\n        usage: \"GAUGE\"\n        description: \"Difference in bytes from the last write-ahead log location sent on this connection\"\n    - write_diff_bytes:\n        usage: \"GAUGE\"\n        description: \"Difference in bytes from the last write-ahead log location written to disk by this standby server\"\n    - flush_diff_bytes:\n        usage: \"GAUGE\"\n        description: \"Difference in bytes from the last write-ahead log location flushed to disk by this standby server\"\n    - replay_diff_bytes:\n        usage: \"GAUGE\"\n        description: \"Difference in bytes from the last write-ahead log location replayed into the database on this standby server\"\n    - write_lag_seconds:\n        usage: \"GAUGE\"\n        description: \"Time elapsed between flushing recent WAL locally and receiving notification that this standby server has written it\"\n    - flush_lag_seconds:\n        usage: \"GAUGE\"\n        description: \"Time elapsed between flushing recent WAL locally and receiving notification that this standby server has written and flushed it\"\n    - replay_lag_seconds:\n        usage: \"GAUGE\"\n        description: \"Time elapsed between flushing recent WAL locally and receiving notification that this standby server has written, flushed and applied it\"\n\npg_settings:\n  query: |\n    SELECT name,\n    CASE setting WHEN 'on' THEN '1' WHEN 'off' THEN '0' ELSE setting END AS setting\n    FROM pg_catalog.pg_settings\n    WHERE vartype IN ('integer', 'real', 'bool')\n    ORDER BY 1\n  metrics:\n    - name:\n        usage: \"LABEL\"\n        description: \"Name of the setting\"\n    - setting:\n        usage: \"GAUGE\"\n        description: \"Setting value\"\n\npg_extensions:\n  query: |\n    SELECT\n      pg_catalog.current_database() as datname,\n      name as extname,\n      default_version,\n      installed_version,\n      CASE\n        WHEN default_version OPERATOR(pg_catalog.=) installed_version THEN 0\n        ELSE 1\n    END AS update_available\n    FROM pg_catalog.pg_available_extensions\n    WHERE installed_version IS NOT NULL\n  metrics:\n    - datname:\n        usage: \"LABEL\"\n        description: \"Name of the database\"\n    - extname:\n        usage: \"LABEL\"\n        description: \"Extension name\"\n    - default_version:\n        usage: \"LABEL\"\n        description: \"Default version\"\n    - installed_version:\n        usage: \"LABEL\"\n        description: \"Installed version\"\n    - update_available:\n        usage: \"GAUGE\"\n        description: \"An update is available\"\n  target_databases:\n    - '*'\n",
           "description": "A string representation of a YAML defining monitoring queries.",
-          "title": "queries",
           "type": "string"
         }
       },
-      "required": [
-        "name",
-        "queries"
-      ],
-      "title": "monitoringQueriesConfigMap",
+      "required": [],
       "type": "object"
     },
     "nameOverride": {
       "default": "",
-      "title": "nameOverride",
       "type": "string"
     },
     "namespaceOverride": {
       "default": "",
-      "title": "namespaceOverride",
       "type": "string"
     },
     "nodeSelector": {
       "description": "Nodeselector for the operator to be installed.",
       "required": [],
-      "title": "nodeSelector",
       "type": "object"
     },
     "podAnnotations": {
       "description": "Annotations to be added to the pod.",
       "required": [],
-      "title": "podAnnotations",
       "type": "object"
     },
     "podLabels": {
       "description": "Labels to be added to the pod.",
       "required": [],
-      "title": "podLabels",
       "type": "object"
     },
     "podSecurityContext": {
@@ -373,35 +280,25 @@
       "properties": {
         "runAsNonRoot": {
           "default": true,
-          "title": "runAsNonRoot",
           "type": "boolean"
         },
         "seccompProfile": {
           "properties": {
             "type": {
               "default": "RuntimeDefault",
-              "title": "type",
               "type": "string"
             }
           },
-          "required": [
-            "type"
-          ],
-          "title": "seccompProfile",
+          "required": [],
           "type": "object"
         }
       },
-      "required": [
-        "runAsNonRoot",
-        "seccompProfile"
-      ],
-      "title": "podSecurityContext",
+      "required": [],
       "type": "object"
     },
     "priorityClassName": {
       "default": "",
       "description": "Priority indicates the importance of a Pod relative to other Pods.",
-      "title": "priorityClassName",
       "type": "string"
     },
     "rbac": {
@@ -409,31 +306,23 @@
         "aggregateClusterRoles": {
           "default": false,
           "description": "Aggregate ClusterRoles to Kubernetes default user-facing roles.\nRef: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles",
-          "title": "aggregateClusterRoles",
           "type": "boolean"
         },
         "create": {
           "default": true,
           "description": "Specifies whether ClusterRole and ClusterRoleBinding should be created.",
-          "title": "create",
           "type": "boolean"
         }
       },
-      "required": [
-        "create",
-        "aggregateClusterRoles"
-      ],
-      "title": "rbac",
+      "required": [],
       "type": "object"
     },
     "replicaCount": {
       "default": 1,
-      "title": "replicaCount",
       "type": "integer"
     },
     "resources": {
       "required": [],
-      "title": "resources",
       "type": "object"
     },
     "service": {
@@ -443,40 +332,28 @@
           "items": {
             "required": []
           },
-          "title": "ipFamilies",
           "type": "array"
         },
         "ipFamilyPolicy": {
           "default": "",
           "description": "Set the ip family policy to configure dual-stack see [Configure dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services)",
-          "title": "ipFamilyPolicy",
           "type": "string"
         },
         "name": {
           "default": "cnpg-webhook-service",
           "description": "DO NOT CHANGE THE SERVICE NAME as it is currently used to generate the certificate\nand can not be configured",
-          "title": "name",
           "type": "string"
         },
         "port": {
           "default": 443,
-          "title": "port",
           "type": "integer"
         },
         "type": {
           "default": "ClusterIP",
-          "title": "type",
           "type": "string"
         }
       },
-      "required": [
-        "type",
-        "name",
-        "port",
-        "ipFamilyPolicy",
-        "ipFamilies"
-      ],
-      "title": "service",
+      "required": [],
       "type": "object"
     },
     "serviceAccount": {
@@ -484,21 +361,15 @@
         "create": {
           "default": true,
           "description": "Specifies whether the service account should be created.",
-          "title": "create",
           "type": "boolean"
         },
         "name": {
           "default": "",
           "description": "The name of the service account to use.\nIf not set and create is true, a name is generated using the fullname template.",
-          "title": "name",
           "type": "string"
         }
       },
-      "required": [
-        "create",
-        "name"
-      ],
-      "title": "serviceAccount",
+      "required": [],
       "type": "object"
     },
     "tolerations": {
@@ -506,7 +377,6 @@
       "items": {
         "required": []
       },
-      "title": "tolerations",
       "type": "array"
     },
     "topologySpreadConstraints": {
@@ -514,13 +384,11 @@
       "items": {
         "required": []
       },
-      "title": "topologySpreadConstraints",
       "type": "array"
     },
     "updateStrategy": {
       "description": "Update strategy for the operator.\nref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy\nFor example:\n type: RollingUpdate\n rollingUpdate:\n   maxSurge: 25%\n   maxUnavailable: 25%",
       "required": [],
-      "title": "updateStrategy",
       "type": "object"
     },
     "webhook": {
@@ -530,139 +398,73 @@
           "properties": {
             "initialDelaySeconds": {
               "default": 3,
-              "title": "initialDelaySeconds",
               "type": "integer"
             }
           },
-          "required": [
-            "initialDelaySeconds"
-          ],
-          "title": "livenessProbe",
+          "required": [],
           "type": "object"
         },
         "mutating": {
           "properties": {
             "create": {
               "default": true,
-              "title": "create",
               "type": "boolean"
             },
             "failurePolicy": {
               "default": "Fail",
-              "title": "failurePolicy",
               "type": "string"
             }
           },
-          "required": [
-            "create",
-            "failurePolicy"
-          ],
-          "title": "mutating",
+          "required": [],
           "type": "object"
         },
         "port": {
           "default": 9443,
-          "title": "port",
           "type": "integer"
         },
         "readinessProbe": {
           "properties": {
             "initialDelaySeconds": {
               "default": 3,
-              "title": "initialDelaySeconds",
               "type": "integer"
             }
           },
-          "required": [
-            "initialDelaySeconds"
-          ],
-          "title": "readinessProbe",
+          "required": [],
           "type": "object"
         },
         "startupProbe": {
           "properties": {
             "failureThreshold": {
               "default": 6,
-              "title": "failureThreshold",
               "type": "integer"
             },
             "periodSeconds": {
               "default": 5,
-              "title": "periodSeconds",
               "type": "integer"
             }
           },
-          "required": [
-            "failureThreshold",
-            "periodSeconds"
-          ],
-          "title": "startupProbe",
+          "required": [],
           "type": "object"
         },
         "validating": {
           "properties": {
             "create": {
               "default": true,
-              "title": "create",
               "type": "boolean"
             },
             "failurePolicy": {
               "default": "Fail",
-              "title": "failurePolicy",
               "type": "string"
             }
           },
-          "required": [
-            "create",
-            "failurePolicy"
-          ],
-          "title": "validating",
+          "required": [],
           "type": "object"
         }
       },
-      "required": [
-        "port",
-        "mutating",
-        "validating",
-        "livenessProbe",
-        "readinessProbe",
-        "startupProbe"
-      ],
-      "title": "webhook",
+      "required": [],
       "type": "object"
     }
   },
-  "required": [
-    "replicaCount",
-    "image",
-    "imagePullSecrets",
-    "nameOverride",
-    "fullnameOverride",
-    "namespaceOverride",
-    "hostNetwork",
-    "dnsPolicy",
-    "updateStrategy",
-    "crds",
-    "webhook",
-    "config",
-    "additionalArgs",
-    "additionalEnv",
-    "serviceAccount",
-    "rbac",
-    "commonAnnotations",
-    "podAnnotations",
-    "podLabels",
-    "containerSecurityContext",
-    "podSecurityContext",
-    "priorityClassName",
-    "service",
-    "resources",
-    "nodeSelector",
-    "topologySpreadConstraints",
-    "tolerations",
-    "affinity",
-    "monitoring",
-    "monitoringQueriesConfigMap"
-  ],
+  "required": [],
   "type": "object"
 }

--- a/charts/cloudnative-pg/values.schema.json
+++ b/charts/cloudnative-pg/values.schema.json
@@ -6,57 +6,54 @@
       "items": {
         "required": []
       },
-      "type": "array"
+      "required": []
     },
     "additionalEnv": {
-      "description": "Array containing extra environment variables which can be templated.\nFor example:\n - name: RELEASE_NAME\n   value: \"{{ .Release.Name }}\"\n - name: MY_VAR\n   value: \"mySpecialKey\"",
+      "description": "Array containing extra environment variables which can be templated. For example:  - name: RELEASE_NAME    value: \"{{ .Release.Name }}\"  - name: MY_VAR    value: \"mySpecialKey\"",
       "items": {
         "required": []
       },
-      "type": "array"
+      "required": []
     },
     "affinity": {
       "description": "Affinity for the operator to be installed.",
-      "required": [],
-      "type": "object"
+      "required": []
     },
     "commonAnnotations": {
       "description": "Annotations to be added to all other resources.",
-      "required": [],
-      "type": "object"
+      "required": []
     },
     "config": {
       "description": "Operator configuration.",
       "properties": {
         "clusterWide": {
-          "default": true,
-          "description": "This option determines if the operator is responsible for observing\nevents across the entire Kubernetes cluster or if its focus should be\nnarrowed down to the specific namespace within which it has been deployed.",
-          "type": "boolean"
+          "default": "true",
+          "description": "This option determines if the operator is responsible for observing events across the entire Kubernetes cluster or if its focus should be narrowed down to the specific namespace within which it has been deployed.",
+          "required": []
         },
         "create": {
-          "default": true,
+          "default": "true",
           "description": "Specifies whether the secret should be created.",
-          "type": "boolean"
+          "required": []
         },
         "data": {
-          "description": "The content of the configmap/secret, see\nhttps://cloudnative-pg.io/documentation/current/operator_conf/#available-options\nfor all the available options.",
-          "required": [],
-          "type": "object"
+          "description": "The content of the configmap/secret, see https://cloudnative-pg.io/documentation/current/operator_conf/#available-options for all the available options.",
+          "required": []
         },
         "maxConcurrentReconciles": {
-          "default": 10,
-          "description": "INHERITED_ANNOTATIONS: categories\nINHERITED_LABELS: environment, workload, app\nWATCH_NAMESPACE: namespace-a,namespace-b\nThe maximum number of concurrent reconciles. Defaults to 10.",
-          "type": "integer"
+          "default": "10",
+          "description": "The maximum number of concurrent reconciles. Defaults to 10.",
+          "required": []
         },
         "name": {
           "default": "cnpg-controller-manager-config",
           "description": "The name of the configmap/secret to use.",
-          "type": "string"
+          "required": []
         },
         "secret": {
-          "default": false,
+          "default": "false",
           "description": "Specifies whether it should be stored in a secret, instead of a configmap.",
-          "type": "boolean"
+          "required": []
         }
       },
       "required": [],
@@ -109,15 +106,14 @@
           "type": "object"
         }
       },
-      "required": [],
-      "type": "object"
+      "required": []
     },
     "crds": {
       "properties": {
         "create": {
-          "default": true,
+          "default": "true",
           "description": "Specifies whether the CRDs should be created when installing the chart.",
-          "type": "boolean"
+          "required": []
         }
       },
       "required": [],
@@ -153,7 +149,7 @@
         "tag": {
           "default": "",
           "description": "Overrides the image tag whose default is the chart appVersion.",
-          "type": "string"
+          "required": []
         }
       },
       "required": [],
@@ -171,13 +167,12 @@
           "properties": {
             "annotations": {
               "description": "Annotations that ConfigMaps can have to get configured in Grafana.",
-              "required": [],
-              "type": "object"
+              "required": []
             },
             "configMapName": {
               "default": "cnpg-grafana-dashboard",
               "description": "The name of the ConfigMap containing the dashboard.",
-              "type": "string"
+              "required": []
             },
             "create": {
               "default": false,
@@ -185,23 +180,22 @@
             },
             "labels": {
               "description": "Labels that ConfigMaps should have to get configured in Grafana.",
-              "required": [],
-              "type": "object"
+              "required": []
             },
             "namespace": {
               "default": "",
               "description": "Allows overriding the namespace where the ConfigMap will be created, defaulting to the same one as the Release.",
-              "type": "string"
+              "required": []
             },
             "sidecarLabel": {
               "default": "grafana_dashboard",
               "description": "Label that ConfigMaps should have to be loaded as dashboards.  DEPRECATED: Use labels instead.",
-              "type": "string"
+              "required": []
             },
             "sidecarLabelValue": {
               "default": "1",
               "description": "Label value that ConfigMaps should have to be loaded as dashboards.  DEPRECATED: Use labels instead.",
-              "type": "string"
+              "required": []
             }
           },
           "required": [],
@@ -209,27 +203,26 @@
         },
         "podMonitorAdditionalLabels": {
           "description": "Additional labels for the podMonitor",
-          "required": [],
-          "type": "object"
+          "required": []
         },
         "podMonitorEnabled": {
-          "default": false,
+          "default": "false",
           "description": "Specifies whether the monitoring should be enabled. Requires Prometheus Operator CRDs.",
-          "type": "boolean"
+          "required": []
         },
         "podMonitorMetricRelabelings": {
           "description": "Metrics relabel configurations to apply to samples before ingestion.",
           "items": {
             "required": []
           },
-          "type": "array"
+          "required": []
         },
         "podMonitorRelabelings": {
           "description": "Relabel configurations to apply to samples before scraping.",
           "items": {
             "required": []
           },
-          "type": "array"
+          "required": []
         }
       },
       "required": [],
@@ -241,12 +234,12 @@
         "name": {
           "default": "cnpg-default-monitoring",
           "description": "The name of the default monitoring configmap.",
-          "type": "string"
+          "required": []
         },
         "queries": {
           "default": "backends:\n  query: |\n    SELECT sa.datname\n      , sa.usename\n      , sa.application_name\n      , states.state\n      , COALESCE(sa.count, 0) AS total\n      , COALESCE(sa.max_tx_secs, 0) AS max_tx_duration_seconds\n    FROM ( VALUES ('active')\n      , ('idle')\n      , ('idle in transaction')\n      , ('idle in transaction (aborted)')\n      , ('fastpath function call')\n      , ('disabled')\n      ) AS states(state)\n    LEFT JOIN (\n      SELECT datname\n        , state\n        , usename\n        , COALESCE(application_name, '') AS application_name\n        , pg_catalog.count(*)\n        , COALESCE(EXTRACT (EPOCH FROM (pg_catalog.max(pg_catalog.now() OPERATOR(pg_catalog.-) xact_start))), 0) AS max_tx_secs\n      FROM pg_catalog.pg_stat_activity\n      GROUP BY datname, state, usename, application_name\n    ) sa ON states.state OPERATOR(pg_catalog.=) sa.state\n    WHERE sa.usename IS NOT NULL\n  metrics:\n    - datname:\n        usage: \"LABEL\"\n        description: \"Name of the database\"\n    - usename:\n        usage: \"LABEL\"\n        description: \"Name of the user\"\n    - application_name:\n        usage: \"LABEL\"\n        description: \"Name of the application\"\n    - state:\n        usage: \"LABEL\"\n        description: \"State of the backend\"\n    - total:\n        usage: \"GAUGE\"\n        description: \"Number of backends\"\n    - max_tx_duration_seconds:\n        usage: \"GAUGE\"\n        description: \"Maximum duration of a transaction in seconds\"\n\nbackends_waiting:\n  query: |\n    SELECT pg_catalog.count(*) AS total\n    FROM pg_catalog.pg_locks blocked_locks\n    JOIN pg_catalog.pg_locks blocking_locks\n      ON blocking_locks.locktype OPERATOR(pg_catalog.=) blocked_locks.locktype\n      AND blocking_locks.database IS NOT DISTINCT FROM blocked_locks.database\n      AND blocking_locks.relation IS NOT DISTINCT FROM blocked_locks.relation\n      AND blocking_locks.page IS NOT DISTINCT FROM blocked_locks.page\n      AND blocking_locks.tuple IS NOT DISTINCT FROM blocked_locks.tuple\n      AND blocking_locks.virtualxid IS NOT DISTINCT FROM blocked_locks.virtualxid\n      AND blocking_locks.transactionid IS NOT DISTINCT FROM blocked_locks.transactionid\n      AND blocking_locks.classid IS NOT DISTINCT FROM blocked_locks.classid\n      AND blocking_locks.objid IS NOT DISTINCT FROM blocked_locks.objid\n      AND blocking_locks.objsubid IS NOT DISTINCT FROM blocked_locks.objsubid\n      AND blocking_locks.pid OPERATOR(pg_catalog.\u003c\u003e) blocked_locks.pid\n    JOIN pg_catalog.pg_stat_activity blocking_activity ON blocking_activity.pid OPERATOR(pg_catalog.=) blocking_locks.pid\n    WHERE NOT blocked_locks.granted\n  metrics:\n    - total:\n        usage: \"GAUGE\"\n        description: \"Total number of backends that are currently waiting on other queries\"\n\npg_database:\n  query: |\n    SELECT datname\n      , pg_catalog.pg_database_size(datname) AS size_bytes\n      , pg_catalog.age(datfrozenxid) AS xid_age\n      , pg_catalog.mxid_age(datminmxid) AS mxid_age\n    FROM pg_catalog.pg_database\n    WHERE datallowconn\n  metrics:\n    - datname:\n        usage: \"LABEL\"\n        description: \"Name of the database\"\n    - size_bytes:\n        usage: \"GAUGE\"\n        description: \"Disk space used by the database\"\n    - xid_age:\n        usage: \"GAUGE\"\n        description: \"Number of transactions from the frozen XID to the current one\"\n    - mxid_age:\n        usage: \"GAUGE\"\n        description: \"Number of multiple transactions (Multixact) from the frozen XID to the current one\"\n\npg_postmaster:\n  query: |\n    SELECT EXTRACT(EPOCH FROM pg_postmaster_start_time) AS start_time\n    FROM pg_catalog.pg_postmaster_start_time()\n  metrics:\n    - start_time:\n        usage: \"GAUGE\"\n        description: \"Time at which postgres started (based on epoch)\"\n\npg_replication:\n  query: |\n    SELECT CASE WHEN (\n        NOT pg_catalog.pg_is_in_recovery()\n        OR pg_catalog.pg_last_wal_receive_lsn() OPERATOR(pg_catalog.=) pg_catalog.pg_last_wal_replay_lsn())\n      THEN 0\n      ELSE GREATEST (0,\n        EXTRACT(EPOCH FROM (pg_catalog.now() OPERATOR(pg_catalog.-) pg_catalog.pg_last_xact_replay_timestamp())))\n      END AS lag,\n      pg_catalog.pg_is_in_recovery() AS in_recovery,\n      EXISTS (TABLE pg_catalog.pg_stat_wal_receiver) AS is_wal_receiver_up,\n      (SELECT pg_catalog.count(*) FROM pg_catalog.pg_stat_replication) AS streaming_replicas\n  metrics:\n    - lag:\n        usage: \"GAUGE\"\n        description: \"Replication lag behind primary in seconds\"\n    - in_recovery:\n        usage: \"GAUGE\"\n        description: \"Whether the instance is in recovery\"\n    - is_wal_receiver_up:\n        usage: \"GAUGE\"\n        description: \"Whether the instance wal_receiver is up\"\n    - streaming_replicas:\n        usage: \"GAUGE\"\n        description: \"Number of streaming replicas connected to the instance\"\n\npg_replication_slots:\n  query: |\n    SELECT slot_name,\n      slot_type,\n      database,\n      active,\n      (CASE pg_catalog.pg_is_in_recovery()\n        WHEN TRUE THEN pg_catalog.pg_wal_lsn_diff(pg_catalog.pg_last_wal_receive_lsn(), restart_lsn)\n        ELSE pg_catalog.pg_wal_lsn_diff(pg_catalog.pg_current_wal_lsn(), restart_lsn)\n      END) as pg_wal_lsn_diff\n    FROM pg_catalog.pg_replication_slots\n    WHERE NOT temporary\n  metrics:\n    - slot_name:\n        usage: \"LABEL\"\n        description: \"Name of the replication slot\"\n    - slot_type:\n        usage: \"LABEL\"\n        description: \"Type of the replication slot\"\n    - database:\n        usage: \"LABEL\"\n        description: \"Name of the database\"\n    - active:\n        usage: \"GAUGE\"\n        description: \"Flag indicating whether the slot is active\"\n    - pg_wal_lsn_diff:\n        usage: \"GAUGE\"\n        description: \"Replication lag in bytes\"\n\npg_stat_archiver:\n  query: |\n    SELECT archived_count\n      , failed_count\n      , COALESCE(EXTRACT(EPOCH FROM (pg_catalog.now() OPERATOR(pg_catalog.-) last_archived_time)), -1) AS seconds_since_last_archival\n      , COALESCE(EXTRACT(EPOCH FROM (pg_catalog.now() OPERATOR(pg_catalog.-) last_failed_time)), -1) AS seconds_since_last_failure\n      , COALESCE(EXTRACT(EPOCH FROM last_archived_time), -1) AS last_archived_time\n      , COALESCE(EXTRACT(EPOCH FROM last_failed_time), -1) AS last_failed_time\n      , COALESCE(CAST(CAST('x' OPERATOR(pg_catalog.||) pg_catalog.right(pg_catalog.split_part(last_archived_wal, '.', 1), 16) AS pg_catalog.bit(64)) AS pg_catalog.int8), -1) AS last_archived_wal_start_lsn\n      , COALESCE(CAST(CAST('x' OPERATOR(pg_catalog.||) pg_catalog.right(pg_catalog.split_part(last_failed_wal, '.', 1), 16) AS pg_catalog.bit(64)) AS pg_catalog.int8), -1) AS last_failed_wal_start_lsn\n      , EXTRACT(EPOCH FROM stats_reset) AS stats_reset_time\n    FROM pg_catalog.pg_stat_archiver\n  predicate_query: |\n    SELECT NOT pg_catalog.pg_is_in_recovery()\n      OR pg_catalog.current_setting('archive_mode') OPERATOR(pg_catalog.=) 'always'\n  metrics:\n    - archived_count:\n        usage: \"COUNTER\"\n        description: \"Number of WAL files that have been successfully archived\"\n    - failed_count:\n        usage: \"COUNTER\"\n        description: \"Number of failed attempts for archiving WAL files\"\n    - seconds_since_last_archival:\n        usage: \"GAUGE\"\n        description: \"Seconds since the last successful archival operation\"\n    - seconds_since_last_failure:\n        usage: \"GAUGE\"\n        description: \"Seconds since the last failed archival operation\"\n    - last_archived_time:\n        usage: \"GAUGE\"\n        description: \"Epoch of the last time WAL archiving succeeded\"\n    - last_failed_time:\n        usage: \"GAUGE\"\n        description: \"Epoch of the last time WAL archiving failed\"\n    - last_archived_wal_start_lsn:\n        usage: \"GAUGE\"\n        description: \"Archived WAL start LSN\"\n    - last_failed_wal_start_lsn:\n        usage: \"GAUGE\"\n        description: \"Last failed WAL LSN\"\n    - stats_reset_time:\n        usage: \"GAUGE\"\n        description: \"Time at which these statistics were last reset\"\n\npg_stat_bgwriter:\n  runonserver: \"\u003c17.0.0\"\n  query: |\n    SELECT checkpoints_timed\n      , checkpoints_req\n      , checkpoint_write_time\n      , checkpoint_sync_time\n      , buffers_checkpoint\n      , buffers_clean\n      , maxwritten_clean\n      , buffers_backend\n      , buffers_backend_fsync\n      , buffers_alloc\n    FROM pg_catalog.pg_stat_bgwriter\n  metrics:\n    - checkpoints_timed:\n        usage: \"COUNTER\"\n        description: \"Number of scheduled checkpoints that have been performed\"\n    - checkpoints_req:\n        usage: \"COUNTER\"\n        description: \"Number of requested checkpoints that have been performed\"\n    - checkpoint_write_time:\n        usage: \"COUNTER\"\n        description: \"Total amount of time that has been spent in the portion of checkpoint processing where files are written to disk, in milliseconds\"\n    - checkpoint_sync_time:\n        usage: \"COUNTER\"\n        description: \"Total amount of time that has been spent in the portion of checkpoint processing where files are synchronized to disk, in milliseconds\"\n    - buffers_checkpoint:\n        usage: \"COUNTER\"\n        description: \"Number of buffers written during checkpoints\"\n    - buffers_clean:\n        usage: \"COUNTER\"\n        description: \"Number of buffers written by the background writer\"\n    - maxwritten_clean:\n        usage: \"COUNTER\"\n        description: \"Number of times the background writer stopped a cleaning scan because it had written too many buffers\"\n    - buffers_backend:\n        usage: \"COUNTER\"\n        description: \"Number of buffers written directly by a backend\"\n    - buffers_backend_fsync:\n        usage: \"COUNTER\"\n        description: \"Number of times a backend had to execute its own fsync call (normally the background writer handles those even when the backend does its own write)\"\n    - buffers_alloc:\n        usage: \"COUNTER\"\n        description: \"Number of buffers allocated\"\n\npg_stat_bgwriter_17:\n  runonserver: \"\u003e=17.0.0\"\n  name: pg_stat_bgwriter\n  query: |\n    SELECT buffers_clean\n      , maxwritten_clean\n      , buffers_alloc\n      , EXTRACT(EPOCH FROM stats_reset) AS stats_reset_time\n    FROM pg_catalog.pg_stat_bgwriter\n  metrics:\n    - buffers_clean:\n        usage: \"COUNTER\"\n        description: \"Number of buffers written by the background writer\"\n    - maxwritten_clean:\n        usage: \"COUNTER\"\n        description: \"Number of times the background writer stopped a cleaning scan because it had written too many buffers\"\n    - buffers_alloc:\n        usage: \"COUNTER\"\n        description: \"Number of buffers allocated\"\n    - stats_reset_time:\n        usage: \"GAUGE\"\n        description: \"Time at which these statistics were last reset\"\n\npg_stat_checkpointer:\n  runonserver: \"\u003e=17.0.0\"\n  query: |\n    SELECT num_timed AS checkpoints_timed\n      , num_requested AS checkpoints_req\n      , restartpoints_timed\n      , restartpoints_req\n      , restartpoints_done\n      , write_time\n      , sync_time\n      , buffers_written\n      , EXTRACT(EPOCH FROM stats_reset) AS stats_reset_time\n    FROM pg_catalog.pg_stat_checkpointer\n  metrics:\n    - checkpoints_timed:\n        usage: \"COUNTER\"\n        description: \"Number of scheduled checkpoints that have been performed\"\n    - checkpoints_req:\n        usage: \"COUNTER\"\n        description: \"Number of requested checkpoints that have been performed\"\n    - restartpoints_timed:\n        usage: \"COUNTER\"\n        description: \"Number of scheduled restartpoints due to timeout or after a failed attempt to perform it\"\n    - restartpoints_req:\n        usage: \"COUNTER\"\n        description: \"Number of requested restartpoints that have been performed\"\n    - restartpoints_done:\n        usage: \"COUNTER\"\n        description: \"Number of restartpoints that have been performed\"\n    - write_time:\n        usage: \"COUNTER\"\n        description: \"Total amount of time that has been spent in the portion of processing checkpoints and restartpoints where files are written to disk, in milliseconds\"\n    - sync_time:\n        usage: \"COUNTER\"\n        description: \"Total amount of time that has been spent in the portion of processing checkpoints and restartpoints where files are synchronized to disk, in milliseconds\"\n    - buffers_written:\n        usage: \"COUNTER\"\n        description: \"Number of buffers written during checkpoints and restartpoints\"\n    - stats_reset_time:\n        usage: \"GAUGE\"\n        description: \"Time at which these statistics were last reset\"\n\npg_stat_database:\n  query: |\n    SELECT datname\n      , xact_commit\n      , xact_rollback\n      , blks_read\n      , blks_hit\n      , tup_returned\n      , tup_fetched\n      , tup_inserted\n      , tup_updated\n      , tup_deleted\n      , conflicts\n      , temp_files\n      , temp_bytes\n      , deadlocks\n      , blk_read_time\n      , blk_write_time\n    FROM pg_catalog.pg_stat_database\n  metrics:\n    - datname:\n        usage: \"LABEL\"\n        description: \"Name of this database\"\n    - xact_commit:\n        usage: \"COUNTER\"\n        description: \"Number of transactions in this database that have been committed\"\n    - xact_rollback:\n        usage: \"COUNTER\"\n        description: \"Number of transactions in this database that have been rolled back\"\n    - blks_read:\n        usage: \"COUNTER\"\n        description: \"Number of disk blocks read in this database\"\n    - blks_hit:\n        usage: \"COUNTER\"\n        description: \"Number of times disk blocks were found already in the buffer cache, so that a read was not necessary (this only includes hits in the PostgreSQL buffer cache, not the operating system's file system cache)\"\n    - tup_returned:\n        usage: \"COUNTER\"\n        description: \"Number of rows returned by queries in this database\"\n    - tup_fetched:\n        usage: \"COUNTER\"\n        description: \"Number of rows fetched by queries in this database\"\n    - tup_inserted:\n        usage: \"COUNTER\"\n        description: \"Number of rows inserted by queries in this database\"\n    - tup_updated:\n        usage: \"COUNTER\"\n        description: \"Number of rows updated by queries in this database\"\n    - tup_deleted:\n        usage: \"COUNTER\"\n        description: \"Number of rows deleted by queries in this database\"\n    - conflicts:\n        usage: \"COUNTER\"\n        description: \"Number of queries canceled due to conflicts with recovery in this database\"\n    - temp_files:\n        usage: \"COUNTER\"\n        description: \"Number of temporary files created by queries in this database\"\n    - temp_bytes:\n        usage: \"COUNTER\"\n        description: \"Total amount of data written to temporary files by queries in this database\"\n    - deadlocks:\n        usage: \"COUNTER\"\n        description: \"Number of deadlocks detected in this database\"\n    - blk_read_time:\n        usage: \"COUNTER\"\n        description: \"Time spent reading data file blocks by backends in this database, in milliseconds\"\n    - blk_write_time:\n        usage: \"COUNTER\"\n        description: \"Time spent writing data file blocks by backends in this database, in milliseconds\"\n\npg_stat_replication:\n  primary: true\n  query: |\n    SELECT usename\n      , COALESCE(application_name, '') AS application_name\n      , COALESCE(client_addr::text, '') AS client_addr\n      , COALESCE(client_port::text, '') AS client_port\n      , EXTRACT(EPOCH FROM backend_start) AS backend_start\n      , COALESCE(pg_catalog.age(backend_xmin), 0) AS backend_xmin_age\n      , pg_catalog.pg_wal_lsn_diff(pg_catalog.pg_current_wal_lsn(), sent_lsn) AS sent_diff_bytes\n      , pg_catalog.pg_wal_lsn_diff(pg_catalog.pg_current_wal_lsn(), write_lsn) AS write_diff_bytes\n      , pg_catalog.pg_wal_lsn_diff(pg_catalog.pg_current_wal_lsn(), flush_lsn) AS flush_diff_bytes\n      , COALESCE(pg_catalog.pg_wal_lsn_diff(pg_catalog.pg_current_wal_lsn(), replay_lsn),0) AS replay_diff_bytes\n      , COALESCE((EXTRACT(EPOCH FROM write_lag)),0)::float AS write_lag_seconds\n      , COALESCE((EXTRACT(EPOCH FROM flush_lag)),0)::float AS flush_lag_seconds\n      , COALESCE((EXTRACT(EPOCH FROM replay_lag)),0)::float AS replay_lag_seconds\n    FROM pg_catalog.pg_stat_replication\n  metrics:\n    - usename:\n        usage: \"LABEL\"\n        description: \"Name of the replication user\"\n    - application_name:\n        usage: \"LABEL\"\n        description: \"Name of the application\"\n    - client_addr:\n        usage: \"LABEL\"\n        description: \"Client IP address\"\n    - client_port:\n        usage: \"LABEL\"\n        description: \"Client TCP port\"\n    - backend_start:\n        usage: \"COUNTER\"\n        description: \"Time when this process was started\"\n    - backend_xmin_age:\n        usage: \"COUNTER\"\n        description: \"The age of this standby's xmin horizon\"\n    - sent_diff_bytes:\n        usage: \"GAUGE\"\n        description: \"Difference in bytes from the last write-ahead log location sent on this connection\"\n    - write_diff_bytes:\n        usage: \"GAUGE\"\n        description: \"Difference in bytes from the last write-ahead log location written to disk by this standby server\"\n    - flush_diff_bytes:\n        usage: \"GAUGE\"\n        description: \"Difference in bytes from the last write-ahead log location flushed to disk by this standby server\"\n    - replay_diff_bytes:\n        usage: \"GAUGE\"\n        description: \"Difference in bytes from the last write-ahead log location replayed into the database on this standby server\"\n    - write_lag_seconds:\n        usage: \"GAUGE\"\n        description: \"Time elapsed between flushing recent WAL locally and receiving notification that this standby server has written it\"\n    - flush_lag_seconds:\n        usage: \"GAUGE\"\n        description: \"Time elapsed between flushing recent WAL locally and receiving notification that this standby server has written and flushed it\"\n    - replay_lag_seconds:\n        usage: \"GAUGE\"\n        description: \"Time elapsed between flushing recent WAL locally and receiving notification that this standby server has written, flushed and applied it\"\n\npg_settings:\n  query: |\n    SELECT name,\n    CASE setting WHEN 'on' THEN '1' WHEN 'off' THEN '0' ELSE setting END AS setting\n    FROM pg_catalog.pg_settings\n    WHERE vartype IN ('integer', 'real', 'bool')\n    ORDER BY 1\n  metrics:\n    - name:\n        usage: \"LABEL\"\n        description: \"Name of the setting\"\n    - setting:\n        usage: \"GAUGE\"\n        description: \"Setting value\"\n\npg_extensions:\n  query: |\n    SELECT\n      pg_catalog.current_database() as datname,\n      name as extname,\n      default_version,\n      installed_version,\n      CASE\n        WHEN default_version OPERATOR(pg_catalog.=) installed_version THEN 0\n        ELSE 1\n    END AS update_available\n    FROM pg_catalog.pg_available_extensions\n    WHERE installed_version IS NOT NULL\n  metrics:\n    - datname:\n        usage: \"LABEL\"\n        description: \"Name of the database\"\n    - extname:\n        usage: \"LABEL\"\n        description: \"Extension name\"\n    - default_version:\n        usage: \"LABEL\"\n        description: \"Default version\"\n    - installed_version:\n        usage: \"LABEL\"\n        description: \"Installed version\"\n    - update_available:\n        usage: \"GAUGE\"\n        description: \"An update is available\"\n  target_databases:\n    - '*'\n",
           "description": "A string representation of a YAML defining monitoring queries.",
-          "type": "string"
+          "required": []
         }
       },
       "required": [],
@@ -262,18 +255,15 @@
     },
     "nodeSelector": {
       "description": "Nodeselector for the operator to be installed.",
-      "required": [],
-      "type": "object"
+      "required": []
     },
     "podAnnotations": {
       "description": "Annotations to be added to the pod.",
-      "required": [],
-      "type": "object"
+      "required": []
     },
     "podLabels": {
       "description": "Labels to be added to the pod.",
-      "required": [],
-      "type": "object"
+      "required": []
     },
     "podSecurityContext": {
       "description": "Security Context for the whole pod.",
@@ -293,25 +283,24 @@
           "type": "object"
         }
       },
-      "required": [],
-      "type": "object"
+      "required": []
     },
     "priorityClassName": {
       "default": "",
       "description": "Priority indicates the importance of a Pod relative to other Pods.",
-      "type": "string"
+      "required": []
     },
     "rbac": {
       "properties": {
         "aggregateClusterRoles": {
-          "default": false,
-          "description": "Aggregate ClusterRoles to Kubernetes default user-facing roles.\nRef: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles",
-          "type": "boolean"
+          "default": "false",
+          "description": "Aggregate ClusterRoles to Kubernetes default user-facing roles. Ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles",
+          "required": []
         },
         "create": {
-          "default": true,
+          "default": "true",
           "description": "Specifies whether ClusterRole and ClusterRoleBinding should be created.",
-          "type": "boolean"
+          "required": []
         }
       },
       "required": [],
@@ -332,17 +321,17 @@
           "items": {
             "required": []
           },
-          "type": "array"
+          "required": []
         },
         "ipFamilyPolicy": {
           "default": "",
           "description": "Set the ip family policy to configure dual-stack see [Configure dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services)",
-          "type": "string"
+          "required": []
         },
         "name": {
           "default": "cnpg-webhook-service",
-          "description": "DO NOT CHANGE THE SERVICE NAME as it is currently used to generate the certificate\nand can not be configured",
-          "type": "string"
+          "description": "DO NOT CHANGE THE SERVICE NAME as it is currently used to generate the certificate and can not be configured",
+          "required": []
         },
         "port": {
           "default": 443,
@@ -359,14 +348,14 @@
     "serviceAccount": {
       "properties": {
         "create": {
-          "default": true,
+          "default": "true",
           "description": "Specifies whether the service account should be created.",
-          "type": "boolean"
+          "required": []
         },
         "name": {
           "default": "",
-          "description": "The name of the service account to use.\nIf not set and create is true, a name is generated using the fullname template.",
-          "type": "string"
+          "description": "The name of the service account to use. If not set and create is true, a name is generated using the fullname template.",
+          "required": []
         }
       },
       "required": [],
@@ -377,19 +366,18 @@
       "items": {
         "required": []
       },
-      "type": "array"
+      "required": []
     },
     "topologySpreadConstraints": {
       "description": "Topology Spread Constraints for the operator to be installed.",
       "items": {
         "required": []
       },
-      "type": "array"
+      "required": []
     },
     "updateStrategy": {
-      "description": "Update strategy for the operator.\nref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy\nFor example:\n type: RollingUpdate\n rollingUpdate:\n   maxSurge: 25%\n   maxUnavailable: 25%",
-      "required": [],
-      "type": "object"
+      "description": "Update strategy for the operator. ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy For example:  type: RollingUpdate  rollingUpdate:    maxSurge: 25%    maxUnavailable: 25%",
+      "required": []
     },
     "webhook": {
       "description": "The webhook configuration.",
@@ -461,8 +449,7 @@
           "type": "object"
         }
       },
-      "required": [],
-      "type": "object"
+      "required": []
     }
   },
   "required": [],

--- a/charts/cloudnative-pg/values.yaml
+++ b/charts/cloudnative-pg/values.yaml
@@ -85,6 +85,7 @@ config:
   # INHERITED_ANNOTATIONS: categories
   # INHERITED_LABELS: environment, workload, app
   # WATCH_NAMESPACE: namespace-a,namespace-b
+
   # -- The maximum number of concurrent reconciles. Defaults to 10.
   maxConcurrentReconciles: 10
 

--- a/charts/cloudnative-pg/values.yaml
+++ b/charts/cloudnative-pg/values.yaml
@@ -38,12 +38,12 @@ dnsPolicy: ""
 
 # -- Update strategy for the operator.
 # ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+updateStrategy: {}
 # For example:
 #  type: RollingUpdate
 #  rollingUpdate:
 #    maxSurge: 25%
 #    maxUnavailable: 25%
-updateStrategy: {}
 
 crds:
   # -- Specifies whether the CRDs should be created when installing the chart.
@@ -93,12 +93,12 @@ config:
 additionalArgs: []
 
 # -- Array containing extra environment variables which can be templated.
+additionalEnv: []
 # For example:
 #  - name: RELEASE_NAME
 #    value: "{{ .Release.Name }}"
 #  - name: MY_VAR
 #    value: "mySpecialKey"
-additionalEnv: []
 
 serviceAccount:
   # -- Specifies whether the service account should be created.
@@ -145,9 +145,11 @@ priorityClassName: ""
 
 service:
   type: ClusterIP
-  # -- DO NOT CHANGE THE SERVICE NAME as it is currently used to generate the certificate
-  # and can not be configured
+  # -- The name of the Webhook Service.
   name: cnpg-webhook-service
+  # DO NOT CHANGE THE SERVICE NAME as it is currently used to generate the certificate
+  # and can not be configured
+
   port: 443
   # -- Set the ip family policy to configure dual-stack see [Configure dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services)
   ipFamilyPolicy: ""
@@ -194,9 +196,9 @@ monitoring:
     namespace: ""
     # -- The name of the ConfigMap containing the dashboard.
     configMapName: "cnpg-grafana-dashboard"
-    # -- Label that ConfigMaps should have to be loaded as dashboards.  DEPRECATED: Use labels instead.
+    # -- Label that ConfigMaps should have to be loaded as dashboards. DEPRECATED: Use labels instead.
     sidecarLabel: "grafana_dashboard"
-    # -- Label value that ConfigMaps should have to be loaded as dashboards.  DEPRECATED: Use labels instead.
+    # -- Label value that ConfigMaps should have to be loaded as dashboards. DEPRECATED: Use labels instead.
     sidecarLabelValue: "1"
     # -- Labels that ConfigMaps should have to get configured in Grafana.
     labels: {}

--- a/charts/cluster/README.md
+++ b/charts/cluster/README.md
@@ -127,11 +127,11 @@ Kubernetes: `>=1.29.0-0`
 | backups.data.compression | string | `"gzip"` | Data compression method. One of `` (for no compression), `gzip`, `bzip2` or `snappy`. |
 | backups.data.encryption | string | `"AES256"` | Whether to instruct the storage provider to encrypt data files. One of `` (use the storage container default), `AES256` or `aws:kms`. |
 | backups.data.jobs | int | `2` | Number of data files to be archived or restored in parallel. |
-| backups.destinationPath | string | `""` | Overrides the provider specific default path. Defaults to: S3: s3://<bucket><path> Azure: https://<storageAccount>.<serviceName>.core.windows.net/<containerName><path> Google: gs://<bucket><path> |
+| backups.destinationPath | string | `""` | Overrides the provider specific default path. |
 | backups.enabled | bool | `false` | You need to configure backups manually, so backups are disabled by default. |
 | backups.endpointCA | object | `{"create":false,"key":"","name":"","value":""}` | Specifies a CA bundle to validate a privately signed certificate. |
 | backups.endpointCA.create | bool | `false` | Creates a secret with the given value if true, otherwise uses an existing secret. |
-| backups.endpointURL | string | `""` | Overrides the provider specific default endpoint. Defaults to: S3: https://s3.<region>.amazonaws.com" |
+| backups.endpointURL | string | `""` | Overrides the provider specific default endpoint. |
 | backups.google.applicationCredentials | string | `""` |  |
 | backups.google.bucket | string | `""` |  |
 | backups.google.gkeEnvironment | bool | `false` |  |
@@ -222,10 +222,10 @@ Kubernetes: `>=1.29.0-0`
 | recovery.backupName | string | `""` | Backup Recovery Method |
 | recovery.clusterName | string | `""` | The original cluster name when used in backups. Also known as serverName. |
 | recovery.database | string | `"app"` | Name of the database used by the application. Default: `app`. |
-| recovery.destinationPath | string | `""` | Overrides the provider specific default path. Defaults to: S3: s3://<bucket><path> Azure: https://<storageAccount>.<serviceName>.core.windows.net/<containerName><path> Google: gs://<bucket><path> |
+| recovery.destinationPath | string | `""` | Overrides the provider specific default path. |
 | recovery.endpointCA | object | `{"create":false,"key":"","name":"","value":""}` | Specifies a CA bundle to validate a privately signed certificate. |
 | recovery.endpointCA.create | bool | `false` | Creates a secret with the given value if true, otherwise uses an existing secret. |
-| recovery.endpointURL | string | `""` | Overrides the provider specific default endpoint. Defaults to: S3: https://s3.<region>.amazonaws.com" Leave empty if using the default S3 endpoint |
+| recovery.endpointURL | string | `""` | Overrides the provider specific default endpoint. |
 | recovery.google.applicationCredentials | string | `""` |  |
 | recovery.google.bucket | string | `""` |  |
 | recovery.google.gkeEnvironment | bool | `false` |  |
@@ -297,7 +297,7 @@ Kubernetes: `>=1.29.0-0`
 | replica.origin.objectStore.azure.storageKey | string | `""` |  |
 | replica.origin.objectStore.azure.storageSasToken | string | `""` |  |
 | replica.origin.objectStore.clusterName | string | `""` | The original cluster name when used in backups. Also known as serverName. |
-| replica.origin.objectStore.destinationPath | string | `""` | Overrides the provider specific default path. Defaults to: S3: s3://<bucket><path> Azure: https://<storageAccount>.<serviceName>.core.windows.net/<containerName><path> Google: gs://<bucket><path> |
+| replica.origin.objectStore.destinationPath | string | `""` | Overrides the provider specific default path. |
 | replica.origin.objectStore.endpointCA | object | `{"create":false,"key":"","name":"","value":""}` | Specifies a CA bundle to validate a privately signed certificate. |
 | replica.origin.objectStore.endpointCA.create | bool | `false` | Creates a secret with the given value if true, otherwise uses an existing secret. |
 | replica.origin.objectStore.google.applicationCredentials | string | `""` |  |

--- a/charts/cluster/README.md
+++ b/charts/cluster/README.md
@@ -203,7 +203,7 @@ Kubernetes: `>=1.29.0-0`
 | cluster.walStorage.enabled | bool | `false` |  |
 | cluster.walStorage.size | string | `"1Gi"` |  |
 | cluster.walStorage.storageClass | string | `""` |  |
-| databases | list | `[]` |  |
+| databases | list | `[]` | Database management configuration. |
 | fullnameOverride | string | `""` | Override the full name of the chart |
 | imageCatalog.create | bool | `true` | Whether to provision an image catalog. If imageCatalog.images is empty this option will be ignored. |
 | imageCatalog.images | list | `[]` | List of images to be provisioned in an image catalog. |
@@ -272,6 +272,7 @@ Kubernetes: `>=1.29.0-0`
 | recovery.pgBaseBackup.source.sslRootCertSecret.key | string | `""` |  |
 | recovery.pgBaseBackup.source.sslRootCertSecret.name | string | `""` |  |
 | recovery.pgBaseBackup.source.username | string | `""` |  |
+| recovery.pitrTarget | object | `{"time":""}` | Point in time recovery target. Specify one of the following: |
 | recovery.pitrTarget.time | string | `""` | Time in RFC3339 format |
 | recovery.provider | string | `"s3"` | One of `s3`, `azure` or `google` |
 | recovery.s3.accessKey | string | `""` |  |

--- a/charts/cluster/values.schema.json
+++ b/charts/cluster/values.schema.json
@@ -46,17 +46,17 @@
             "compression": {
               "default": "gzip",
               "description": "Data compression method. One of `` (for no compression), `gzip`, `bzip2` or `snappy`.",
-              "type": "string"
+              "required": []
             },
             "encryption": {
               "default": "AES256",
               "description": "Whether to instruct the storage provider to encrypt data files. One of `` (use the storage container default), `AES256` or `aws:kms`.",
-              "type": "string"
+              "required": []
             },
             "jobs": {
-              "default": 2,
+              "default": "2",
               "description": "Number of data files to be archived or restored in parallel.",
-              "type": "integer"
+              "required": []
             }
           },
           "required": [],
@@ -64,21 +64,21 @@
         },
         "destinationPath": {
           "default": "",
-          "description": "Overrides the provider specific default path. Defaults to:\nS3: s3://\u003cbucket\u003e\u003cpath\u003e\nAzure: https://\u003cstorageAccount\u003e.\u003cserviceName\u003e.core.windows.net/\u003ccontainerName\u003e\u003cpath\u003e\nGoogle: gs://\u003cbucket\u003e\u003cpath\u003e",
-          "type": "string"
+          "description": "Overrides the provider specific default path. Defaults to: S3: s3://\u003cbucket\u003e\u003cpath\u003e Azure: https://\u003cstorageAccount\u003e.\u003cserviceName\u003e.core.windows.net/\u003ccontainerName\u003e\u003cpath\u003e Google: gs://\u003cbucket\u003e\u003cpath\u003e",
+          "required": []
         },
         "enabled": {
-          "default": false,
+          "default": "false",
           "description": "You need to configure backups manually, so backups are disabled by default.",
-          "type": "boolean"
+          "required": []
         },
         "endpointCA": {
           "description": "Specifies a CA bundle to validate a privately signed certificate.",
           "properties": {
             "create": {
-              "default": false,
+              "default": "false",
               "description": "Creates a secret with the given value if true, otherwise uses an existing secret.",
-              "type": "boolean"
+              "required": []
             },
             "key": {
               "default": "",
@@ -93,13 +93,12 @@
               "type": "string"
             }
           },
-          "required": [],
-          "type": "object"
+          "required": []
         },
         "endpointURL": {
           "default": "",
-          "description": "Overrides the provider specific default endpoint. Defaults to:\nS3: https://s3.\u003cregion\u003e.amazonaws.com\"",
-          "type": "string"
+          "description": "Overrides the provider specific default endpoint. Defaults to: S3: https://s3.\u003cregion\u003e.amazonaws.com\"",
+          "required": []
         },
         "google": {
           "properties": {
@@ -126,12 +125,12 @@
         "provider": {
           "default": "s3",
           "description": "One of `s3`, `azure` or `google`",
-          "type": "string"
+          "required": []
         },
         "retentionPolicy": {
           "default": "30d",
           "description": "Retention policy for backups",
-          "type": "string"
+          "required": []
         },
         "s3": {
           "properties": {
@@ -144,9 +143,9 @@
               "type": "string"
             },
             "inheritFromIAMRole": {
-              "default": false,
+              "default": "false",
               "description": "Use the role based authentication without providing explicitly the keys",
-              "type": "boolean"
+              "required": []
             },
             "path": {
               "default": "/",
@@ -172,22 +171,22 @@
                   "backupOwnerReference": {
                     "default": "self",
                     "description": "Backup owner reference",
-                    "type": "string"
+                    "required": []
                   },
                   "method": {
                     "default": "barmanObjectStore",
                     "description": "Backup method, can be `barmanObjectStore` (default) or `volumeSnapshot`",
-                    "type": "string"
+                    "required": []
                   },
                   "name": {
                     "default": "daily-backup",
                     "description": "Scheduled backup name",
-                    "type": "string"
+                    "required": []
                   },
                   "schedule": {
                     "default": "0 0 0 * * *",
                     "description": "Schedule in cron format",
-                    "type": "string"
+                    "required": []
                   }
                 },
                 "required": [],
@@ -201,14 +200,14 @@
         "secret": {
           "properties": {
             "create": {
-              "default": true,
+              "default": "true",
               "description": "Whether to create a secret for the backup credentials",
-              "type": "boolean"
+              "required": []
             },
             "name": {
               "default": "",
               "description": "Name of the backup credentials secret",
-              "type": "string"
+              "required": []
             }
           },
           "required": [],
@@ -219,17 +218,17 @@
             "compression": {
               "default": "gzip",
               "description": "WAL compression method. One of `` (for no compression), `gzip`, `bzip2` or `snappy`.",
-              "type": "string"
+              "required": []
             },
             "encryption": {
               "default": "AES256",
               "description": "Whether to instruct the storage provider to encrypt WAL files. One of `` (use the storage container default), `AES256` or `aws:kms`.",
-              "type": "string"
+              "required": []
             },
             "maxParallel": {
-              "default": 1,
+              "default": "1",
               "description": "Number of WAL files to be archived or restored in parallel.",
-              "type": "integer"
+              "required": []
             }
           },
           "required": [],
@@ -246,130 +245,126 @@
           "type": "object"
         },
         "affinity": {
-          "description": "Affinity/Anti-affinity rules for Pods.\nSee: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-AffinityConfiguration",
+          "description": "Affinity/Anti-affinity rules for Pods. See: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-AffinityConfiguration",
           "properties": {
             "topologyKey": {
               "default": "topology.kubernetes.io/zone",
               "type": "string"
             }
           },
-          "required": [],
-          "type": "object"
+          "required": []
         },
         "annotations": {
           "required": [],
           "type": "object"
         },
         "certificates": {
-          "description": "The configuration for the CA and related certificates.\nSee: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-CertificatesConfiguration",
-          "required": [],
-          "type": "object"
+          "description": "The configuration for the CA and related certificates. See: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-CertificatesConfiguration",
+          "required": []
         },
         "console": {
           "properties": {
             "enabled": {
-              "default": false,
+              "default": "false",
               "description": "Deploys a console StatefulSet to run long-running commands against the cluster (e.g. `CREATE INDEX`).",
-              "type": "boolean"
+              "required": []
             }
           },
           "required": [],
           "type": "object"
         },
         "enablePDB": {
-          "default": true,
-          "description": "Allow to disable PDB, mainly useful for upgrade of single-instance clusters or development purposes\nSee: https://cloudnative-pg.io/documentation/current/kubernetes_upgrade/#pod-disruption-budgets",
-          "type": "boolean"
+          "default": "true",
+          "description": "Allow to disable PDB, mainly useful for upgrade of single-instance clusters or development purposes See: https://cloudnative-pg.io/documentation/current/kubernetes_upgrade/#pod-disruption-budgets",
+          "required": []
         },
         "enableSuperuserAccess": {
-          "default": true,
-          "description": "When this option is enabled, the operator will use the SuperuserSecret to update the postgres user password.\nIf the secret is not present, the operator will automatically create one.\nWhen this option is disabled, the operator will ignore the SuperuserSecret content, delete it when automatically created,\nand then blank the password of the postgres user by setting it to NULL.",
-          "type": "boolean"
+          "default": "true",
+          "description": "When this option is enabled, the operator will use the SuperuserSecret to update the postgres user password. If the secret is not present, the operator will automatically create one. When this option is disabled, the operator will ignore the SuperuserSecret content, delete it when automatically created, and then blank the password of the postgres user by setting it to NULL.",
+          "required": []
         },
         "env": {
           "description": "Env follows the Env format to pass environment variables to the pods created in the cluster",
           "items": {
             "required": []
           },
-          "type": "array"
+          "required": []
         },
         "envFrom": {
           "description": "EnvFrom follows the EnvFrom format to pass environment variables sources to the pods to be used by Env",
           "items": {
             "required": []
           },
-          "type": "array"
+          "required": []
         },
         "imageCatalogRef": {
           "description": "Reference to `ImageCatalog` of `ClusterImageCatalog`, if specified takes precedence over `cluster.imageName`",
-          "required": [],
-          "type": "object"
+          "required": []
         },
         "imageName": {
           "default": "",
-          "description": "Name of the container image, supporting both tags (\u003cimage\u003e:\u003ctag\u003e) and digests for deterministic and repeatable deployments:\n\u003cimage\u003e:\u003ctag\u003e",
-          "type": "string"
+          "description": "Name of the container image, supporting both tags (\u003cimage\u003e:\u003ctag\u003e) and digests for deterministic and repeatable deployments: \u003cimage\u003e:\u003ctag\u003e@sha256:\u003cdigestValue\u003e",
+          "required": []
         },
         "imagePullPolicy": {
           "default": "IfNotPresent",
-          "description": "Image pull policy. One of Always, Never or IfNotPresent. If not defined, it defaults to IfNotPresent. Cannot be updated.\nMore info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
-          "type": "string"
+          "description": "Image pull policy. One of Always, Never or IfNotPresent. If not defined, it defaults to IfNotPresent. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+          "required": []
         },
         "imagePullSecrets": {
-          "description": "The list of pull secrets to be used to pull the images.\nSee: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-LocalObjectReference",
+          "description": "The list of pull secrets to be used to pull the images. See: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-LocalObjectReference",
           "items": {
             "required": []
           },
-          "type": "array"
+          "required": []
         },
         "initdb": {
-          "description": "BootstrapInitDB is the configuration of the bootstrap process when initdb is used.\nSee: https://cloudnative-pg.io/documentation/current/bootstrap/\nSee: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-bootstrapinitdb",
-          "required": [],
-          "type": "object"
+          "description": "BootstrapInitDB is the configuration of the bootstrap process when initdb is used. See: https://cloudnative-pg.io/documentation/current/bootstrap/ See: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-bootstrapinitdb",
+          "required": []
         },
         "instances": {
-          "default": 3,
+          "default": "3",
           "description": "Number of instances",
-          "type": "integer"
+          "required": []
         },
         "logLevel": {
           "default": "info",
           "description": "The instances' log level, one of the following values: error, warning, info (default), debug, trace",
-          "type": "string"
+          "required": []
         },
         "monitoring": {
           "properties": {
             "customQueries": {
-              "description": "Custom Prometheus metrics\nWill be stored in the ConfigMap",
+              "description": "Custom Prometheus metrics Will be stored in the ConfigMap",
               "items": {
                 "required": []
               },
-              "type": "array"
+              "required": []
             },
             "customQueriesSecret": {
-              "description": " - name: \"pg_cache_hit_ratio\"\n   query: \"SELECT current_database() as datname, sum(heap_blks_hit) / (sum(heap_blks_hit) + sum(heap_blks_read)) as ratio FROM pg_statio_user_tables;\"\n   target_databases: [\"*\"]\n   predicate_query: \"SELECT '{{ .Values.version.postgresql }}';\"\n   metrics:\n     - datname:\n         usage: \"LABEL\"\n         description: \"Name of the database\"\n     - ratio:\n         usage: GAUGE\n         description: \"Cache hit ratio\"\nThe list of secrets containing the custom queries",
+              "description": "The list of secrets containing the custom queries",
               "items": {
                 "required": []
               },
-              "type": "array"
+              "required": []
             },
             "disableDefaultQueries": {
-              "default": false,
-              "description": "Whether the default queries should be injected.\nSet it to true if you don't want to inject default queries into the cluster.",
-              "type": "boolean"
+              "default": "false",
+              "description": "Whether the default queries should be injected. Set it to true if you don't want to inject default queries into the cluster.",
+              "required": []
             },
             "enabled": {
-              "default": false,
+              "default": "false",
               "description": "Whether to enable monitoring",
-              "type": "boolean"
+              "required": []
             },
             "instrumentation": {
               "description": "Additional instrumentation via custom metrics",
               "properties": {
                 "logicalReplication": {
-                  "default": true,
+                  "default": "true",
                   "description": "Enable logical replication metrics",
-                  "type": "boolean"
+                  "required": []
                 }
               },
               "required": [],
@@ -378,28 +373,27 @@
             "podMonitor": {
               "properties": {
                 "enabled": {
-                  "default": true,
+                  "default": "true",
                   "description": "Whether to enable the PodMonitor",
-                  "type": "boolean"
+                  "required": []
                 },
                 "labels": {
-                  "description": "Additional labels to set on the generated PodMonitor resource.\nAdd labels your monitoring stack requires (for example `team-name`).",
-                  "required": [],
-                  "type": "object"
+                  "description": "Additional labels to set on the generated PodMonitor resource. Add labels your monitoring stack requires (for example `team-name`).",
+                  "required": []
                 },
                 "metricRelabelings": {
-                  "description": "The list of metric relabelings for the PodMonitor.\nApplied to samples before ingestion.",
+                  "description": "The list of metric relabelings for the PodMonitor. Applied to samples before ingestion.",
                   "items": {
                     "required": []
                   },
-                  "type": "array"
+                  "required": []
                 },
                 "relabelings": {
-                  "description": "The list of relabelings for the PodMonitor.\nApplied to samples before scraping.",
+                  "description": "The list of relabelings for the PodMonitor. Applied to samples before scraping.",
                   "items": {
                     "required": []
                   },
-                  "type": "array"
+                  "required": []
                 }
               },
               "required": [],
@@ -408,16 +402,16 @@
             "prometheusRule": {
               "properties": {
                 "enabled": {
-                  "default": true,
+                  "default": "true",
                   "description": "Whether to enable the PrometheusRule automated alerts",
-                  "type": "boolean"
+                  "required": []
                 },
                 "excludeRules": {
                   "description": "Exclude specified rules",
                   "items": {
                     "required": []
                   },
-                  "type": "array"
+                  "required": []
                 }
               },
               "required": [],
@@ -428,57 +422,53 @@
           "type": "object"
         },
         "podSecurityContext": {
-          "description": "Configure the Pod Security Context.\nSee: https://cloudnative-pg.io/documentation/preview/security/",
-          "required": [],
-          "type": "object"
+          "description": "Configure the Pod Security Context. See: https://cloudnative-pg.io/documentation/preview/security/",
+          "required": []
         },
         "postgresGID": {
-          "default": -1,
+          "default": "-1",
           "description": "The GID of the postgres user inside the image, defaults to 26",
-          "type": "integer"
+          "required": []
         },
         "postgresUID": {
-          "default": -1,
+          "default": "-1",
           "description": "The UID of the postgres user inside the image, defaults to 26",
-          "type": "integer"
+          "required": []
         },
         "postgresql": {
           "properties": {
             "ldap": {
-              "description": "- pgaudit\nPostgreSQL LDAP configuration (see https://cloudnative-pg.io/documentation/current/postgresql_conf/#ldap-configuration)",
-              "required": [],
-              "type": "object"
+              "description": "PostgreSQL LDAP configuration (see https://cloudnative-pg.io/documentation/current/postgresql_conf/#ldap-configuration)",
+              "required": []
             },
             "parameters": {
               "description": "PostgreSQL configuration options (postgresql.conf)",
-              "required": [],
-              "type": "object"
+              "required": []
             },
             "pg_hba": {
-              "description": "method: any\nnumber: 1\nPostgreSQL Host Based Authentication rules (lines to be appended to the pg_hba.conf file)",
+              "description": "PostgreSQL Host Based Authentication rules (lines to be appended to the pg_hba.conf file)",
               "items": {
                 "required": []
               },
-              "type": "array"
+              "required": []
             },
             "pg_ident": {
-              "description": "- host all all 10.244.0.0/16 md5\nPostgreSQL User Name Maps rules (lines to be appended to the pg_ident.conf file)",
+              "description": "PostgreSQL User Name Maps rules (lines to be appended to the pg_ident.conf file)",
               "items": {
                 "required": []
               },
-              "type": "array"
+              "required": []
             },
             "shared_preload_libraries": {
-              "description": "- mymap   /^(.*)\nLists of shared preload libraries to add to the default ones",
+              "description": "Lists of shared preload libraries to add to the default ones",
               "items": {
                 "required": []
               },
-              "type": "array"
+              "required": []
             },
             "synchronous": {
-              "description": "max_connections: 300\nQuorum-based Synchronous Replication",
-              "required": [],
-              "type": "object"
+              "description": "Quorum-based Synchronous Replication",
+              "required": []
             }
           },
           "required": [],
@@ -486,44 +476,40 @@
         },
         "primaryUpdateMethod": {
           "default": "switchover",
-          "description": "Method to follow to upgrade the primary server during a rolling update procedure, after all replicas have been\nsuccessfully updated. It can be switchover (default) or restart.",
-          "type": "string"
+          "description": "Method to follow to upgrade the primary server during a rolling update procedure, after all replicas have been successfully updated. It can be switchover (default) or restart.",
+          "required": []
         },
         "primaryUpdateStrategy": {
           "default": "unsupervised",
-          "description": "Strategy to follow to upgrade the primary server during a rolling update procedure, after all replicas have been\nsuccessfully updated: it can be automated (unsupervised - default) or manual (supervised)",
-          "type": "string"
+          "description": "Strategy to follow to upgrade the primary server during a rolling update procedure, after all replicas have been successfully updated: it can be automated (unsupervised - default) or manual (supervised)",
+          "required": []
         },
         "priorityClassName": {
           "default": "",
           "type": "string"
         },
         "resources": {
-          "description": "Resources requirements of every generated Pod.\nPlease refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ for more information.\nWe strongly advise you use the same setting for limits and requests so that your cluster pods are given a Guaranteed QoS.\nSee: https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/",
-          "required": [],
-          "type": "object"
+          "description": "Resources requirements of every generated Pod. Please refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ for more information. We strongly advise you use the same setting for limits and requests so that your cluster pods are given a Guaranteed QoS. See: https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/",
+          "required": []
         },
         "roles": {
-          "description": "This feature enables declarative management of existing roles, as well as the creation of new roles if they are not\nalready present in the database.\nSee: https://cloudnative-pg.io/documentation/current/declarative_role_management/",
+          "description": "This feature enables declarative management of existing roles, as well as the creation of new roles if they are not already present in the database. See: https://cloudnative-pg.io/documentation/current/declarative_role_management/",
           "items": {
             "required": []
           },
-          "type": "array"
+          "required": []
         },
         "securityContext": {
-          "description": "Configure Container Security Context.\nSee: https://cloudnative-pg.io/documentation/preview/security/",
-          "required": [],
-          "type": "object"
+          "description": "Configure Container Security Context. See: https://cloudnative-pg.io/documentation/preview/security/",
+          "required": []
         },
         "serviceAccountTemplate": {
           "description": "Configure the metadata of the generated service account",
-          "required": [],
-          "type": "object"
+          "required": []
         },
         "services": {
           "description": "Customization of service definitions. Please refer to https://cloudnative-pg.io/documentation/current/service_management/",
-          "required": [],
-          "type": "object"
+          "required": []
         },
         "storage": {
           "properties": {
@@ -566,16 +552,16 @@
       "type": "object"
     },
     "databases": {
-      "description": "#\nDatabase management configuration",
+      "description": " Database management configuration",
       "items": {
         "required": []
       },
-      "type": "array"
+      "required": []
     },
     "fullnameOverride": {
       "default": "",
       "description": "Override the full name of the chart",
-      "type": "string"
+      "required": []
     },
     "global": {
       "description": "Global values are values that can be accessed from any chart or subchart by exactly the same name.",
@@ -585,16 +571,16 @@
     "imageCatalog": {
       "properties": {
         "create": {
-          "default": true,
+          "default": "true",
           "description": "Whether to provision an image catalog. If imageCatalog.images is empty this option will be ignored.",
-          "type": "boolean"
+          "required": []
         },
         "images": {
           "description": "List of images to be provisioned in an image catalog.",
           "items": {
             "required": []
           },
-          "type": "array"
+          "required": []
         }
       },
       "required": [],
@@ -602,25 +588,25 @@
     },
     "mode": {
       "default": "standalone",
-      "description": "##\nCluster mode of operation. Available modes:\n* `standalone` - default mode. Creates new or updates an existing CNPG cluster.\n* `replica` - Creates a replica cluster from an existing CNPG cluster.\n* `recovery` - Same as standalone but creates a cluster from a backup, object store or via pg_basebackup.",
-      "type": "string"
+      "description": "Cluster mode of operation. Available modes: * `standalone` - default mode. Creates new or updates an existing CNPG cluster. * `replica` - Creates a replica cluster from an existing CNPG cluster. * `recovery` - Same as standalone but creates a cluster from a backup, object store or via pg_basebackup.",
+      "required": []
     },
     "nameOverride": {
       "default": "",
       "description": "Override the name of the chart",
-      "type": "string"
+      "required": []
     },
     "namespaceOverride": {
       "default": "",
       "description": "Override the namespace of the chart",
-      "type": "string"
+      "required": []
     },
     "poolers": {
       "description": "List of PgBouncer poolers",
       "items": {
         "required": []
       },
-      "type": "array"
+      "required": []
     },
     "recovery": {
       "properties": {
@@ -664,31 +650,31 @@
         },
         "backupName": {
           "default": "",
-          "description": "#\nBackup Recovery Method",
-          "type": "string"
+          "description": "Backup Recovery Method",
+          "required": []
         },
         "clusterName": {
           "default": "",
-          "description": "#\nThe original cluster name when used in backups. Also known as serverName.",
-          "type": "string"
+          "description": "The original cluster name when used in backups. Also known as serverName.",
+          "required": []
         },
         "database": {
           "default": "app",
           "description": "Name of the database used by the application. Default: `app`.",
-          "type": "string"
+          "required": []
         },
         "destinationPath": {
           "default": "",
-          "description": "Overrides the provider specific default path. Defaults to:\nS3: s3://\u003cbucket\u003e\u003cpath\u003e\nAzure: https://\u003cstorageAccount\u003e.\u003cserviceName\u003e.core.windows.net/\u003ccontainerName\u003e\u003cpath\u003e\nGoogle: gs://\u003cbucket\u003e\u003cpath\u003e",
-          "type": "string"
+          "description": "Overrides the provider specific default path. Defaults to: S3: s3://\u003cbucket\u003e\u003cpath\u003e Azure: https://\u003cstorageAccount\u003e.\u003cserviceName\u003e.core.windows.net/\u003ccontainerName\u003e\u003cpath\u003e Google: gs://\u003cbucket\u003e\u003cpath\u003e",
+          "required": []
         },
         "endpointCA": {
           "description": "Specifies a CA bundle to validate a privately signed certificate.",
           "properties": {
             "create": {
-              "default": false,
+              "default": "false",
               "description": "Creates a secret with the given value if true, otherwise uses an existing secret.",
-              "type": "boolean"
+              "required": []
             },
             "key": {
               "default": "",
@@ -703,13 +689,12 @@
               "type": "string"
             }
           },
-          "required": [],
-          "type": "object"
+          "required": []
         },
         "endpointURL": {
           "default": "",
-          "description": "Overrides the provider specific default endpoint. Defaults to:\nS3: https://s3.\u003cregion\u003e.amazonaws.com\"\nLeave empty if using the default S3 endpoint",
-          "type": "string"
+          "description": "Overrides the provider specific default endpoint. Defaults to: S3: https://s3.\u003cregion\u003e.amazonaws.com\" Leave empty if using the default S3 endpoint",
+          "required": []
         },
         "google": {
           "properties": {
@@ -741,40 +726,40 @@
               "items": {
                 "required": []
               },
-              "type": "array"
+              "required": []
             },
             "pgDumpExtraOptions": {
-              "description": "List of custom options to pass to the `pg_dump` command. IMPORTANT: Use these options with caution and at your\nown risk, as the operator does not validate their content. Be aware that certain options may conflict with the\noperator's intended functionality or design.",
+              "description": "List of custom options to pass to the `pg_dump` command. IMPORTANT: Use these options with caution and at your own risk, as the operator does not validate their content. Be aware that certain options may conflict with the operator's intended functionality or design.",
               "items": {
                 "required": []
               },
-              "type": "array"
+              "required": []
             },
             "pgRestoreExtraOptions": {
-              "description": "List of custom options to pass to the `pg_restore` command. IMPORTANT: Use these options with caution and at\nyour own risk, as the operator does not validate their content. Be aware that certain options may conflict with the\noperator's intended functionality or design.",
+              "description": "List of custom options to pass to the `pg_restore` command. IMPORTANT: Use these options with caution and at your own risk, as the operator does not validate their content. Be aware that certain options may conflict with the operator's intended functionality or design.",
               "items": {
                 "required": []
               },
-              "type": "array"
+              "required": []
             },
             "postImportApplicationSQL": {
-              "description": "List of SQL queries to be executed as a superuser in the application database right after is imported.\nTo be used with extreme care. Only available in microservice type.",
+              "description": "List of SQL queries to be executed as a superuser in the application database right after is imported. To be used with extreme care. Only available in microservice type.",
               "items": {
                 "required": []
               },
-              "type": "array"
+              "required": []
             },
             "roles": {
               "description": "Roles to import",
               "items": {
                 "required": []
               },
-              "type": "array"
+              "required": []
             },
             "schemaOnly": {
-              "default": false,
+              "default": "false",
               "description": "When set to true, only the pre-data and post-data sections of pg_restore are invoked, avoiding data import.",
-              "type": "boolean"
+              "required": []
             },
             "source": {
               "properties": {
@@ -789,24 +774,24 @@
                 "passwordSecret": {
                   "properties": {
                     "create": {
-                      "default": false,
+                      "default": "false",
                       "description": "Whether to create a secret for the password",
-                      "type": "boolean"
+                      "required": []
                     },
                     "key": {
                       "default": "password",
                       "description": "The key in the secret containing the password",
-                      "type": "string"
+                      "required": []
                     },
                     "name": {
                       "default": "",
                       "description": "Name of the secret containing the password",
-                      "type": "string"
+                      "required": []
                     },
                     "value": {
                       "default": "",
                       "description": "The password value to use when creating the secret",
-                      "type": "string"
+                      "required": []
                     }
                   },
                   "required": [],
@@ -872,8 +857,8 @@
             },
             "type": {
               "default": "microservice",
-              "description": "One of `microservice` or `monolith.`\nSee: https://cloudnative-pg.io/documentation/current/database_import/#how-it-works",
-              "type": "string"
+              "description": "One of `microservice` or `monolith.` See: https://cloudnative-pg.io/documentation/current/database_import/#how-it-works",
+              "required": []
             }
           },
           "required": [],
@@ -881,13 +866,13 @@
         },
         "method": {
           "default": "backup",
-          "description": "#\nAvailable recovery methods:\n* `backup` - Recovers a CNPG cluster from a CNPG backup (PITR supported) Needs to be on the same cluster in the same namespace.\n* `object_store` - Recovers a CNPG cluster from a barman object store (PITR supported).\n* `pg_basebackup` - Recovers a CNPG cluster viaa streaming replication protocol. Useful if you want to\n       migrate databases to CloudNativePG, even from outside Kubernetes.\n* `import` - Import one or more databases from an existing Postgres cluster.",
-          "type": "string"
+          "description": "Available recovery methods: * `backup` - Recovers a CNPG cluster from a CNPG backup (PITR supported) Needs to be on the same cluster in the same namespace. * `object_store` - Recovers a CNPG cluster from a barman object store (PITR supported). * `pg_basebackup` - Recovers a CNPG cluster viaa streaming replication protocol. Useful if you want to        migrate databases to CloudNativePG, even from outside Kubernetes. * `import` - Import one or more databases from an existing Postgres cluster.",
+          "required": []
         },
         "owner": {
           "default": "",
           "description": "Name of the owner of the database in the instance to be used by applications. Defaults to the value of the `database` key.",
-          "type": "string"
+          "required": []
         },
         "pgBaseBackup": {
           "description": "See https://cloudnative-pg.io/documentation/current/bootstrap/#bootstrap-from-a-live-cluster-pg_basebackup",
@@ -895,17 +880,17 @@
             "database": {
               "default": "app",
               "description": "Name of the database used by the application. Default: `app`.",
-              "type": "string"
+              "required": []
             },
             "owner": {
               "default": "",
               "description": "Name of the owner of the database in the instance to be used by applications. Defaults to the value of the `database` key.",
-              "type": "string"
+              "required": []
             },
             "secretName": {
               "default": "",
               "description": "Name of the kubernetes.io/basic-auth secret containing the initial credentials for the owner of the user database. If empty a new secret will be created from scratch.",
-              "type": "string"
+              "required": []
             },
             "source": {
               "properties": {
@@ -920,24 +905,24 @@
                 "passwordSecret": {
                   "properties": {
                     "create": {
-                      "default": false,
+                      "default": "false",
                       "description": "Whether to create a secret for the password",
-                      "type": "boolean"
+                      "required": []
                     },
                     "key": {
                       "default": "password",
                       "description": "The key in the secret containing the password",
-                      "type": "string"
+                      "required": []
                     },
                     "name": {
                       "default": "",
                       "description": "Name of the secret containing the password",
-                      "type": "string"
+                      "required": []
                     },
                     "value": {
                       "default": "",
                       "description": "The password value to use when creating the secret",
-                      "type": "string"
+                      "required": []
                     }
                   },
                   "required": [],
@@ -1006,21 +991,20 @@
           "type": "object"
         },
         "pitrTarget": {
-          "description": "# -- Point in time recovery target. Specify one of the following:",
+          "description": "Point in time recovery target. Specify one of the following:",
           "properties": {
             "time": {
               "default": "",
               "description": "Time in RFC3339 format",
-              "type": "string"
+              "required": []
             }
           },
-          "required": [],
-          "type": "object"
+          "required": []
         },
         "provider": {
           "default": "s3",
           "description": "One of `s3`, `azure` or `google`",
-          "type": "string"
+          "required": []
         },
         "s3": {
           "properties": {
@@ -1033,9 +1017,9 @@
               "type": "string"
             },
             "inheritFromIAMRole": {
-              "default": false,
+              "default": "false",
               "description": "Use the role based authentication without providing explicitly the keys",
-              "type": "boolean"
+              "required": []
             },
             "path": {
               "default": "/",
@@ -1056,14 +1040,14 @@
         "secret": {
           "properties": {
             "create": {
-              "default": true,
+              "default": "true",
               "description": "Whether to create a secret for the backup credentials",
-              "type": "boolean"
+              "required": []
             },
             "name": {
               "default": "",
               "description": "Name of the backup credentials secret",
-              "type": "string"
+              "required": []
             }
           },
           "required": [],
@@ -1080,22 +1064,22 @@
             "database": {
               "default": "",
               "description": "Name of the database used by the application",
-              "type": "string"
+              "required": []
             },
             "owner": {
               "default": "",
               "description": "Name of the owner of the database in the instance to be used by applications. Defaults to the value of the `database` key.",
-              "type": "string"
+              "required": []
             },
             "secret": {
               "default": "",
               "description": "Name of the secret containing the initial credentials for the owner of the user database. If empty a new secret will be created from scratch",
-              "type": "string"
+              "required": []
             },
             "source": {
               "default": "",
-              "description": " One of `object_store` or `pg_basebackup`. Method to use for bootstrap.",
-              "type": "string"
+              "description": "One of `object_store` or `pg_basebackup`. Method to use for bootstrap.",
+              "required": []
             }
           },
           "required": [],
@@ -1104,7 +1088,7 @@
         "minApplyDelay": {
           "default": "",
           "description": "When replica mode is enabled, this parameter allows you to replay transactions only when the system time is at least the configured time past the commit time. This provides an opportunity to correct data loss errors. Note that when this parameter is set, a promotion token cannot be used.",
-          "type": "string"
+          "required": []
         },
         "origin": {
           "properties": {
@@ -1151,20 +1135,20 @@
                 "clusterName": {
                   "default": "",
                   "description": "The original cluster name when used in backups. Also known as serverName.",
-                  "type": "string"
+                  "required": []
                 },
                 "destinationPath": {
                   "default": "",
-                  "description": "Overrides the provider specific default path. Defaults to:\nS3: s3://\u003cbucket\u003e\u003cpath\u003e\nAzure: https://\u003cstorageAccount\u003e.\u003cserviceName\u003e.core.windows.net/\u003ccontainerName\u003e\u003cpath\u003e\nGoogle: gs://\u003cbucket\u003e\u003cpath\u003e",
-                  "type": "string"
+                  "description": "Overrides the provider specific default path. Defaults to: S3: s3://\u003cbucket\u003e\u003cpath\u003e Azure: https://\u003cstorageAccount\u003e.\u003cserviceName\u003e.core.windows.net/\u003ccontainerName\u003e\u003cpath\u003e Google: gs://\u003cbucket\u003e\u003cpath\u003e",
+                  "required": []
                 },
                 "endpointCA": {
                   "description": "Specifies a CA bundle to validate a privately signed certificate.",
                   "properties": {
                     "create": {
-                      "default": false,
+                      "default": "false",
                       "description": "Creates a secret with the given value if true, otherwise uses an existing secret.",
-                      "type": "boolean"
+                      "required": []
                     },
                     "key": {
                       "default": "",
@@ -1179,8 +1163,7 @@
                       "type": "string"
                     }
                   },
-                  "required": [],
-                  "type": "object"
+                  "required": []
                 },
                 "google": {
                   "properties": {
@@ -1207,7 +1190,7 @@
                 "provider": {
                   "default": "",
                   "description": "One of `s3`, `azure` or `google`",
-                  "type": "string"
+                  "required": []
                 },
                 "s3": {
                   "properties": {
@@ -1220,9 +1203,9 @@
                       "type": "string"
                     },
                     "inheritFromIAMRole": {
-                      "default": false,
+                      "default": "false",
                       "description": "Use the role based authentication without providing explicitly the keys",
-                      "type": "boolean"
+                      "required": []
                     },
                     "path": {
                       "default": "/",
@@ -1243,14 +1226,14 @@
                 "secret": {
                   "properties": {
                     "create": {
-                      "default": true,
+                      "default": "true",
                       "description": "Whether to create a secret for the backup credentials",
-                      "type": "boolean"
+                      "required": []
                     },
                     "name": {
                       "default": "",
                       "description": "Name of the backup credentials secret",
-                      "type": "string"
+                      "required": []
                     }
                   },
                   "required": [],
@@ -1349,17 +1332,17 @@
         "primary": {
           "default": "",
           "description": "Primary defines which Cluster is defined to be the primary in the distributed PostgreSQL cluster, based on the topology specified in externalClusters",
-          "type": "string"
+          "required": []
         },
         "promotionToken": {
           "default": "",
           "description": "A demotion token generated by an external cluster used to check if the promotion requirements are met.",
-          "type": "string"
+          "required": []
         },
         "self": {
           "default": "",
-          "description": " Defines the name of this cluster. It is used to determine if this is a primary or a replica cluster, comparing it with primary. Leave empty by default.",
-          "type": "string"
+          "description": "Defines the name of this cluster. It is used to determine if this is a primary or a replica cluster, comparing it with primary. Leave empty by default.",
+          "required": []
         }
       },
       "required": [],
@@ -1367,25 +1350,25 @@
     },
     "type": {
       "default": "postgresql",
-      "description": "##\nType of the CNPG database. Available types:\n* `postgresql`\n* `postgis`\n* `timescaledb`",
-      "type": "string"
+      "description": "Type of the CNPG database. Available types: * `postgresql` * `postgis` * `timescaledb`",
+      "required": []
     },
     "version": {
       "properties": {
         "postgis": {
           "default": "3.4",
           "description": "If using PostGIS, specify the version",
-          "type": "string"
+          "required": []
         },
         "postgresql": {
           "default": "16",
           "description": "PostgreSQL major version to use",
-          "type": "string"
+          "required": []
         },
         "timescaledb": {
           "default": "2.15",
           "description": "If using TimescaleDB, specify the version",
-          "type": "string"
+          "required": []
         }
       },
       "required": [],

--- a/charts/cluster/values.schema.json
+++ b/charts/cluster/values.schema.json
@@ -1,945 +1,2005 @@
 {
-    "$schema": "http://json-schema.org/schema#",
-    "type": "object",
-    "properties": {
-        "backups": {
-            "type": "object",
-            "properties": {
-                "azure": {
-                    "type": "object",
-                    "properties": {
-                        "connectionString": {
-                            "type": "string"
-                        },
-                        "containerName": {
-                            "type": "string"
-                        },
-                        "inheritFromAzureAD": {
-                            "type": "boolean"
-                        },
-                        "path": {
-                            "type": "string"
-                        },
-                        "serviceName": {
-                            "type": "string"
-                        },
-                        "storageAccount": {
-                            "type": "string"
-                        },
-                        "storageKey": {
-                            "type": "string"
-                        },
-                        "storageSasToken": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "data": {
-                    "type": "object",
-                    "properties": {
-                        "compression": {
-                            "type": "string"
-                        },
-                        "encryption": {
-                            "type": "string"
-                        },
-                        "jobs": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                "destinationPath": {
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "backups": {
+      "properties": {
+        "azure": {
+          "properties": {
+            "connectionString": {
+              "default": "",
+              "title": "connectionString",
+              "type": "string"
+            },
+            "containerName": {
+              "default": "",
+              "title": "containerName",
+              "type": "string"
+            },
+            "inheritFromAzureAD": {
+              "default": false,
+              "title": "inheritFromAzureAD",
+              "type": "boolean"
+            },
+            "path": {
+              "default": "/",
+              "title": "path",
+              "type": "string"
+            },
+            "serviceName": {
+              "default": "blob",
+              "title": "serviceName",
+              "type": "string"
+            },
+            "storageAccount": {
+              "default": "",
+              "title": "storageAccount",
+              "type": "string"
+            },
+            "storageKey": {
+              "default": "",
+              "title": "storageKey",
+              "type": "string"
+            },
+            "storageSasToken": {
+              "default": "",
+              "title": "storageSasToken",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "connectionString",
+            "storageAccount",
+            "storageKey",
+            "storageSasToken",
+            "containerName",
+            "serviceName",
+            "inheritFromAzureAD"
+          ],
+          "title": "azure",
+          "type": "object"
+        },
+        "data": {
+          "properties": {
+            "compression": {
+              "default": "gzip",
+              "description": "Data compression method. One of `` (for no compression), `gzip`, `bzip2` or `snappy`.",
+              "title": "compression",
+              "type": "string"
+            },
+            "encryption": {
+              "default": "AES256",
+              "description": "Whether to instruct the storage provider to encrypt data files. One of `` (use the storage container default), `AES256` or `aws:kms`.",
+              "title": "encryption",
+              "type": "string"
+            },
+            "jobs": {
+              "default": 2,
+              "description": "Number of data files to be archived or restored in parallel.",
+              "title": "jobs",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "compression",
+            "encryption",
+            "jobs"
+          ],
+          "title": "data",
+          "type": "object"
+        },
+        "destinationPath": {
+          "default": "",
+          "description": "Overrides the provider specific default path. Defaults to:\nS3: s3://\u003cbucket\u003e\u003cpath\u003e\nAzure: https://\u003cstorageAccount\u003e.\u003cserviceName\u003e.core.windows.net/\u003ccontainerName\u003e\u003cpath\u003e\nGoogle: gs://\u003cbucket\u003e\u003cpath\u003e",
+          "title": "destinationPath",
+          "type": "string"
+        },
+        "enabled": {
+          "default": false,
+          "description": "You need to configure backups manually, so backups are disabled by default.",
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "endpointCA": {
+          "description": "Specifies a CA bundle to validate a privately signed certificate.",
+          "properties": {
+            "create": {
+              "default": false,
+              "description": "Creates a secret with the given value if true, otherwise uses an existing secret.",
+              "title": "create",
+              "type": "boolean"
+            },
+            "key": {
+              "default": "",
+              "title": "key",
+              "type": "string"
+            },
+            "name": {
+              "default": "",
+              "title": "name",
+              "type": "string"
+            },
+            "value": {
+              "default": "",
+              "title": "value",
+              "type": "string"
+            }
+          },
+          "required": [
+            "create",
+            "name",
+            "key",
+            "value"
+          ],
+          "title": "endpointCA",
+          "type": "object"
+        },
+        "endpointURL": {
+          "default": "",
+          "description": "Overrides the provider specific default endpoint. Defaults to:\nS3: https://s3.\u003cregion\u003e.amazonaws.com\"",
+          "title": "endpointURL",
+          "type": "string"
+        },
+        "google": {
+          "properties": {
+            "applicationCredentials": {
+              "default": "",
+              "title": "applicationCredentials",
+              "type": "string"
+            },
+            "bucket": {
+              "default": "",
+              "title": "bucket",
+              "type": "string"
+            },
+            "gkeEnvironment": {
+              "default": false,
+              "title": "gkeEnvironment",
+              "type": "boolean"
+            },
+            "path": {
+              "default": "/",
+              "title": "path",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "bucket",
+            "gkeEnvironment",
+            "applicationCredentials"
+          ],
+          "title": "google",
+          "type": "object"
+        },
+        "provider": {
+          "default": "s3",
+          "description": "One of `s3`, `azure` or `google`",
+          "title": "provider",
+          "type": "string"
+        },
+        "retentionPolicy": {
+          "default": "30d",
+          "description": "Retention policy for backups",
+          "title": "retentionPolicy",
+          "type": "string"
+        },
+        "s3": {
+          "properties": {
+            "accessKey": {
+              "default": "",
+              "title": "accessKey",
+              "type": "string"
+            },
+            "bucket": {
+              "default": "",
+              "title": "bucket",
+              "type": "string"
+            },
+            "inheritFromIAMRole": {
+              "default": false,
+              "description": "Use the role based authentication without providing explicitly the keys",
+              "title": "inheritFromIAMRole",
+              "type": "boolean"
+            },
+            "path": {
+              "default": "/",
+              "title": "path",
+              "type": "string"
+            },
+            "region": {
+              "default": "",
+              "title": "region",
+              "type": "string"
+            },
+            "secretKey": {
+              "default": "",
+              "title": "secretKey",
+              "type": "string"
+            }
+          },
+          "required": [
+            "region",
+            "bucket",
+            "path",
+            "accessKey",
+            "secretKey",
+            "inheritFromIAMRole"
+          ],
+          "title": "s3",
+          "type": "object"
+        },
+        "scheduledBackups": {
+          "items": {
+            "anyOf": [
+              {
+                "properties": {
+                  "backupOwnerReference": {
+                    "default": "self",
+                    "description": "Backup owner reference",
+                    "title": "backupOwnerReference",
                     "type": "string"
+                  },
+                  "method": {
+                    "default": "barmanObjectStore",
+                    "description": "Backup method, can be `barmanObjectStore` (default) or `volumeSnapshot`",
+                    "title": "method",
+                    "type": "string"
+                  },
+                  "name": {
+                    "default": "daily-backup",
+                    "description": "Scheduled backup name",
+                    "title": "name",
+                    "type": "string"
+                  },
+                  "schedule": {
+                    "default": "0 0 0 * * *",
+                    "description": "Schedule in cron format",
+                    "title": "schedule",
+                    "type": "string"
+                  }
                 },
+                "required": [
+                  "name",
+                  "schedule",
+                  "backupOwnerReference",
+                  "method"
+                ],
+                "type": "object"
+              }
+            ],
+            "required": []
+          },
+          "title": "scheduledBackups",
+          "type": "array"
+        },
+        "secret": {
+          "properties": {
+            "create": {
+              "default": true,
+              "description": "Whether to create a secret for the backup credentials",
+              "title": "create",
+              "type": "boolean"
+            },
+            "name": {
+              "default": "",
+              "description": "Name of the backup credentials secret",
+              "title": "name",
+              "type": "string"
+            }
+          },
+          "required": [
+            "create",
+            "name"
+          ],
+          "title": "secret",
+          "type": "object"
+        },
+        "wal": {
+          "properties": {
+            "compression": {
+              "default": "gzip",
+              "description": "WAL compression method. One of `` (for no compression), `gzip`, `bzip2` or `snappy`.",
+              "title": "compression",
+              "type": "string"
+            },
+            "encryption": {
+              "default": "AES256",
+              "description": "Whether to instruct the storage provider to encrypt WAL files. One of `` (use the storage container default), `AES256` or `aws:kms`.",
+              "title": "encryption",
+              "type": "string"
+            },
+            "maxParallel": {
+              "default": 1,
+              "description": "Number of WAL files to be archived or restored in parallel.",
+              "title": "maxParallel",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "compression",
+            "encryption",
+            "maxParallel"
+          ],
+          "title": "wal",
+          "type": "object"
+        }
+      },
+      "required": [
+        "enabled",
+        "endpointURL",
+        "endpointCA",
+        "destinationPath",
+        "provider",
+        "s3",
+        "azure",
+        "google",
+        "secret",
+        "wal",
+        "data",
+        "scheduledBackups",
+        "retentionPolicy"
+      ],
+      "title": "backups",
+      "type": "object"
+    },
+    "cluster": {
+      "properties": {
+        "additionalLabels": {
+          "required": [],
+          "title": "additionalLabels",
+          "type": "object"
+        },
+        "affinity": {
+          "description": "Affinity/Anti-affinity rules for Pods.\nSee: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-AffinityConfiguration",
+          "properties": {
+            "topologyKey": {
+              "default": "topology.kubernetes.io/zone",
+              "title": "topologyKey",
+              "type": "string"
+            }
+          },
+          "required": [
+            "topologyKey"
+          ],
+          "title": "affinity",
+          "type": "object"
+        },
+        "annotations": {
+          "required": [],
+          "title": "annotations",
+          "type": "object"
+        },
+        "certificates": {
+          "description": "The configuration for the CA and related certificates.\nSee: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-CertificatesConfiguration",
+          "required": [],
+          "title": "certificates",
+          "type": "object"
+        },
+        "console": {
+          "properties": {
+            "enabled": {
+              "default": false,
+              "description": "Deploys a console StatefulSet to run long-running commands against the cluster (e.g. `CREATE INDEX`).",
+              "title": "enabled",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "enabled"
+          ],
+          "title": "console",
+          "type": "object"
+        },
+        "enablePDB": {
+          "default": true,
+          "description": "Allow to disable PDB, mainly useful for upgrade of single-instance clusters or development purposes\nSee: https://cloudnative-pg.io/documentation/current/kubernetes_upgrade/#pod-disruption-budgets",
+          "title": "enablePDB",
+          "type": "boolean"
+        },
+        "enableSuperuserAccess": {
+          "default": true,
+          "description": "When this option is enabled, the operator will use the SuperuserSecret to update the postgres user password.\nIf the secret is not present, the operator will automatically create one.\nWhen this option is disabled, the operator will ignore the SuperuserSecret content, delete it when automatically created,\nand then blank the password of the postgres user by setting it to NULL.",
+          "title": "enableSuperuserAccess",
+          "type": "boolean"
+        },
+        "env": {
+          "description": "Env follows the Env format to pass environment variables to the pods created in the cluster",
+          "items": {
+            "required": []
+          },
+          "title": "env",
+          "type": "array"
+        },
+        "envFrom": {
+          "description": "EnvFrom follows the EnvFrom format to pass environment variables sources to the pods to be used by Env",
+          "items": {
+            "required": []
+          },
+          "title": "envFrom",
+          "type": "array"
+        },
+        "imageCatalogRef": {
+          "description": "Reference to `ImageCatalog` of `ClusterImageCatalog`, if specified takes precedence over `cluster.imageName`",
+          "required": [],
+          "title": "imageCatalogRef",
+          "type": "object"
+        },
+        "imageName": {
+          "default": "",
+          "description": "Name of the container image, supporting both tags (\u003cimage\u003e:\u003ctag\u003e) and digests for deterministic and repeatable deployments:\n\u003cimage\u003e:\u003ctag\u003e",
+          "title": "imageName",
+          "type": "string"
+        },
+        "imagePullPolicy": {
+          "default": "IfNotPresent",
+          "description": "Image pull policy. One of Always, Never or IfNotPresent. If not defined, it defaults to IfNotPresent. Cannot be updated.\nMore info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+          "title": "imagePullPolicy",
+          "type": "string"
+        },
+        "imagePullSecrets": {
+          "description": "The list of pull secrets to be used to pull the images.\nSee: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-LocalObjectReference",
+          "items": {
+            "required": []
+          },
+          "title": "imagePullSecrets",
+          "type": "array"
+        },
+        "initdb": {
+          "description": "BootstrapInitDB is the configuration of the bootstrap process when initdb is used.\nSee: https://cloudnative-pg.io/documentation/current/bootstrap/\nSee: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-bootstrapinitdb",
+          "required": [],
+          "title": "initdb",
+          "type": "object"
+        },
+        "instances": {
+          "default": 3,
+          "description": "Number of instances",
+          "title": "instances",
+          "type": "integer"
+        },
+        "logLevel": {
+          "default": "info",
+          "description": "The instances' log level, one of the following values: error, warning, info (default), debug, trace",
+          "title": "logLevel",
+          "type": "string"
+        },
+        "monitoring": {
+          "properties": {
+            "customQueries": {
+              "description": "Custom Prometheus metrics\nWill be stored in the ConfigMap",
+              "items": {
+                "required": []
+              },
+              "title": "customQueries",
+              "type": "array"
+            },
+            "customQueriesSecret": {
+              "description": " - name: \"pg_cache_hit_ratio\"\n   query: \"SELECT current_database() as datname, sum(heap_blks_hit) / (sum(heap_blks_hit) + sum(heap_blks_read)) as ratio FROM pg_statio_user_tables;\"\n   target_databases: [\"*\"]\n   predicate_query: \"SELECT '{{ .Values.version.postgresql }}';\"\n   metrics:\n     - datname:\n         usage: \"LABEL\"\n         description: \"Name of the database\"\n     - ratio:\n         usage: GAUGE\n         description: \"Cache hit ratio\"\nThe list of secrets containing the custom queries",
+              "items": {
+                "required": []
+              },
+              "title": "customQueriesSecret",
+              "type": "array"
+            },
+            "disableDefaultQueries": {
+              "default": false,
+              "description": "Whether the default queries should be injected.\nSet it to true if you don't want to inject default queries into the cluster.",
+              "title": "disableDefaultQueries",
+              "type": "boolean"
+            },
+            "enabled": {
+              "default": false,
+              "description": "Whether to enable monitoring",
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "instrumentation": {
+              "description": "Additional instrumentation via custom metrics",
+              "properties": {
+                "logicalReplication": {
+                  "default": true,
+                  "description": "Enable logical replication metrics",
+                  "title": "logicalReplication",
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "logicalReplication"
+              ],
+              "title": "instrumentation",
+              "type": "object"
+            },
+            "podMonitor": {
+              "properties": {
                 "enabled": {
-                    "type": "boolean"
+                  "default": true,
+                  "description": "Whether to enable the PodMonitor",
+                  "title": "enabled",
+                  "type": "boolean"
                 },
-                "endpointCA": {
-                    "type": "object",
-                    "properties": {
-                        "create": {
-                            "type": "boolean"
-                        },
-                        "key": {
-                            "type": "string"
-                        },
-                        "name": {
-                            "type": "string"
-                        },
-                        "value": {
-                            "type": "string"
-                        }
-                    }
+                "labels": {
+                  "description": "Additional labels to set on the generated PodMonitor resource.\nAdd labels your monitoring stack requires (for example `team-name`).",
+                  "required": [],
+                  "title": "labels",
+                  "type": "object"
                 },
-                "endpointURL": {
-                    "type": "string"
+                "metricRelabelings": {
+                  "description": "The list of metric relabelings for the PodMonitor.\nApplied to samples before ingestion.",
+                  "items": {
+                    "required": []
+                  },
+                  "title": "metricRelabelings",
+                  "type": "array"
                 },
-                "google": {
-                    "type": "object",
-                    "properties": {
-                        "applicationCredentials": {
-                            "type": "string"
-                        },
-                        "bucket": {
-                            "type": "string"
-                        },
-                        "gkeEnvironment": {
-                            "type": "boolean"
-                        },
-                        "path": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "provider": {
-                    "type": "string"
-                },
-                "retentionPolicy": {
-                    "type": "string"
-                },
-                "s3": {
-                    "type": "object",
-                    "properties": {
-                        "accessKey": {
-                            "type": "string"
-                        },
-                        "bucket": {
-                            "type": "string"
-                        },
-                        "inheritFromIAMRole": {
-                            "type": "boolean"
-                        },
-                        "path": {
-                            "type": "string"
-                        },
-                        "region": {
-                            "type": "string"
-                        },
-                        "secretKey": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "scheduledBackups": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "backupOwnerReference": {
-                                "type": "string"
-                            },
-                            "method": {
-                                "type": "string"
-                            },
-                            "name": {
-                                "type": "string"
-                            },
-                            "schedule": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "secret": {
-                    "type": "object",
-                    "properties": {
-                        "create": {
-                            "type": "boolean"
-                        },
-                        "name": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "wal": {
-                    "type": "object",
-                    "properties": {
-                        "compression": {
-                            "type": "string"
-                        },
-                        "encryption": {
-                            "type": "string"
-                        },
-                        "maxParallel": {
-                            "type": "integer"
-                        }
-                    }
+                "relabelings": {
+                  "description": "The list of relabelings for the PodMonitor.\nApplied to samples before scraping.",
+                  "items": {
+                    "required": []
+                  },
+                  "title": "relabelings",
+                  "type": "array"
                 }
-            }
-        },
-        "cluster": {
-            "type": "object",
-            "properties": {
-                "additionalLabels": {
-                    "type": "object"
+              },
+              "required": [
+                "enabled",
+                "labels",
+                "relabelings",
+                "metricRelabelings"
+              ],
+              "title": "podMonitor",
+              "type": "object"
+            },
+            "prometheusRule": {
+              "properties": {
+                "enabled": {
+                  "default": true,
+                  "description": "Whether to enable the PrometheusRule automated alerts",
+                  "title": "enabled",
+                  "type": "boolean"
                 },
-                "affinity": {
-                    "type": "object",
-                    "properties": {
-                        "topologyKey": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "annotations": {
-                    "type": "object"
-                },
-                "certificates": {
-                    "type": "object"
-                },
-                "console": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean"
-                        }
-                    }
-                },
-                "enablePDB": {
-                    "type": "boolean"
-                },
-                "enableSuperuserAccess": {
-                    "type": "boolean"
-                },
-                "env": {
-                    "type": "array"
-                },
-                "envFrom": {
-                    "type": "array"
-                },
-                "imageCatalogRef": {
-                    "type": "object"
-                },
-                "imageName": {
-                    "type": "string"
-                },
-                "imagePullPolicy": {
-                    "type": "string"
-                },
-                "imagePullSecrets": {
-                    "type": "array"
-                },
-                "initdb": {
-                    "type": "object"
-                },
-                "instances": {
-                    "type": "integer"
-                },
-                "logLevel": {
-                    "type": "string"
-                },
-                "monitoring": {
-                    "type": "object",
-                    "properties": {
-                        "customQueries": {
-                            "type": "array"
-                        },
-                        "customQueriesSecret": {
-                            "type": "array"
-                        },
-                        "disableDefaultQueries": {
-                            "type": "boolean"
-                        },
-                        "enabled": {
-                            "type": "boolean"
-                        },
-                        "instrumentation": {
-                            "type": "object",
-                            "properties": {
-                                "logicalReplication": {
-                                    "type": "boolean"
-                                }
-                            }
-                        },
-                        "podMonitor": {
-                            "type": "object",
-                            "properties": {
-                                "enabled": {
-                                    "type": "boolean"
-                                },
-                                "labels": {
-                                    "type": "object"
-                                },
-                                "metricRelabelings": {
-                                    "type": "array"
-                                },
-                                "relabelings": {
-                                    "type": "array"
-                                }
-                            }
-                        },
-                        "prometheusRule": {
-                            "type": "object",
-                            "properties": {
-                                "enabled": {
-                                    "type": "boolean"
-                                },
-                                "excludeRules": {
-                                    "type": "array"
-                                }
-                            }
-                        }
-                    }
-                },
-                "podSecurityContext": {
-                    "type": "object"
-                },
-                "postgresGID": {
-                    "type": "integer"
-                },
-                "postgresUID": {
-                    "type": "integer"
-                },
-                "postgresql": {
-                    "type": "object",
-                    "properties": {
-                        "ldap": {
-                            "type": "object"
-                        },
-                        "parameters": {
-                            "type": "object"
-                        },
-                        "pg_hba": {
-                            "type": "array"
-                        },
-                        "pg_ident": {
-                            "type": "array"
-                        },
-                        "shared_preload_libraries": {
-                            "type": "array"
-                        },
-                        "synchronous": {
-                            "type": "object"
-                        }
-                    }
-                },
-                "primaryUpdateMethod": {
-                    "type": "string"
-                },
-                "primaryUpdateStrategy": {
-                    "type": "string"
-                },
-                "priorityClassName": {
-                    "type": "string"
-                },
-                "resources": {
-                    "type": "object"
-                },
-                "roles": {
-                    "type": "array"
-                },
-                "securityContext": {
-                    "type": "object"
-                },
-                "serviceAccountTemplate": {
-                    "type": "object"
-                },
-                "services": {
-                    "type": "object"
-                },
-                "storage": {
-                    "type": "object",
-                    "properties": {
-                        "size": {
-                            "type": "string"
-                        },
-                        "storageClass": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "superuserSecret": {
-                    "type": "string"
-                },
-                "walStorage": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean"
-                        },
-                        "size": {
-                            "type": "string"
-                        },
-                        "storageClass": {
-                            "type": "string"
-                        }
-                    }
+                "excludeRules": {
+                  "description": "Exclude specified rules",
+                  "items": {
+                    "required": []
+                  },
+                  "title": "excludeRules",
+                  "type": "array"
                 }
+              },
+              "required": [
+                "enabled",
+                "excludeRules"
+              ],
+              "title": "prometheusRule",
+              "type": "object"
             }
+          },
+          "required": [
+            "enabled",
+            "podMonitor",
+            "prometheusRule",
+            "instrumentation",
+            "disableDefaultQueries",
+            "customQueries",
+            "customQueriesSecret"
+          ],
+          "title": "monitoring",
+          "type": "object"
         },
-        "databases": {
-            "type": "array"
+        "podSecurityContext": {
+          "description": "Configure the Pod Security Context.\nSee: https://cloudnative-pg.io/documentation/preview/security/",
+          "required": [],
+          "title": "podSecurityContext",
+          "type": "object"
         },
-        "fullnameOverride": {
-            "type": "string"
+        "postgresGID": {
+          "default": -1,
+          "description": "The GID of the postgres user inside the image, defaults to 26",
+          "title": "postgresGID",
+          "type": "integer"
         },
-        "imageCatalog": {
-            "type": "object",
-            "properties": {
-                "create": {
-                    "type": "boolean"
+        "postgresUID": {
+          "default": -1,
+          "description": "The UID of the postgres user inside the image, defaults to 26",
+          "title": "postgresUID",
+          "type": "integer"
+        },
+        "postgresql": {
+          "properties": {
+            "ldap": {
+              "description": "- pgaudit\nPostgreSQL LDAP configuration (see https://cloudnative-pg.io/documentation/current/postgresql_conf/#ldap-configuration)",
+              "required": [],
+              "title": "ldap",
+              "type": "object"
+            },
+            "parameters": {
+              "description": "PostgreSQL configuration options (postgresql.conf)",
+              "required": [],
+              "title": "parameters",
+              "type": "object"
+            },
+            "pg_hba": {
+              "description": "method: any\nnumber: 1\nPostgreSQL Host Based Authentication rules (lines to be appended to the pg_hba.conf file)",
+              "items": {
+                "required": []
+              },
+              "title": "pg_hba",
+              "type": "array"
+            },
+            "pg_ident": {
+              "description": "- host all all 10.244.0.0/16 md5\nPostgreSQL User Name Maps rules (lines to be appended to the pg_ident.conf file)",
+              "items": {
+                "required": []
+              },
+              "title": "pg_ident",
+              "type": "array"
+            },
+            "shared_preload_libraries": {
+              "description": "- mymap   /^(.*)\nLists of shared preload libraries to add to the default ones",
+              "items": {
+                "required": []
+              },
+              "title": "shared_preload_libraries",
+              "type": "array"
+            },
+            "synchronous": {
+              "description": "max_connections: 300\nQuorum-based Synchronous Replication",
+              "required": [],
+              "title": "synchronous",
+              "type": "object"
+            }
+          },
+          "required": [
+            "parameters",
+            "synchronous",
+            "pg_hba",
+            "pg_ident",
+            "shared_preload_libraries",
+            "ldap"
+          ],
+          "title": "postgresql",
+          "type": "object"
+        },
+        "primaryUpdateMethod": {
+          "default": "switchover",
+          "description": "Method to follow to upgrade the primary server during a rolling update procedure, after all replicas have been\nsuccessfully updated. It can be switchover (default) or restart.",
+          "title": "primaryUpdateMethod",
+          "type": "string"
+        },
+        "primaryUpdateStrategy": {
+          "default": "unsupervised",
+          "description": "Strategy to follow to upgrade the primary server during a rolling update procedure, after all replicas have been\nsuccessfully updated: it can be automated (unsupervised - default) or manual (supervised)",
+          "title": "primaryUpdateStrategy",
+          "type": "string"
+        },
+        "priorityClassName": {
+          "default": "",
+          "title": "priorityClassName",
+          "type": "string"
+        },
+        "resources": {
+          "description": "Resources requirements of every generated Pod.\nPlease refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ for more information.\nWe strongly advise you use the same setting for limits and requests so that your cluster pods are given a Guaranteed QoS.\nSee: https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/",
+          "required": [],
+          "title": "resources",
+          "type": "object"
+        },
+        "roles": {
+          "description": "This feature enables declarative management of existing roles, as well as the creation of new roles if they are not\nalready present in the database.\nSee: https://cloudnative-pg.io/documentation/current/declarative_role_management/",
+          "items": {
+            "required": []
+          },
+          "title": "roles",
+          "type": "array"
+        },
+        "securityContext": {
+          "description": "Configure Container Security Context.\nSee: https://cloudnative-pg.io/documentation/preview/security/",
+          "required": [],
+          "title": "securityContext",
+          "type": "object"
+        },
+        "serviceAccountTemplate": {
+          "description": "Configure the metadata of the generated service account",
+          "required": [],
+          "title": "serviceAccountTemplate",
+          "type": "object"
+        },
+        "services": {
+          "description": "Customization of service definitions. Please refer to https://cloudnative-pg.io/documentation/current/service_management/",
+          "required": [],
+          "title": "services",
+          "type": "object"
+        },
+        "storage": {
+          "properties": {
+            "size": {
+              "default": "8Gi",
+              "title": "size",
+              "type": "string"
+            },
+            "storageClass": {
+              "default": "",
+              "title": "storageClass",
+              "type": "string"
+            }
+          },
+          "required": [
+            "size",
+            "storageClass"
+          ],
+          "title": "storage",
+          "type": "object"
+        },
+        "superuserSecret": {
+          "default": "",
+          "title": "superuserSecret",
+          "type": "string"
+        },
+        "walStorage": {
+          "properties": {
+            "enabled": {
+              "default": false,
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "size": {
+              "default": "1Gi",
+              "title": "size",
+              "type": "string"
+            },
+            "storageClass": {
+              "default": "",
+              "title": "storageClass",
+              "type": "string"
+            }
+          },
+          "required": [
+            "enabled",
+            "size",
+            "storageClass"
+          ],
+          "title": "walStorage",
+          "type": "object"
+        }
+      },
+      "required": [
+        "instances",
+        "imageName",
+        "imageCatalogRef",
+        "imagePullPolicy",
+        "imagePullSecrets",
+        "storage",
+        "walStorage",
+        "postgresUID",
+        "postgresGID",
+        "services",
+        "resources",
+        "priorityClassName",
+        "primaryUpdateMethod",
+        "primaryUpdateStrategy",
+        "logLevel",
+        "affinity",
+        "env",
+        "envFrom",
+        "certificates",
+        "enableSuperuserAccess",
+        "superuserSecret",
+        "enablePDB",
+        "roles",
+        "monitoring",
+        "postgresql",
+        "initdb",
+        "serviceAccountTemplate",
+        "podSecurityContext",
+        "securityContext",
+        "additionalLabels",
+        "annotations",
+        "console"
+      ],
+      "title": "cluster",
+      "type": "object"
+    },
+    "databases": {
+      "description": "#\nDatabase management configuration",
+      "items": {
+        "required": []
+      },
+      "title": "databases",
+      "type": "array"
+    },
+    "fullnameOverride": {
+      "default": "",
+      "description": "Override the full name of the chart",
+      "title": "fullnameOverride",
+      "type": "string"
+    },
+    "global": {
+      "description": "Global values are values that can be accessed from any chart or subchart by exactly the same name.",
+      "required": [],
+      "title": "global",
+      "type": "object"
+    },
+    "imageCatalog": {
+      "properties": {
+        "create": {
+          "default": true,
+          "description": "Whether to provision an image catalog. If imageCatalog.images is empty this option will be ignored.",
+          "title": "create",
+          "type": "boolean"
+        },
+        "images": {
+          "description": "List of images to be provisioned in an image catalog.",
+          "items": {
+            "required": []
+          },
+          "title": "images",
+          "type": "array"
+        }
+      },
+      "required": [
+        "create",
+        "images"
+      ],
+      "title": "imageCatalog",
+      "type": "object"
+    },
+    "mode": {
+      "default": "standalone",
+      "description": "##\nCluster mode of operation. Available modes:\n* `standalone` - default mode. Creates new or updates an existing CNPG cluster.\n* `replica` - Creates a replica cluster from an existing CNPG cluster.\n* `recovery` - Same as standalone but creates a cluster from a backup, object store or via pg_basebackup.",
+      "title": "mode",
+      "type": "string"
+    },
+    "nameOverride": {
+      "default": "",
+      "description": "Override the name of the chart",
+      "title": "nameOverride",
+      "type": "string"
+    },
+    "namespaceOverride": {
+      "default": "",
+      "description": "Override the namespace of the chart",
+      "title": "namespaceOverride",
+      "type": "string"
+    },
+    "poolers": {
+      "description": "List of PgBouncer poolers",
+      "items": {
+        "required": []
+      },
+      "title": "poolers",
+      "type": "array"
+    },
+    "recovery": {
+      "properties": {
+        "azure": {
+          "properties": {
+            "connectionString": {
+              "default": "",
+              "title": "connectionString",
+              "type": "string"
+            },
+            "containerName": {
+              "default": "",
+              "title": "containerName",
+              "type": "string"
+            },
+            "inheritFromAzureAD": {
+              "default": false,
+              "title": "inheritFromAzureAD",
+              "type": "boolean"
+            },
+            "path": {
+              "default": "/",
+              "title": "path",
+              "type": "string"
+            },
+            "serviceName": {
+              "default": "blob",
+              "title": "serviceName",
+              "type": "string"
+            },
+            "storageAccount": {
+              "default": "",
+              "title": "storageAccount",
+              "type": "string"
+            },
+            "storageKey": {
+              "default": "",
+              "title": "storageKey",
+              "type": "string"
+            },
+            "storageSasToken": {
+              "default": "",
+              "title": "storageSasToken",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "connectionString",
+            "storageAccount",
+            "storageKey",
+            "storageSasToken",
+            "containerName",
+            "serviceName",
+            "inheritFromAzureAD"
+          ],
+          "title": "azure",
+          "type": "object"
+        },
+        "backupName": {
+          "default": "",
+          "description": "#\nBackup Recovery Method",
+          "title": "backupName",
+          "type": "string"
+        },
+        "clusterName": {
+          "default": "",
+          "description": "#\nThe original cluster name when used in backups. Also known as serverName.",
+          "title": "clusterName",
+          "type": "string"
+        },
+        "database": {
+          "default": "app",
+          "description": "Name of the database used by the application. Default: `app`.",
+          "title": "database",
+          "type": "string"
+        },
+        "destinationPath": {
+          "default": "",
+          "description": "Overrides the provider specific default path. Defaults to:\nS3: s3://\u003cbucket\u003e\u003cpath\u003e\nAzure: https://\u003cstorageAccount\u003e.\u003cserviceName\u003e.core.windows.net/\u003ccontainerName\u003e\u003cpath\u003e\nGoogle: gs://\u003cbucket\u003e\u003cpath\u003e",
+          "title": "destinationPath",
+          "type": "string"
+        },
+        "endpointCA": {
+          "description": "Specifies a CA bundle to validate a privately signed certificate.",
+          "properties": {
+            "create": {
+              "default": false,
+              "description": "Creates a secret with the given value if true, otherwise uses an existing secret.",
+              "title": "create",
+              "type": "boolean"
+            },
+            "key": {
+              "default": "",
+              "title": "key",
+              "type": "string"
+            },
+            "name": {
+              "default": "",
+              "title": "name",
+              "type": "string"
+            },
+            "value": {
+              "default": "",
+              "title": "value",
+              "type": "string"
+            }
+          },
+          "required": [
+            "create",
+            "name",
+            "key",
+            "value"
+          ],
+          "title": "endpointCA",
+          "type": "object"
+        },
+        "endpointURL": {
+          "default": "",
+          "description": "Overrides the provider specific default endpoint. Defaults to:\nS3: https://s3.\u003cregion\u003e.amazonaws.com\"\nLeave empty if using the default S3 endpoint",
+          "title": "endpointURL",
+          "type": "string"
+        },
+        "google": {
+          "properties": {
+            "applicationCredentials": {
+              "default": "",
+              "title": "applicationCredentials",
+              "type": "string"
+            },
+            "bucket": {
+              "default": "",
+              "title": "bucket",
+              "type": "string"
+            },
+            "gkeEnvironment": {
+              "default": false,
+              "title": "gkeEnvironment",
+              "type": "boolean"
+            },
+            "path": {
+              "default": "/",
+              "title": "path",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "bucket",
+            "gkeEnvironment",
+            "applicationCredentials"
+          ],
+          "title": "google",
+          "type": "object"
+        },
+        "import": {
+          "description": "See: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-Import",
+          "properties": {
+            "databases": {
+              "description": "Databases to import",
+              "items": {
+                "required": []
+              },
+              "title": "databases",
+              "type": "array"
+            },
+            "pgDumpExtraOptions": {
+              "description": "List of custom options to pass to the `pg_dump` command. IMPORTANT: Use these options with caution and at your\nown risk, as the operator does not validate their content. Be aware that certain options may conflict with the\noperator's intended functionality or design.",
+              "items": {
+                "required": []
+              },
+              "title": "pgDumpExtraOptions",
+              "type": "array"
+            },
+            "pgRestoreExtraOptions": {
+              "description": "List of custom options to pass to the `pg_restore` command. IMPORTANT: Use these options with caution and at\nyour own risk, as the operator does not validate their content. Be aware that certain options may conflict with the\noperator's intended functionality or design.",
+              "items": {
+                "required": []
+              },
+              "title": "pgRestoreExtraOptions",
+              "type": "array"
+            },
+            "postImportApplicationSQL": {
+              "description": "List of SQL queries to be executed as a superuser in the application database right after is imported.\nTo be used with extreme care. Only available in microservice type.",
+              "items": {
+                "required": []
+              },
+              "title": "postImportApplicationSQL",
+              "type": "array"
+            },
+            "roles": {
+              "description": "Roles to import",
+              "items": {
+                "required": []
+              },
+              "title": "roles",
+              "type": "array"
+            },
+            "schemaOnly": {
+              "default": false,
+              "description": "When set to true, only the pre-data and post-data sections of pg_restore are invoked, avoiding data import.",
+              "title": "schemaOnly",
+              "type": "boolean"
+            },
+            "source": {
+              "properties": {
+                "database": {
+                  "default": "",
+                  "title": "database",
+                  "type": "string"
                 },
-                "images": {
-                    "type": "array"
+                "host": {
+                  "default": "",
+                  "title": "host",
+                  "type": "string"
+                },
+                "passwordSecret": {
+                  "properties": {
+                    "create": {
+                      "default": false,
+                      "description": "Whether to create a secret for the password",
+                      "title": "create",
+                      "type": "boolean"
+                    },
+                    "key": {
+                      "default": "password",
+                      "description": "The key in the secret containing the password",
+                      "title": "key",
+                      "type": "string"
+                    },
+                    "name": {
+                      "default": "",
+                      "description": "Name of the secret containing the password",
+                      "title": "name",
+                      "type": "string"
+                    },
+                    "value": {
+                      "default": "",
+                      "description": "The password value to use when creating the secret",
+                      "title": "value",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "create",
+                    "name",
+                    "key",
+                    "value"
+                  ],
+                  "title": "passwordSecret",
+                  "type": "object"
+                },
+                "port": {
+                  "default": 5432,
+                  "title": "port",
+                  "type": "integer"
+                },
+                "sslCertSecret": {
+                  "properties": {
+                    "key": {
+                      "default": "",
+                      "title": "key",
+                      "type": "string"
+                    },
+                    "name": {
+                      "default": "",
+                      "title": "name",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "key"
+                  ],
+                  "title": "sslCertSecret",
+                  "type": "object"
+                },
+                "sslKeySecret": {
+                  "properties": {
+                    "key": {
+                      "default": "",
+                      "title": "key",
+                      "type": "string"
+                    },
+                    "name": {
+                      "default": "",
+                      "title": "name",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "key"
+                  ],
+                  "title": "sslKeySecret",
+                  "type": "object"
+                },
+                "sslMode": {
+                  "default": "verify-full",
+                  "title": "sslMode",
+                  "type": "string"
+                },
+                "sslRootCertSecret": {
+                  "properties": {
+                    "key": {
+                      "default": "",
+                      "title": "key",
+                      "type": "string"
+                    },
+                    "name": {
+                      "default": "",
+                      "title": "name",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "key"
+                  ],
+                  "title": "sslRootCertSecret",
+                  "type": "object"
+                },
+                "username": {
+                  "default": "",
+                  "title": "username",
+                  "type": "string"
                 }
+              },
+              "required": [
+                "host",
+                "port",
+                "username",
+                "database",
+                "sslMode",
+                "passwordSecret",
+                "sslKeySecret",
+                "sslCertSecret",
+                "sslRootCertSecret"
+              ],
+              "title": "source",
+              "type": "object"
+            },
+            "type": {
+              "default": "microservice",
+              "description": "One of `microservice` or `monolith.`\nSee: https://cloudnative-pg.io/documentation/current/database_import/#how-it-works",
+              "title": "type",
+              "type": "string"
             }
+          },
+          "required": [
+            "type",
+            "databases",
+            "roles",
+            "postImportApplicationSQL",
+            "schemaOnly",
+            "pgDumpExtraOptions",
+            "pgRestoreExtraOptions",
+            "source"
+          ],
+          "title": "import",
+          "type": "object"
         },
-        "mode": {
-            "type": "string"
+        "method": {
+          "default": "backup",
+          "description": "#\nAvailable recovery methods:\n* `backup` - Recovers a CNPG cluster from a CNPG backup (PITR supported) Needs to be on the same cluster in the same namespace.\n* `object_store` - Recovers a CNPG cluster from a barman object store (PITR supported).\n* `pg_basebackup` - Recovers a CNPG cluster viaa streaming replication protocol. Useful if you want to\n       migrate databases to CloudNativePG, even from outside Kubernetes.\n* `import` - Import one or more databases from an existing Postgres cluster.",
+          "title": "method",
+          "type": "string"
         },
-        "nameOverride": {
-            "type": "string"
+        "owner": {
+          "default": "",
+          "description": "Name of the owner of the database in the instance to be used by applications. Defaults to the value of the `database` key.",
+          "title": "owner",
+          "type": "string"
         },
-        "namespaceOverride": {
-            "type": "string"
+        "pgBaseBackup": {
+          "description": "See https://cloudnative-pg.io/documentation/current/bootstrap/#bootstrap-from-a-live-cluster-pg_basebackup",
+          "properties": {
+            "database": {
+              "default": "app",
+              "description": "Name of the database used by the application. Default: `app`.",
+              "title": "database",
+              "type": "string"
+            },
+            "owner": {
+              "default": "",
+              "description": "Name of the owner of the database in the instance to be used by applications. Defaults to the value of the `database` key.",
+              "title": "owner",
+              "type": "string"
+            },
+            "secretName": {
+              "default": "",
+              "description": "Name of the kubernetes.io/basic-auth secret containing the initial credentials for the owner of the user database. If empty a new secret will be created from scratch.",
+              "title": "secretName",
+              "type": "string"
+            },
+            "source": {
+              "properties": {
+                "database": {
+                  "default": "app",
+                  "title": "database",
+                  "type": "string"
+                },
+                "host": {
+                  "default": "",
+                  "title": "host",
+                  "type": "string"
+                },
+                "passwordSecret": {
+                  "properties": {
+                    "create": {
+                      "default": false,
+                      "description": "Whether to create a secret for the password",
+                      "title": "create",
+                      "type": "boolean"
+                    },
+                    "key": {
+                      "default": "password",
+                      "description": "The key in the secret containing the password",
+                      "title": "key",
+                      "type": "string"
+                    },
+                    "name": {
+                      "default": "",
+                      "description": "Name of the secret containing the password",
+                      "title": "name",
+                      "type": "string"
+                    },
+                    "value": {
+                      "default": "",
+                      "description": "The password value to use when creating the secret",
+                      "title": "value",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "create",
+                    "name",
+                    "key",
+                    "value"
+                  ],
+                  "title": "passwordSecret",
+                  "type": "object"
+                },
+                "port": {
+                  "default": 5432,
+                  "title": "port",
+                  "type": "integer"
+                },
+                "sslCertSecret": {
+                  "properties": {
+                    "key": {
+                      "default": "",
+                      "title": "key",
+                      "type": "string"
+                    },
+                    "name": {
+                      "default": "",
+                      "title": "name",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "key"
+                  ],
+                  "title": "sslCertSecret",
+                  "type": "object"
+                },
+                "sslKeySecret": {
+                  "properties": {
+                    "key": {
+                      "default": "",
+                      "title": "key",
+                      "type": "string"
+                    },
+                    "name": {
+                      "default": "",
+                      "title": "name",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "key"
+                  ],
+                  "title": "sslKeySecret",
+                  "type": "object"
+                },
+                "sslMode": {
+                  "default": "verify-full",
+                  "title": "sslMode",
+                  "type": "string"
+                },
+                "sslRootCertSecret": {
+                  "properties": {
+                    "key": {
+                      "default": "",
+                      "title": "key",
+                      "type": "string"
+                    },
+                    "name": {
+                      "default": "",
+                      "title": "name",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "key"
+                  ],
+                  "title": "sslRootCertSecret",
+                  "type": "object"
+                },
+                "username": {
+                  "default": "",
+                  "title": "username",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "host",
+                "port",
+                "username",
+                "database",
+                "sslMode",
+                "passwordSecret",
+                "sslKeySecret",
+                "sslCertSecret",
+                "sslRootCertSecret"
+              ],
+              "title": "source",
+              "type": "object"
+            }
+          },
+          "required": [
+            "database",
+            "secretName",
+            "owner",
+            "source"
+          ],
+          "title": "pgBaseBackup",
+          "type": "object"
         },
-        "poolers": {
-            "type": "array"
+        "pitrTarget": {
+          "description": "# -- Point in time recovery target. Specify one of the following:",
+          "properties": {
+            "time": {
+              "default": "",
+              "description": "Time in RFC3339 format",
+              "title": "time",
+              "type": "string"
+            }
+          },
+          "required": [
+            "time"
+          ],
+          "title": "pitrTarget",
+          "type": "object"
         },
-        "recovery": {
-            "type": "object",
-            "properties": {
+        "provider": {
+          "default": "s3",
+          "description": "One of `s3`, `azure` or `google`",
+          "title": "provider",
+          "type": "string"
+        },
+        "s3": {
+          "properties": {
+            "accessKey": {
+              "default": "",
+              "title": "accessKey",
+              "type": "string"
+            },
+            "bucket": {
+              "default": "",
+              "title": "bucket",
+              "type": "string"
+            },
+            "inheritFromIAMRole": {
+              "default": false,
+              "description": "Use the role based authentication without providing explicitly the keys",
+              "title": "inheritFromIAMRole",
+              "type": "boolean"
+            },
+            "path": {
+              "default": "/",
+              "title": "path",
+              "type": "string"
+            },
+            "region": {
+              "default": "",
+              "title": "region",
+              "type": "string"
+            },
+            "secretKey": {
+              "default": "",
+              "title": "secretKey",
+              "type": "string"
+            }
+          },
+          "required": [
+            "region",
+            "bucket",
+            "path",
+            "accessKey",
+            "secretKey",
+            "inheritFromIAMRole"
+          ],
+          "title": "s3",
+          "type": "object"
+        },
+        "secret": {
+          "properties": {
+            "create": {
+              "default": true,
+              "description": "Whether to create a secret for the backup credentials",
+              "title": "create",
+              "type": "boolean"
+            },
+            "name": {
+              "default": "",
+              "description": "Name of the backup credentials secret",
+              "title": "name",
+              "type": "string"
+            }
+          },
+          "required": [
+            "create",
+            "name"
+          ],
+          "title": "secret",
+          "type": "object"
+        }
+      },
+      "required": [
+        "method",
+        "pitrTarget",
+        "backupName",
+        "clusterName",
+        "database",
+        "owner",
+        "endpointURL",
+        "endpointCA",
+        "destinationPath",
+        "provider",
+        "s3",
+        "azure",
+        "google",
+        "secret",
+        "pgBaseBackup",
+        "import"
+      ],
+      "title": "recovery",
+      "type": "object"
+    },
+    "replica": {
+      "properties": {
+        "bootstrap": {
+          "properties": {
+            "database": {
+              "default": "",
+              "description": "Name of the database used by the application",
+              "title": "database",
+              "type": "string"
+            },
+            "owner": {
+              "default": "",
+              "description": "Name of the owner of the database in the instance to be used by applications. Defaults to the value of the `database` key.",
+              "title": "owner",
+              "type": "string"
+            },
+            "secret": {
+              "default": "",
+              "description": "Name of the secret containing the initial credentials for the owner of the user database. If empty a new secret will be created from scratch",
+              "title": "secret",
+              "type": "string"
+            },
+            "source": {
+              "default": "",
+              "description": " One of `object_store` or `pg_basebackup`. Method to use for bootstrap.",
+              "title": "source",
+              "type": "string"
+            }
+          },
+          "required": [
+            "source",
+            "database",
+            "secret",
+            "owner"
+          ],
+          "title": "bootstrap",
+          "type": "object"
+        },
+        "minApplyDelay": {
+          "default": "",
+          "description": "When replica mode is enabled, this parameter allows you to replay transactions only when the system time is at least the configured time past the commit time. This provides an opportunity to correct data loss errors. Note that when this parameter is set, a promotion token cannot be used.",
+          "title": "minApplyDelay",
+          "type": "string"
+        },
+        "origin": {
+          "properties": {
+            "objectStore": {
+              "properties": {
                 "azure": {
-                    "type": "object",
-                    "properties": {
-                        "connectionString": {
-                            "type": "string"
-                        },
-                        "containerName": {
-                            "type": "string"
-                        },
-                        "inheritFromAzureAD": {
-                            "type": "boolean"
-                        },
-                        "path": {
-                            "type": "string"
-                        },
-                        "serviceName": {
-                            "type": "string"
-                        },
-                        "storageAccount": {
-                            "type": "string"
-                        },
-                        "storageKey": {
-                            "type": "string"
-                        },
-                        "storageSasToken": {
-                            "type": "string"
-                        }
+                  "properties": {
+                    "connectionString": {
+                      "default": "",
+                      "title": "connectionString",
+                      "type": "string"
+                    },
+                    "containerName": {
+                      "default": "",
+                      "title": "containerName",
+                      "type": "string"
+                    },
+                    "inheritFromAzureAD": {
+                      "default": false,
+                      "title": "inheritFromAzureAD",
+                      "type": "boolean"
+                    },
+                    "path": {
+                      "default": "/",
+                      "title": "path",
+                      "type": "string"
+                    },
+                    "serviceName": {
+                      "default": "blob",
+                      "title": "serviceName",
+                      "type": "string"
+                    },
+                    "storageAccount": {
+                      "default": "",
+                      "title": "storageAccount",
+                      "type": "string"
+                    },
+                    "storageKey": {
+                      "default": "",
+                      "title": "storageKey",
+                      "type": "string"
+                    },
+                    "storageSasToken": {
+                      "default": "",
+                      "title": "storageSasToken",
+                      "type": "string"
                     }
-                },
-                "backupName": {
-                    "type": "string"
+                  },
+                  "required": [
+                    "path",
+                    "connectionString",
+                    "storageAccount",
+                    "storageKey",
+                    "storageSasToken",
+                    "containerName",
+                    "serviceName",
+                    "inheritFromAzureAD"
+                  ],
+                  "title": "azure",
+                  "type": "object"
                 },
                 "clusterName": {
-                    "type": "string"
-                },
-                "database": {
-                    "type": "string"
+                  "default": "",
+                  "description": "The original cluster name when used in backups. Also known as serverName.",
+                  "title": "clusterName",
+                  "type": "string"
                 },
                 "destinationPath": {
-                    "type": "string"
+                  "default": "",
+                  "description": "Overrides the provider specific default path. Defaults to:\nS3: s3://\u003cbucket\u003e\u003cpath\u003e\nAzure: https://\u003cstorageAccount\u003e.\u003cserviceName\u003e.core.windows.net/\u003ccontainerName\u003e\u003cpath\u003e\nGoogle: gs://\u003cbucket\u003e\u003cpath\u003e",
+                  "title": "destinationPath",
+                  "type": "string"
                 },
                 "endpointCA": {
-                    "type": "object",
-                    "properties": {
-                        "create": {
-                            "type": "boolean"
-                        },
-                        "key": {
-                            "type": "string"
-                        },
-                        "name": {
-                            "type": "string"
-                        },
-                        "value": {
-                            "type": "string"
-                        }
+                  "description": "Specifies a CA bundle to validate a privately signed certificate.",
+                  "properties": {
+                    "create": {
+                      "default": false,
+                      "description": "Creates a secret with the given value if true, otherwise uses an existing secret.",
+                      "title": "create",
+                      "type": "boolean"
+                    },
+                    "key": {
+                      "default": "",
+                      "title": "key",
+                      "type": "string"
+                    },
+                    "name": {
+                      "default": "",
+                      "title": "name",
+                      "type": "string"
+                    },
+                    "value": {
+                      "default": "",
+                      "title": "value",
+                      "type": "string"
                     }
-                },
-                "endpointURL": {
-                    "type": "string"
+                  },
+                  "required": [
+                    "create",
+                    "name",
+                    "key",
+                    "value"
+                  ],
+                  "title": "endpointCA",
+                  "type": "object"
                 },
                 "google": {
-                    "type": "object",
-                    "properties": {
-                        "applicationCredentials": {
-                            "type": "string"
-                        },
-                        "bucket": {
-                            "type": "string"
-                        },
-                        "gkeEnvironment": {
-                            "type": "boolean"
-                        },
-                        "path": {
-                            "type": "string"
-                        }
+                  "properties": {
+                    "applicationCredentials": {
+                      "default": "",
+                      "title": "applicationCredentials",
+                      "type": "string"
+                    },
+                    "bucket": {
+                      "default": "",
+                      "title": "bucket",
+                      "type": "string"
+                    },
+                    "gkeEnvironment": {
+                      "default": false,
+                      "title": "gkeEnvironment",
+                      "type": "boolean"
+                    },
+                    "path": {
+                      "default": "/",
+                      "title": "path",
+                      "type": "string"
                     }
-                },
-                "import": {
-                    "type": "object",
-                    "properties": {
-                        "databases": {
-                            "type": "array"
-                        },
-                        "pgDumpExtraOptions": {
-                            "type": "array"
-                        },
-                        "pgRestoreExtraOptions": {
-                            "type": "array"
-                        },
-                        "postImportApplicationSQL": {
-                            "type": "array"
-                        },
-                        "roles": {
-                            "type": "array"
-                        },
-                        "schemaOnly": {
-                            "type": "boolean"
-                        },
-                        "source": {
-                            "type": "object",
-                            "properties": {
-                                "database": {
-                                    "type": "string"
-                                },
-                                "host": {
-                                    "type": "string"
-                                },
-                                "passwordSecret": {
-                                    "type": "object",
-                                    "properties": {
-                                        "create": {
-                                            "type": "boolean"
-                                        },
-                                        "key": {
-                                            "type": "string"
-                                        },
-                                        "name": {
-                                            "type": "string"
-                                        },
-                                        "value": {
-                                            "type": "string"
-                                        }
-                                    }
-                                },
-                                "port": {
-                                    "type": "integer"
-                                },
-                                "sslCertSecret": {
-                                    "type": "object",
-                                    "properties": {
-                                        "key": {
-                                            "type": "string"
-                                        },
-                                        "name": {
-                                            "type": "string"
-                                        }
-                                    }
-                                },
-                                "sslKeySecret": {
-                                    "type": "object",
-                                    "properties": {
-                                        "key": {
-                                            "type": "string"
-                                        },
-                                        "name": {
-                                            "type": "string"
-                                        }
-                                    }
-                                },
-                                "sslMode": {
-                                    "type": "string"
-                                },
-                                "sslRootCertSecret": {
-                                    "type": "object",
-                                    "properties": {
-                                        "key": {
-                                            "type": "string"
-                                        },
-                                        "name": {
-                                            "type": "string"
-                                        }
-                                    }
-                                },
-                                "username": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "type": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "method": {
-                    "type": "string"
-                },
-                "owner": {
-                    "type": "string"
-                },
-                "pgBaseBackup": {
-                    "type": "object",
-                    "properties": {
-                        "database": {
-                            "type": "string"
-                        },
-                        "owner": {
-                            "type": "string"
-                        },
-                        "secretName": {
-                            "type": "string"
-                        },
-                        "source": {
-                            "type": "object",
-                            "properties": {
-                                "database": {
-                                    "type": "string"
-                                },
-                                "host": {
-                                    "type": "string"
-                                },
-                                "passwordSecret": {
-                                    "type": "object",
-                                    "properties": {
-                                        "create": {
-                                            "type": "boolean"
-                                        },
-                                        "key": {
-                                            "type": "string"
-                                        },
-                                        "name": {
-                                            "type": "string"
-                                        },
-                                        "value": {
-                                            "type": "string"
-                                        }
-                                    }
-                                },
-                                "port": {
-                                    "type": "integer"
-                                },
-                                "sslCertSecret": {
-                                    "type": "object",
-                                    "properties": {
-                                        "key": {
-                                            "type": "string"
-                                        },
-                                        "name": {
-                                            "type": "string"
-                                        }
-                                    }
-                                },
-                                "sslKeySecret": {
-                                    "type": "object",
-                                    "properties": {
-                                        "key": {
-                                            "type": "string"
-                                        },
-                                        "name": {
-                                            "type": "string"
-                                        }
-                                    }
-                                },
-                                "sslMode": {
-                                    "type": "string"
-                                },
-                                "sslRootCertSecret": {
-                                    "type": "object",
-                                    "properties": {
-                                        "key": {
-                                            "type": "string"
-                                        },
-                                        "name": {
-                                            "type": "string"
-                                        }
-                                    }
-                                },
-                                "username": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                },
-                "pitrTarget": {
-                    "type": "object",
-                    "properties": {
-                        "time": {
-                            "type": "string"
-                        }
-                    }
+                  },
+                  "required": [
+                    "path",
+                    "bucket",
+                    "gkeEnvironment",
+                    "applicationCredentials"
+                  ],
+                  "title": "google",
+                  "type": "object"
                 },
                 "provider": {
-                    "type": "string"
+                  "default": "",
+                  "description": "One of `s3`, `azure` or `google`",
+                  "title": "provider",
+                  "type": "string"
                 },
                 "s3": {
-                    "type": "object",
-                    "properties": {
-                        "accessKey": {
-                            "type": "string"
-                        },
-                        "bucket": {
-                            "type": "string"
-                        },
-                        "inheritFromIAMRole": {
-                            "type": "boolean"
-                        },
-                        "path": {
-                            "type": "string"
-                        },
-                        "region": {
-                            "type": "string"
-                        },
-                        "secretKey": {
-                            "type": "string"
-                        }
+                  "properties": {
+                    "accessKey": {
+                      "default": "",
+                      "title": "accessKey",
+                      "type": "string"
+                    },
+                    "bucket": {
+                      "default": "",
+                      "title": "bucket",
+                      "type": "string"
+                    },
+                    "inheritFromIAMRole": {
+                      "default": false,
+                      "description": "Use the role based authentication without providing explicitly the keys",
+                      "title": "inheritFromIAMRole",
+                      "type": "boolean"
+                    },
+                    "path": {
+                      "default": "/",
+                      "title": "path",
+                      "type": "string"
+                    },
+                    "region": {
+                      "default": "",
+                      "title": "region",
+                      "type": "string"
+                    },
+                    "secretKey": {
+                      "default": "",
+                      "title": "secretKey",
+                      "type": "string"
                     }
+                  },
+                  "required": [
+                    "region",
+                    "bucket",
+                    "path",
+                    "accessKey",
+                    "secretKey",
+                    "inheritFromIAMRole"
+                  ],
+                  "title": "s3",
+                  "type": "object"
                 },
                 "secret": {
-                    "type": "object",
-                    "properties": {
-                        "create": {
-                            "type": "boolean"
-                        },
-                        "name": {
-                            "type": "string"
-                        }
+                  "properties": {
+                    "create": {
+                      "default": true,
+                      "description": "Whether to create a secret for the backup credentials",
+                      "title": "create",
+                      "type": "boolean"
+                    },
+                    "name": {
+                      "default": "",
+                      "description": "Name of the backup credentials secret",
+                      "title": "name",
+                      "type": "string"
                     }
+                  },
+                  "required": [
+                    "create",
+                    "name"
+                  ],
+                  "title": "secret",
+                  "type": "object"
                 }
-            }
-        },
-        "replica": {
-            "type": "object",
-            "properties": {
-                "bootstrap": {
-                    "type": "object",
-                    "properties": {
-                        "database": {
-                            "type": "string"
-                        },
-                        "owner": {
-                            "type": "string"
-                        },
-                        "secret": {
-                            "type": "string"
-                        },
-                        "source": {
-                            "type": "string"
-                        }
+              },
+              "required": [
+                "clusterName",
+                "destinationPath",
+                "endpointCA",
+                "provider",
+                "s3",
+                "azure",
+                "google",
+                "secret"
+              ],
+              "title": "objectStore",
+              "type": "object"
+            },
+            "pg_basebackup": {
+              "properties": {
+                "database": {
+                  "default": "",
+                  "title": "database",
+                  "type": "string"
+                },
+                "host": {
+                  "default": "",
+                  "title": "host",
+                  "type": "string"
+                },
+                "passwordSecret": {
+                  "properties": {
+                    "key": {
+                      "default": "",
+                      "title": "key",
+                      "type": "string"
+                    },
+                    "name": {
+                      "default": "",
+                      "title": "name",
+                      "type": "string"
                     }
+                  },
+                  "required": [
+                    "name",
+                    "key"
+                  ],
+                  "title": "passwordSecret",
+                  "type": "object"
                 },
-                "minApplyDelay": {
-                    "type": "string"
+                "port": {
+                  "default": 5432,
+                  "title": "port",
+                  "type": "integer"
                 },
-                "origin": {
-                    "type": "object",
-                    "properties": {
-                        "objectStore": {
-                            "type": "object",
-                            "properties": {
-                                "azure": {
-                                    "type": "object",
-                                    "properties": {
-                                        "connectionString": {
-                                            "type": "string"
-                                        },
-                                        "containerName": {
-                                            "type": "string"
-                                        },
-                                        "inheritFromAzureAD": {
-                                            "type": "boolean"
-                                        },
-                                        "path": {
-                                            "type": "string"
-                                        },
-                                        "serviceName": {
-                                            "type": "string"
-                                        },
-                                        "storageAccount": {
-                                            "type": "string"
-                                        },
-                                        "storageKey": {
-                                            "type": "string"
-                                        },
-                                        "storageSasToken": {
-                                            "type": "string"
-                                        }
-                                    }
-                                },
-                                "clusterName": {
-                                    "type": "string"
-                                },
-                                "destinationPath": {
-                                    "type": "string"
-                                },
-                                "endpointCA": {
-                                    "type": "object",
-                                    "properties": {
-                                        "create": {
-                                            "type": "boolean"
-                                        },
-                                        "key": {
-                                            "type": "string"
-                                        },
-                                        "name": {
-                                            "type": "string"
-                                        },
-                                        "value": {
-                                            "type": "string"
-                                        }
-                                    }
-                                },
-                                "google": {
-                                    "type": "object",
-                                    "properties": {
-                                        "applicationCredentials": {
-                                            "type": "string"
-                                        },
-                                        "bucket": {
-                                            "type": "string"
-                                        },
-                                        "gkeEnvironment": {
-                                            "type": "boolean"
-                                        },
-                                        "path": {
-                                            "type": "string"
-                                        }
-                                    }
-                                },
-                                "provider": {
-                                    "type": "string"
-                                },
-                                "s3": {
-                                    "type": "object",
-                                    "properties": {
-                                        "accessKey": {
-                                            "type": "string"
-                                        },
-                                        "bucket": {
-                                            "type": "string"
-                                        },
-                                        "inheritFromIAMRole": {
-                                            "type": "boolean"
-                                        },
-                                        "path": {
-                                            "type": "string"
-                                        },
-                                        "region": {
-                                            "type": "string"
-                                        },
-                                        "secretKey": {
-                                            "type": "string"
-                                        }
-                                    }
-                                },
-                                "secret": {
-                                    "type": "object",
-                                    "properties": {
-                                        "create": {
-                                            "type": "boolean"
-                                        },
-                                        "name": {
-                                            "type": "string"
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "pg_basebackup": {
-                            "type": "object",
-                            "properties": {
-                                "database": {
-                                    "type": "string"
-                                },
-                                "host": {
-                                    "type": "string"
-                                },
-                                "passwordSecret": {
-                                    "type": "object",
-                                    "properties": {
-                                        "key": {
-                                            "type": "string"
-                                        },
-                                        "name": {
-                                            "type": "string"
-                                        }
-                                    }
-                                },
-                                "port": {
-                                    "type": "integer"
-                                },
-                                "sslCertSecret": {
-                                    "type": "object",
-                                    "properties": {
-                                        "key": {
-                                            "type": "string"
-                                        },
-                                        "name": {
-                                            "type": "string"
-                                        }
-                                    }
-                                },
-                                "sslKeySecret": {
-                                    "type": "object",
-                                    "properties": {
-                                        "key": {
-                                            "type": "string"
-                                        },
-                                        "name": {
-                                            "type": "string"
-                                        }
-                                    }
-                                },
-                                "sslMode": {
-                                    "type": "string"
-                                },
-                                "sslRootCertSecret": {
-                                    "type": "object",
-                                    "properties": {
-                                        "key": {
-                                            "type": "string"
-                                        },
-                                        "name": {
-                                            "type": "string"
-                                        }
-                                    }
-                                },
-                                "username": {
-                                    "type": "string"
-                                }
-                            }
-                        }
+                "sslCertSecret": {
+                  "properties": {
+                    "key": {
+                      "default": "",
+                      "title": "key",
+                      "type": "string"
+                    },
+                    "name": {
+                      "default": "",
+                      "title": "name",
+                      "type": "string"
                     }
+                  },
+                  "required": [
+                    "name",
+                    "key"
+                  ],
+                  "title": "sslCertSecret",
+                  "type": "object"
                 },
-                "primary": {
-                    "type": "string"
+                "sslKeySecret": {
+                  "properties": {
+                    "key": {
+                      "default": "",
+                      "title": "key",
+                      "type": "string"
+                    },
+                    "name": {
+                      "default": "",
+                      "title": "name",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "key"
+                  ],
+                  "title": "sslKeySecret",
+                  "type": "object"
                 },
-                "promotionToken": {
-                    "type": "string"
+                "sslMode": {
+                  "default": "verify-full",
+                  "title": "sslMode",
+                  "type": "string"
                 },
-                "self": {
-                    "type": "string"
+                "sslRootCertSecret": {
+                  "properties": {
+                    "key": {
+                      "default": "",
+                      "title": "key",
+                      "type": "string"
+                    },
+                    "name": {
+                      "default": "",
+                      "title": "name",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "key"
+                  ],
+                  "title": "sslRootCertSecret",
+                  "type": "object"
+                },
+                "username": {
+                  "default": "",
+                  "title": "username",
+                  "type": "string"
                 }
+              },
+              "required": [
+                "host",
+                "port",
+                "username",
+                "sslMode",
+                "database",
+                "sslKeySecret",
+                "sslCertSecret",
+                "sslRootCertSecret",
+                "passwordSecret"
+              ],
+              "title": "pg_basebackup",
+              "type": "object"
             }
+          },
+          "required": [
+            "objectStore",
+            "pg_basebackup"
+          ],
+          "title": "origin",
+          "type": "object"
         },
-        "type": {
-            "type": "string"
+        "primary": {
+          "default": "",
+          "description": "Primary defines which Cluster is defined to be the primary in the distributed PostgreSQL cluster, based on the topology specified in externalClusters",
+          "title": "primary",
+          "type": "string"
         },
-        "version": {
-            "type": "object",
-            "properties": {
-                "postgis": {
-                    "type": "string"
-                },
-                "postgresql": {
-                    "type": "string"
-                },
-                "timescaledb": {
-                    "type": "string"
-                }
-            }
+        "promotionToken": {
+          "default": "",
+          "description": "A demotion token generated by an external cluster used to check if the promotion requirements are met.",
+          "title": "promotionToken",
+          "type": "string"
+        },
+        "self": {
+          "default": "",
+          "description": " Defines the name of this cluster. It is used to determine if this is a primary or a replica cluster, comparing it with primary. Leave empty by default.",
+          "title": "self",
+          "type": "string"
         }
+      },
+      "required": [
+        "self",
+        "primary",
+        "promotionToken",
+        "minApplyDelay",
+        "bootstrap",
+        "origin"
+      ],
+      "title": "replica",
+      "type": "object"
+    },
+    "type": {
+      "default": "postgresql",
+      "description": "##\nType of the CNPG database. Available types:\n* `postgresql`\n* `postgis`\n* `timescaledb`",
+      "title": "type",
+      "type": "string"
+    },
+    "version": {
+      "properties": {
+        "postgis": {
+          "default": "3.4",
+          "description": "If using PostGIS, specify the version",
+          "title": "postgis",
+          "type": "string"
+        },
+        "postgresql": {
+          "default": "16",
+          "description": "PostgreSQL major version to use",
+          "title": "postgresql",
+          "type": "string"
+        },
+        "timescaledb": {
+          "default": "2.15",
+          "description": "If using TimescaleDB, specify the version",
+          "title": "timescaledb",
+          "type": "string"
+        }
+      },
+      "required": [
+        "postgresql",
+        "timescaledb",
+        "postgis"
+      ],
+      "title": "version",
+      "type": "object"
     }
+  },
+  "required": [
+    "nameOverride",
+    "fullnameOverride",
+    "namespaceOverride",
+    "type",
+    "version",
+    "mode",
+    "recovery",
+    "cluster",
+    "backups",
+    "replica",
+    "databases",
+    "imageCatalog",
+    "poolers"
+  ],
+  "type": "object"
 }

--- a/charts/cluster/values.schema.json
+++ b/charts/cluster/values.schema.json
@@ -7,56 +7,38 @@
           "properties": {
             "connectionString": {
               "default": "",
-              "title": "connectionString",
               "type": "string"
             },
             "containerName": {
               "default": "",
-              "title": "containerName",
               "type": "string"
             },
             "inheritFromAzureAD": {
               "default": false,
-              "title": "inheritFromAzureAD",
               "type": "boolean"
             },
             "path": {
               "default": "/",
-              "title": "path",
               "type": "string"
             },
             "serviceName": {
               "default": "blob",
-              "title": "serviceName",
               "type": "string"
             },
             "storageAccount": {
               "default": "",
-              "title": "storageAccount",
               "type": "string"
             },
             "storageKey": {
               "default": "",
-              "title": "storageKey",
               "type": "string"
             },
             "storageSasToken": {
               "default": "",
-              "title": "storageSasToken",
               "type": "string"
             }
           },
-          "required": [
-            "path",
-            "connectionString",
-            "storageAccount",
-            "storageKey",
-            "storageSasToken",
-            "containerName",
-            "serviceName",
-            "inheritFromAzureAD"
-          ],
-          "title": "azure",
+          "required": [],
           "type": "object"
         },
         "data": {
@@ -64,40 +46,30 @@
             "compression": {
               "default": "gzip",
               "description": "Data compression method. One of `` (for no compression), `gzip`, `bzip2` or `snappy`.",
-              "title": "compression",
               "type": "string"
             },
             "encryption": {
               "default": "AES256",
               "description": "Whether to instruct the storage provider to encrypt data files. One of `` (use the storage container default), `AES256` or `aws:kms`.",
-              "title": "encryption",
               "type": "string"
             },
             "jobs": {
               "default": 2,
               "description": "Number of data files to be archived or restored in parallel.",
-              "title": "jobs",
               "type": "integer"
             }
           },
-          "required": [
-            "compression",
-            "encryption",
-            "jobs"
-          ],
-          "title": "data",
+          "required": [],
           "type": "object"
         },
         "destinationPath": {
           "default": "",
           "description": "Overrides the provider specific default path. Defaults to:\nS3: s3://\u003cbucket\u003e\u003cpath\u003e\nAzure: https://\u003cstorageAccount\u003e.\u003cserviceName\u003e.core.windows.net/\u003ccontainerName\u003e\u003cpath\u003e\nGoogle: gs://\u003cbucket\u003e\u003cpath\u003e",
-          "title": "destinationPath",
           "type": "string"
         },
         "enabled": {
           "default": false,
           "description": "You need to configure backups manually, so backups are disabled by default.",
-          "title": "enabled",
           "type": "boolean"
         },
         "endpointCA": {
@@ -106,127 +78,90 @@
             "create": {
               "default": false,
               "description": "Creates a secret with the given value if true, otherwise uses an existing secret.",
-              "title": "create",
               "type": "boolean"
             },
             "key": {
               "default": "",
-              "title": "key",
               "type": "string"
             },
             "name": {
               "default": "",
-              "title": "name",
               "type": "string"
             },
             "value": {
               "default": "",
-              "title": "value",
               "type": "string"
             }
           },
-          "required": [
-            "create",
-            "name",
-            "key",
-            "value"
-          ],
-          "title": "endpointCA",
+          "required": [],
           "type": "object"
         },
         "endpointURL": {
           "default": "",
           "description": "Overrides the provider specific default endpoint. Defaults to:\nS3: https://s3.\u003cregion\u003e.amazonaws.com\"",
-          "title": "endpointURL",
           "type": "string"
         },
         "google": {
           "properties": {
             "applicationCredentials": {
               "default": "",
-              "title": "applicationCredentials",
               "type": "string"
             },
             "bucket": {
               "default": "",
-              "title": "bucket",
               "type": "string"
             },
             "gkeEnvironment": {
               "default": false,
-              "title": "gkeEnvironment",
               "type": "boolean"
             },
             "path": {
               "default": "/",
-              "title": "path",
               "type": "string"
             }
           },
-          "required": [
-            "path",
-            "bucket",
-            "gkeEnvironment",
-            "applicationCredentials"
-          ],
-          "title": "google",
+          "required": [],
           "type": "object"
         },
         "provider": {
           "default": "s3",
           "description": "One of `s3`, `azure` or `google`",
-          "title": "provider",
           "type": "string"
         },
         "retentionPolicy": {
           "default": "30d",
           "description": "Retention policy for backups",
-          "title": "retentionPolicy",
           "type": "string"
         },
         "s3": {
           "properties": {
             "accessKey": {
               "default": "",
-              "title": "accessKey",
               "type": "string"
             },
             "bucket": {
               "default": "",
-              "title": "bucket",
               "type": "string"
             },
             "inheritFromIAMRole": {
               "default": false,
               "description": "Use the role based authentication without providing explicitly the keys",
-              "title": "inheritFromIAMRole",
               "type": "boolean"
             },
             "path": {
               "default": "/",
-              "title": "path",
               "type": "string"
             },
             "region": {
               "default": "",
-              "title": "region",
               "type": "string"
             },
             "secretKey": {
               "default": "",
-              "title": "secretKey",
               "type": "string"
             }
           },
-          "required": [
-            "region",
-            "bucket",
-            "path",
-            "accessKey",
-            "secretKey",
-            "inheritFromIAMRole"
-          ],
-          "title": "s3",
+          "required": [],
           "type": "object"
         },
         "scheduledBackups": {
@@ -237,40 +172,30 @@
                   "backupOwnerReference": {
                     "default": "self",
                     "description": "Backup owner reference",
-                    "title": "backupOwnerReference",
                     "type": "string"
                   },
                   "method": {
                     "default": "barmanObjectStore",
                     "description": "Backup method, can be `barmanObjectStore` (default) or `volumeSnapshot`",
-                    "title": "method",
                     "type": "string"
                   },
                   "name": {
                     "default": "daily-backup",
                     "description": "Scheduled backup name",
-                    "title": "name",
                     "type": "string"
                   },
                   "schedule": {
                     "default": "0 0 0 * * *",
                     "description": "Schedule in cron format",
-                    "title": "schedule",
                     "type": "string"
                   }
                 },
-                "required": [
-                  "name",
-                  "schedule",
-                  "backupOwnerReference",
-                  "method"
-                ],
+                "required": [],
                 "type": "object"
               }
             ],
             "required": []
           },
-          "title": "scheduledBackups",
           "type": "array"
         },
         "secret": {
@@ -278,21 +203,15 @@
             "create": {
               "default": true,
               "description": "Whether to create a secret for the backup credentials",
-              "title": "create",
               "type": "boolean"
             },
             "name": {
               "default": "",
               "description": "Name of the backup credentials secret",
-              "title": "name",
               "type": "string"
             }
           },
-          "required": [
-            "create",
-            "name"
-          ],
-          "title": "secret",
+          "required": [],
           "type": "object"
         },
         "wal": {
@@ -300,54 +219,30 @@
             "compression": {
               "default": "gzip",
               "description": "WAL compression method. One of `` (for no compression), `gzip`, `bzip2` or `snappy`.",
-              "title": "compression",
               "type": "string"
             },
             "encryption": {
               "default": "AES256",
               "description": "Whether to instruct the storage provider to encrypt WAL files. One of `` (use the storage container default), `AES256` or `aws:kms`.",
-              "title": "encryption",
               "type": "string"
             },
             "maxParallel": {
               "default": 1,
               "description": "Number of WAL files to be archived or restored in parallel.",
-              "title": "maxParallel",
               "type": "integer"
             }
           },
-          "required": [
-            "compression",
-            "encryption",
-            "maxParallel"
-          ],
-          "title": "wal",
+          "required": [],
           "type": "object"
         }
       },
-      "required": [
-        "enabled",
-        "endpointURL",
-        "endpointCA",
-        "destinationPath",
-        "provider",
-        "s3",
-        "azure",
-        "google",
-        "secret",
-        "wal",
-        "data",
-        "scheduledBackups",
-        "retentionPolicy"
-      ],
-      "title": "backups",
+      "required": [],
       "type": "object"
     },
     "cluster": {
       "properties": {
         "additionalLabels": {
           "required": [],
-          "title": "additionalLabels",
           "type": "object"
         },
         "affinity": {
@@ -355,25 +250,19 @@
           "properties": {
             "topologyKey": {
               "default": "topology.kubernetes.io/zone",
-              "title": "topologyKey",
               "type": "string"
             }
           },
-          "required": [
-            "topologyKey"
-          ],
-          "title": "affinity",
+          "required": [],
           "type": "object"
         },
         "annotations": {
           "required": [],
-          "title": "annotations",
           "type": "object"
         },
         "certificates": {
           "description": "The configuration for the CA and related certificates.\nSee: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-CertificatesConfiguration",
           "required": [],
-          "title": "certificates",
           "type": "object"
         },
         "console": {
@@ -381,26 +270,20 @@
             "enabled": {
               "default": false,
               "description": "Deploys a console StatefulSet to run long-running commands against the cluster (e.g. `CREATE INDEX`).",
-              "title": "enabled",
               "type": "boolean"
             }
           },
-          "required": [
-            "enabled"
-          ],
-          "title": "console",
+          "required": [],
           "type": "object"
         },
         "enablePDB": {
           "default": true,
           "description": "Allow to disable PDB, mainly useful for upgrade of single-instance clusters or development purposes\nSee: https://cloudnative-pg.io/documentation/current/kubernetes_upgrade/#pod-disruption-budgets",
-          "title": "enablePDB",
           "type": "boolean"
         },
         "enableSuperuserAccess": {
           "default": true,
           "description": "When this option is enabled, the operator will use the SuperuserSecret to update the postgres user password.\nIf the secret is not present, the operator will automatically create one.\nWhen this option is disabled, the operator will ignore the SuperuserSecret content, delete it when automatically created,\nand then blank the password of the postgres user by setting it to NULL.",
-          "title": "enableSuperuserAccess",
           "type": "boolean"
         },
         "env": {
@@ -408,7 +291,6 @@
           "items": {
             "required": []
           },
-          "title": "env",
           "type": "array"
         },
         "envFrom": {
@@ -416,25 +298,21 @@
           "items": {
             "required": []
           },
-          "title": "envFrom",
           "type": "array"
         },
         "imageCatalogRef": {
           "description": "Reference to `ImageCatalog` of `ClusterImageCatalog`, if specified takes precedence over `cluster.imageName`",
           "required": [],
-          "title": "imageCatalogRef",
           "type": "object"
         },
         "imageName": {
           "default": "",
           "description": "Name of the container image, supporting both tags (\u003cimage\u003e:\u003ctag\u003e) and digests for deterministic and repeatable deployments:\n\u003cimage\u003e:\u003ctag\u003e",
-          "title": "imageName",
           "type": "string"
         },
         "imagePullPolicy": {
           "default": "IfNotPresent",
           "description": "Image pull policy. One of Always, Never or IfNotPresent. If not defined, it defaults to IfNotPresent. Cannot be updated.\nMore info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
-          "title": "imagePullPolicy",
           "type": "string"
         },
         "imagePullSecrets": {
@@ -442,25 +320,21 @@
           "items": {
             "required": []
           },
-          "title": "imagePullSecrets",
           "type": "array"
         },
         "initdb": {
           "description": "BootstrapInitDB is the configuration of the bootstrap process when initdb is used.\nSee: https://cloudnative-pg.io/documentation/current/bootstrap/\nSee: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-bootstrapinitdb",
           "required": [],
-          "title": "initdb",
           "type": "object"
         },
         "instances": {
           "default": 3,
           "description": "Number of instances",
-          "title": "instances",
           "type": "integer"
         },
         "logLevel": {
           "default": "info",
           "description": "The instances' log level, one of the following values: error, warning, info (default), debug, trace",
-          "title": "logLevel",
           "type": "string"
         },
         "monitoring": {
@@ -470,7 +344,6 @@
               "items": {
                 "required": []
               },
-              "title": "customQueries",
               "type": "array"
             },
             "customQueriesSecret": {
@@ -478,19 +351,16 @@
               "items": {
                 "required": []
               },
-              "title": "customQueriesSecret",
               "type": "array"
             },
             "disableDefaultQueries": {
               "default": false,
               "description": "Whether the default queries should be injected.\nSet it to true if you don't want to inject default queries into the cluster.",
-              "title": "disableDefaultQueries",
               "type": "boolean"
             },
             "enabled": {
               "default": false,
               "description": "Whether to enable monitoring",
-              "title": "enabled",
               "type": "boolean"
             },
             "instrumentation": {
@@ -499,14 +369,10 @@
                 "logicalReplication": {
                   "default": true,
                   "description": "Enable logical replication metrics",
-                  "title": "logicalReplication",
                   "type": "boolean"
                 }
               },
-              "required": [
-                "logicalReplication"
-              ],
-              "title": "instrumentation",
+              "required": [],
               "type": "object"
             },
             "podMonitor": {
@@ -514,13 +380,11 @@
                 "enabled": {
                   "default": true,
                   "description": "Whether to enable the PodMonitor",
-                  "title": "enabled",
                   "type": "boolean"
                 },
                 "labels": {
                   "description": "Additional labels to set on the generated PodMonitor resource.\nAdd labels your monitoring stack requires (for example `team-name`).",
                   "required": [],
-                  "title": "labels",
                   "type": "object"
                 },
                 "metricRelabelings": {
@@ -528,7 +392,6 @@
                   "items": {
                     "required": []
                   },
-                  "title": "metricRelabelings",
                   "type": "array"
                 },
                 "relabelings": {
@@ -536,17 +399,10 @@
                   "items": {
                     "required": []
                   },
-                  "title": "relabelings",
                   "type": "array"
                 }
               },
-              "required": [
-                "enabled",
-                "labels",
-                "relabelings",
-                "metricRelabelings"
-              ],
-              "title": "podMonitor",
+              "required": [],
               "type": "object"
             },
             "prometheusRule": {
@@ -554,7 +410,6 @@
                 "enabled": {
                   "default": true,
                   "description": "Whether to enable the PrometheusRule automated alerts",
-                  "title": "enabled",
                   "type": "boolean"
                 },
                 "excludeRules": {
@@ -562,46 +417,29 @@
                   "items": {
                     "required": []
                   },
-                  "title": "excludeRules",
                   "type": "array"
                 }
               },
-              "required": [
-                "enabled",
-                "excludeRules"
-              ],
-              "title": "prometheusRule",
+              "required": [],
               "type": "object"
             }
           },
-          "required": [
-            "enabled",
-            "podMonitor",
-            "prometheusRule",
-            "instrumentation",
-            "disableDefaultQueries",
-            "customQueries",
-            "customQueriesSecret"
-          ],
-          "title": "monitoring",
+          "required": [],
           "type": "object"
         },
         "podSecurityContext": {
           "description": "Configure the Pod Security Context.\nSee: https://cloudnative-pg.io/documentation/preview/security/",
           "required": [],
-          "title": "podSecurityContext",
           "type": "object"
         },
         "postgresGID": {
           "default": -1,
           "description": "The GID of the postgres user inside the image, defaults to 26",
-          "title": "postgresGID",
           "type": "integer"
         },
         "postgresUID": {
           "default": -1,
           "description": "The UID of the postgres user inside the image, defaults to 26",
-          "title": "postgresUID",
           "type": "integer"
         },
         "postgresql": {
@@ -609,13 +447,11 @@
             "ldap": {
               "description": "- pgaudit\nPostgreSQL LDAP configuration (see https://cloudnative-pg.io/documentation/current/postgresql_conf/#ldap-configuration)",
               "required": [],
-              "title": "ldap",
               "type": "object"
             },
             "parameters": {
               "description": "PostgreSQL configuration options (postgresql.conf)",
               "required": [],
-              "title": "parameters",
               "type": "object"
             },
             "pg_hba": {
@@ -623,7 +459,6 @@
               "items": {
                 "required": []
               },
-              "title": "pg_hba",
               "type": "array"
             },
             "pg_ident": {
@@ -631,7 +466,6 @@
               "items": {
                 "required": []
               },
-              "title": "pg_ident",
               "type": "array"
             },
             "shared_preload_libraries": {
@@ -639,48 +473,34 @@
               "items": {
                 "required": []
               },
-              "title": "shared_preload_libraries",
               "type": "array"
             },
             "synchronous": {
               "description": "max_connections: 300\nQuorum-based Synchronous Replication",
               "required": [],
-              "title": "synchronous",
               "type": "object"
             }
           },
-          "required": [
-            "parameters",
-            "synchronous",
-            "pg_hba",
-            "pg_ident",
-            "shared_preload_libraries",
-            "ldap"
-          ],
-          "title": "postgresql",
+          "required": [],
           "type": "object"
         },
         "primaryUpdateMethod": {
           "default": "switchover",
           "description": "Method to follow to upgrade the primary server during a rolling update procedure, after all replicas have been\nsuccessfully updated. It can be switchover (default) or restart.",
-          "title": "primaryUpdateMethod",
           "type": "string"
         },
         "primaryUpdateStrategy": {
           "default": "unsupervised",
           "description": "Strategy to follow to upgrade the primary server during a rolling update procedure, after all replicas have been\nsuccessfully updated: it can be automated (unsupervised - default) or manual (supervised)",
-          "title": "primaryUpdateStrategy",
           "type": "string"
         },
         "priorityClassName": {
           "default": "",
-          "title": "priorityClassName",
           "type": "string"
         },
         "resources": {
           "description": "Resources requirements of every generated Pod.\nPlease refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ for more information.\nWe strongly advise you use the same setting for limits and requests so that your cluster pods are given a Guaranteed QoS.\nSee: https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/",
           "required": [],
-          "title": "resources",
           "type": "object"
         },
         "roles": {
@@ -688,114 +508,61 @@
           "items": {
             "required": []
           },
-          "title": "roles",
           "type": "array"
         },
         "securityContext": {
           "description": "Configure Container Security Context.\nSee: https://cloudnative-pg.io/documentation/preview/security/",
           "required": [],
-          "title": "securityContext",
           "type": "object"
         },
         "serviceAccountTemplate": {
           "description": "Configure the metadata of the generated service account",
           "required": [],
-          "title": "serviceAccountTemplate",
           "type": "object"
         },
         "services": {
           "description": "Customization of service definitions. Please refer to https://cloudnative-pg.io/documentation/current/service_management/",
           "required": [],
-          "title": "services",
           "type": "object"
         },
         "storage": {
           "properties": {
             "size": {
               "default": "8Gi",
-              "title": "size",
               "type": "string"
             },
             "storageClass": {
               "default": "",
-              "title": "storageClass",
               "type": "string"
             }
           },
-          "required": [
-            "size",
-            "storageClass"
-          ],
-          "title": "storage",
+          "required": [],
           "type": "object"
         },
         "superuserSecret": {
           "default": "",
-          "title": "superuserSecret",
           "type": "string"
         },
         "walStorage": {
           "properties": {
             "enabled": {
               "default": false,
-              "title": "enabled",
               "type": "boolean"
             },
             "size": {
               "default": "1Gi",
-              "title": "size",
               "type": "string"
             },
             "storageClass": {
               "default": "",
-              "title": "storageClass",
               "type": "string"
             }
           },
-          "required": [
-            "enabled",
-            "size",
-            "storageClass"
-          ],
-          "title": "walStorage",
+          "required": [],
           "type": "object"
         }
       },
-      "required": [
-        "instances",
-        "imageName",
-        "imageCatalogRef",
-        "imagePullPolicy",
-        "imagePullSecrets",
-        "storage",
-        "walStorage",
-        "postgresUID",
-        "postgresGID",
-        "services",
-        "resources",
-        "priorityClassName",
-        "primaryUpdateMethod",
-        "primaryUpdateStrategy",
-        "logLevel",
-        "affinity",
-        "env",
-        "envFrom",
-        "certificates",
-        "enableSuperuserAccess",
-        "superuserSecret",
-        "enablePDB",
-        "roles",
-        "monitoring",
-        "postgresql",
-        "initdb",
-        "serviceAccountTemplate",
-        "podSecurityContext",
-        "securityContext",
-        "additionalLabels",
-        "annotations",
-        "console"
-      ],
-      "title": "cluster",
+      "required": [],
       "type": "object"
     },
     "databases": {
@@ -803,19 +570,16 @@
       "items": {
         "required": []
       },
-      "title": "databases",
       "type": "array"
     },
     "fullnameOverride": {
       "default": "",
       "description": "Override the full name of the chart",
-      "title": "fullnameOverride",
       "type": "string"
     },
     "global": {
       "description": "Global values are values that can be accessed from any chart or subchart by exactly the same name.",
       "required": [],
-      "title": "global",
       "type": "object"
     },
     "imageCatalog": {
@@ -823,7 +587,6 @@
         "create": {
           "default": true,
           "description": "Whether to provision an image catalog. If imageCatalog.images is empty this option will be ignored.",
-          "title": "create",
           "type": "boolean"
         },
         "images": {
@@ -831,33 +594,25 @@
           "items": {
             "required": []
           },
-          "title": "images",
           "type": "array"
         }
       },
-      "required": [
-        "create",
-        "images"
-      ],
-      "title": "imageCatalog",
+      "required": [],
       "type": "object"
     },
     "mode": {
       "default": "standalone",
       "description": "##\nCluster mode of operation. Available modes:\n* `standalone` - default mode. Creates new or updates an existing CNPG cluster.\n* `replica` - Creates a replica cluster from an existing CNPG cluster.\n* `recovery` - Same as standalone but creates a cluster from a backup, object store or via pg_basebackup.",
-      "title": "mode",
       "type": "string"
     },
     "nameOverride": {
       "default": "",
       "description": "Override the name of the chart",
-      "title": "nameOverride",
       "type": "string"
     },
     "namespaceOverride": {
       "default": "",
       "description": "Override the namespace of the chart",
-      "title": "namespaceOverride",
       "type": "string"
     },
     "poolers": {
@@ -865,7 +620,6 @@
       "items": {
         "required": []
       },
-      "title": "poolers",
       "type": "array"
     },
     "recovery": {
@@ -874,80 +628,58 @@
           "properties": {
             "connectionString": {
               "default": "",
-              "title": "connectionString",
               "type": "string"
             },
             "containerName": {
               "default": "",
-              "title": "containerName",
               "type": "string"
             },
             "inheritFromAzureAD": {
               "default": false,
-              "title": "inheritFromAzureAD",
               "type": "boolean"
             },
             "path": {
               "default": "/",
-              "title": "path",
               "type": "string"
             },
             "serviceName": {
               "default": "blob",
-              "title": "serviceName",
               "type": "string"
             },
             "storageAccount": {
               "default": "",
-              "title": "storageAccount",
               "type": "string"
             },
             "storageKey": {
               "default": "",
-              "title": "storageKey",
               "type": "string"
             },
             "storageSasToken": {
               "default": "",
-              "title": "storageSasToken",
               "type": "string"
             }
           },
-          "required": [
-            "path",
-            "connectionString",
-            "storageAccount",
-            "storageKey",
-            "storageSasToken",
-            "containerName",
-            "serviceName",
-            "inheritFromAzureAD"
-          ],
-          "title": "azure",
+          "required": [],
           "type": "object"
         },
         "backupName": {
           "default": "",
           "description": "#\nBackup Recovery Method",
-          "title": "backupName",
           "type": "string"
         },
         "clusterName": {
           "default": "",
           "description": "#\nThe original cluster name when used in backups. Also known as serverName.",
-          "title": "clusterName",
           "type": "string"
         },
         "database": {
           "default": "app",
           "description": "Name of the database used by the application. Default: `app`.",
-          "title": "database",
           "type": "string"
         },
         "destinationPath": {
           "default": "",
           "description": "Overrides the provider specific default path. Defaults to:\nS3: s3://\u003cbucket\u003e\u003cpath\u003e\nAzure: https://\u003cstorageAccount\u003e.\u003cserviceName\u003e.core.windows.net/\u003ccontainerName\u003e\u003cpath\u003e\nGoogle: gs://\u003cbucket\u003e\u003cpath\u003e",
-          "title": "destinationPath",
           "type": "string"
         },
         "endpointCA": {
@@ -956,70 +688,49 @@
             "create": {
               "default": false,
               "description": "Creates a secret with the given value if true, otherwise uses an existing secret.",
-              "title": "create",
               "type": "boolean"
             },
             "key": {
               "default": "",
-              "title": "key",
               "type": "string"
             },
             "name": {
               "default": "",
-              "title": "name",
               "type": "string"
             },
             "value": {
               "default": "",
-              "title": "value",
               "type": "string"
             }
           },
-          "required": [
-            "create",
-            "name",
-            "key",
-            "value"
-          ],
-          "title": "endpointCA",
+          "required": [],
           "type": "object"
         },
         "endpointURL": {
           "default": "",
           "description": "Overrides the provider specific default endpoint. Defaults to:\nS3: https://s3.\u003cregion\u003e.amazonaws.com\"\nLeave empty if using the default S3 endpoint",
-          "title": "endpointURL",
           "type": "string"
         },
         "google": {
           "properties": {
             "applicationCredentials": {
               "default": "",
-              "title": "applicationCredentials",
               "type": "string"
             },
             "bucket": {
               "default": "",
-              "title": "bucket",
               "type": "string"
             },
             "gkeEnvironment": {
               "default": false,
-              "title": "gkeEnvironment",
               "type": "boolean"
             },
             "path": {
               "default": "/",
-              "title": "path",
               "type": "string"
             }
           },
-          "required": [
-            "path",
-            "bucket",
-            "gkeEnvironment",
-            "applicationCredentials"
-          ],
-          "title": "google",
+          "required": [],
           "type": "object"
         },
         "import": {
@@ -1030,7 +741,6 @@
               "items": {
                 "required": []
               },
-              "title": "databases",
               "type": "array"
             },
             "pgDumpExtraOptions": {
@@ -1038,7 +748,6 @@
               "items": {
                 "required": []
               },
-              "title": "pgDumpExtraOptions",
               "type": "array"
             },
             "pgRestoreExtraOptions": {
@@ -1046,7 +755,6 @@
               "items": {
                 "required": []
               },
-              "title": "pgRestoreExtraOptions",
               "type": "array"
             },
             "postImportApplicationSQL": {
@@ -1054,7 +762,6 @@
               "items": {
                 "required": []
               },
-              "title": "postImportApplicationSQL",
               "type": "array"
             },
             "roles": {
@@ -1062,25 +769,21 @@
               "items": {
                 "required": []
               },
-              "title": "roles",
               "type": "array"
             },
             "schemaOnly": {
               "default": false,
               "description": "When set to true, only the pre-data and post-data sections of pg_restore are invoked, avoiding data import.",
-              "title": "schemaOnly",
               "type": "boolean"
             },
             "source": {
               "properties": {
                 "database": {
                   "default": "",
-                  "title": "database",
                   "type": "string"
                 },
                 "host": {
                   "default": "",
-                  "title": "host",
                   "type": "string"
                 },
                 "passwordSecret": {
@@ -1088,157 +791,102 @@
                     "create": {
                       "default": false,
                       "description": "Whether to create a secret for the password",
-                      "title": "create",
                       "type": "boolean"
                     },
                     "key": {
                       "default": "password",
                       "description": "The key in the secret containing the password",
-                      "title": "key",
                       "type": "string"
                     },
                     "name": {
                       "default": "",
                       "description": "Name of the secret containing the password",
-                      "title": "name",
                       "type": "string"
                     },
                     "value": {
                       "default": "",
                       "description": "The password value to use when creating the secret",
-                      "title": "value",
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "create",
-                    "name",
-                    "key",
-                    "value"
-                  ],
-                  "title": "passwordSecret",
+                  "required": [],
                   "type": "object"
                 },
                 "port": {
                   "default": 5432,
-                  "title": "port",
                   "type": "integer"
                 },
                 "sslCertSecret": {
                   "properties": {
                     "key": {
                       "default": "",
-                      "title": "key",
                       "type": "string"
                     },
                     "name": {
                       "default": "",
-                      "title": "name",
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "name",
-                    "key"
-                  ],
-                  "title": "sslCertSecret",
+                  "required": [],
                   "type": "object"
                 },
                 "sslKeySecret": {
                   "properties": {
                     "key": {
                       "default": "",
-                      "title": "key",
                       "type": "string"
                     },
                     "name": {
                       "default": "",
-                      "title": "name",
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "name",
-                    "key"
-                  ],
-                  "title": "sslKeySecret",
+                  "required": [],
                   "type": "object"
                 },
                 "sslMode": {
                   "default": "verify-full",
-                  "title": "sslMode",
                   "type": "string"
                 },
                 "sslRootCertSecret": {
                   "properties": {
                     "key": {
                       "default": "",
-                      "title": "key",
                       "type": "string"
                     },
                     "name": {
                       "default": "",
-                      "title": "name",
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "name",
-                    "key"
-                  ],
-                  "title": "sslRootCertSecret",
+                  "required": [],
                   "type": "object"
                 },
                 "username": {
                   "default": "",
-                  "title": "username",
                   "type": "string"
                 }
               },
-              "required": [
-                "host",
-                "port",
-                "username",
-                "database",
-                "sslMode",
-                "passwordSecret",
-                "sslKeySecret",
-                "sslCertSecret",
-                "sslRootCertSecret"
-              ],
-              "title": "source",
+              "required": [],
               "type": "object"
             },
             "type": {
               "default": "microservice",
               "description": "One of `microservice` or `monolith.`\nSee: https://cloudnative-pg.io/documentation/current/database_import/#how-it-works",
-              "title": "type",
               "type": "string"
             }
           },
-          "required": [
-            "type",
-            "databases",
-            "roles",
-            "postImportApplicationSQL",
-            "schemaOnly",
-            "pgDumpExtraOptions",
-            "pgRestoreExtraOptions",
-            "source"
-          ],
-          "title": "import",
+          "required": [],
           "type": "object"
         },
         "method": {
           "default": "backup",
           "description": "#\nAvailable recovery methods:\n* `backup` - Recovers a CNPG cluster from a CNPG backup (PITR supported) Needs to be on the same cluster in the same namespace.\n* `object_store` - Recovers a CNPG cluster from a barman object store (PITR supported).\n* `pg_basebackup` - Recovers a CNPG cluster viaa streaming replication protocol. Useful if you want to\n       migrate databases to CloudNativePG, even from outside Kubernetes.\n* `import` - Import one or more databases from an existing Postgres cluster.",
-          "title": "method",
           "type": "string"
         },
         "owner": {
           "default": "",
           "description": "Name of the owner of the database in the instance to be used by applications. Defaults to the value of the `database` key.",
-          "title": "owner",
           "type": "string"
         },
         "pgBaseBackup": {
@@ -1247,31 +895,26 @@
             "database": {
               "default": "app",
               "description": "Name of the database used by the application. Default: `app`.",
-              "title": "database",
               "type": "string"
             },
             "owner": {
               "default": "",
               "description": "Name of the owner of the database in the instance to be used by applications. Defaults to the value of the `database` key.",
-              "title": "owner",
               "type": "string"
             },
             "secretName": {
               "default": "",
               "description": "Name of the kubernetes.io/basic-auth secret containing the initial credentials for the owner of the user database. If empty a new secret will be created from scratch.",
-              "title": "secretName",
               "type": "string"
             },
             "source": {
               "properties": {
                 "database": {
                   "default": "app",
-                  "title": "database",
                   "type": "string"
                 },
                 "host": {
                   "default": "",
-                  "title": "host",
                   "type": "string"
                 },
                 "passwordSecret": {
@@ -1279,135 +922,87 @@
                     "create": {
                       "default": false,
                       "description": "Whether to create a secret for the password",
-                      "title": "create",
                       "type": "boolean"
                     },
                     "key": {
                       "default": "password",
                       "description": "The key in the secret containing the password",
-                      "title": "key",
                       "type": "string"
                     },
                     "name": {
                       "default": "",
                       "description": "Name of the secret containing the password",
-                      "title": "name",
                       "type": "string"
                     },
                     "value": {
                       "default": "",
                       "description": "The password value to use when creating the secret",
-                      "title": "value",
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "create",
-                    "name",
-                    "key",
-                    "value"
-                  ],
-                  "title": "passwordSecret",
+                  "required": [],
                   "type": "object"
                 },
                 "port": {
                   "default": 5432,
-                  "title": "port",
                   "type": "integer"
                 },
                 "sslCertSecret": {
                   "properties": {
                     "key": {
                       "default": "",
-                      "title": "key",
                       "type": "string"
                     },
                     "name": {
                       "default": "",
-                      "title": "name",
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "name",
-                    "key"
-                  ],
-                  "title": "sslCertSecret",
+                  "required": [],
                   "type": "object"
                 },
                 "sslKeySecret": {
                   "properties": {
                     "key": {
                       "default": "",
-                      "title": "key",
                       "type": "string"
                     },
                     "name": {
                       "default": "",
-                      "title": "name",
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "name",
-                    "key"
-                  ],
-                  "title": "sslKeySecret",
+                  "required": [],
                   "type": "object"
                 },
                 "sslMode": {
                   "default": "verify-full",
-                  "title": "sslMode",
                   "type": "string"
                 },
                 "sslRootCertSecret": {
                   "properties": {
                     "key": {
                       "default": "",
-                      "title": "key",
                       "type": "string"
                     },
                     "name": {
                       "default": "",
-                      "title": "name",
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "name",
-                    "key"
-                  ],
-                  "title": "sslRootCertSecret",
+                  "required": [],
                   "type": "object"
                 },
                 "username": {
                   "default": "",
-                  "title": "username",
                   "type": "string"
                 }
               },
-              "required": [
-                "host",
-                "port",
-                "username",
-                "database",
-                "sslMode",
-                "passwordSecret",
-                "sslKeySecret",
-                "sslCertSecret",
-                "sslRootCertSecret"
-              ],
-              "title": "source",
+              "required": [],
               "type": "object"
             }
           },
-          "required": [
-            "database",
-            "secretName",
-            "owner",
-            "source"
-          ],
-          "title": "pgBaseBackup",
+          "required": [],
           "type": "object"
         },
         "pitrTarget": {
@@ -1416,65 +1011,46 @@
             "time": {
               "default": "",
               "description": "Time in RFC3339 format",
-              "title": "time",
               "type": "string"
             }
           },
-          "required": [
-            "time"
-          ],
-          "title": "pitrTarget",
+          "required": [],
           "type": "object"
         },
         "provider": {
           "default": "s3",
           "description": "One of `s3`, `azure` or `google`",
-          "title": "provider",
           "type": "string"
         },
         "s3": {
           "properties": {
             "accessKey": {
               "default": "",
-              "title": "accessKey",
               "type": "string"
             },
             "bucket": {
               "default": "",
-              "title": "bucket",
               "type": "string"
             },
             "inheritFromIAMRole": {
               "default": false,
               "description": "Use the role based authentication without providing explicitly the keys",
-              "title": "inheritFromIAMRole",
               "type": "boolean"
             },
             "path": {
               "default": "/",
-              "title": "path",
               "type": "string"
             },
             "region": {
               "default": "",
-              "title": "region",
               "type": "string"
             },
             "secretKey": {
               "default": "",
-              "title": "secretKey",
               "type": "string"
             }
           },
-          "required": [
-            "region",
-            "bucket",
-            "path",
-            "accessKey",
-            "secretKey",
-            "inheritFromIAMRole"
-          ],
-          "title": "s3",
+          "required": [],
           "type": "object"
         },
         "secret": {
@@ -1482,43 +1058,19 @@
             "create": {
               "default": true,
               "description": "Whether to create a secret for the backup credentials",
-              "title": "create",
               "type": "boolean"
             },
             "name": {
               "default": "",
               "description": "Name of the backup credentials secret",
-              "title": "name",
               "type": "string"
             }
           },
-          "required": [
-            "create",
-            "name"
-          ],
-          "title": "secret",
+          "required": [],
           "type": "object"
         }
       },
-      "required": [
-        "method",
-        "pitrTarget",
-        "backupName",
-        "clusterName",
-        "database",
-        "owner",
-        "endpointURL",
-        "endpointCA",
-        "destinationPath",
-        "provider",
-        "s3",
-        "azure",
-        "google",
-        "secret",
-        "pgBaseBackup",
-        "import"
-      ],
-      "title": "recovery",
+      "required": [],
       "type": "object"
     },
     "replica": {
@@ -1528,41 +1080,30 @@
             "database": {
               "default": "",
               "description": "Name of the database used by the application",
-              "title": "database",
               "type": "string"
             },
             "owner": {
               "default": "",
               "description": "Name of the owner of the database in the instance to be used by applications. Defaults to the value of the `database` key.",
-              "title": "owner",
               "type": "string"
             },
             "secret": {
               "default": "",
               "description": "Name of the secret containing the initial credentials for the owner of the user database. If empty a new secret will be created from scratch",
-              "title": "secret",
               "type": "string"
             },
             "source": {
               "default": "",
               "description": " One of `object_store` or `pg_basebackup`. Method to use for bootstrap.",
-              "title": "source",
               "type": "string"
             }
           },
-          "required": [
-            "source",
-            "database",
-            "secret",
-            "owner"
-          ],
-          "title": "bootstrap",
+          "required": [],
           "type": "object"
         },
         "minApplyDelay": {
           "default": "",
           "description": "When replica mode is enabled, this parameter allows you to replay transactions only when the system time is at least the configured time past the commit time. This provides an opportunity to correct data loss errors. Note that when this parameter is set, a promotion token cannot be used.",
-          "title": "minApplyDelay",
           "type": "string"
         },
         "origin": {
@@ -1573,68 +1114,48 @@
                   "properties": {
                     "connectionString": {
                       "default": "",
-                      "title": "connectionString",
                       "type": "string"
                     },
                     "containerName": {
                       "default": "",
-                      "title": "containerName",
                       "type": "string"
                     },
                     "inheritFromAzureAD": {
                       "default": false,
-                      "title": "inheritFromAzureAD",
                       "type": "boolean"
                     },
                     "path": {
                       "default": "/",
-                      "title": "path",
                       "type": "string"
                     },
                     "serviceName": {
                       "default": "blob",
-                      "title": "serviceName",
                       "type": "string"
                     },
                     "storageAccount": {
                       "default": "",
-                      "title": "storageAccount",
                       "type": "string"
                     },
                     "storageKey": {
                       "default": "",
-                      "title": "storageKey",
                       "type": "string"
                     },
                     "storageSasToken": {
                       "default": "",
-                      "title": "storageSasToken",
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "path",
-                    "connectionString",
-                    "storageAccount",
-                    "storageKey",
-                    "storageSasToken",
-                    "containerName",
-                    "serviceName",
-                    "inheritFromAzureAD"
-                  ],
-                  "title": "azure",
+                  "required": [],
                   "type": "object"
                 },
                 "clusterName": {
                   "default": "",
                   "description": "The original cluster name when used in backups. Also known as serverName.",
-                  "title": "clusterName",
                   "type": "string"
                 },
                 "destinationPath": {
                   "default": "",
                   "description": "Overrides the provider specific default path. Defaults to:\nS3: s3://\u003cbucket\u003e\u003cpath\u003e\nAzure: https://\u003cstorageAccount\u003e.\u003cserviceName\u003e.core.windows.net/\u003ccontainerName\u003e\u003cpath\u003e\nGoogle: gs://\u003cbucket\u003e\u003cpath\u003e",
-                  "title": "destinationPath",
                   "type": "string"
                 },
                 "endpointCA": {
@@ -1643,115 +1164,80 @@
                     "create": {
                       "default": false,
                       "description": "Creates a secret with the given value if true, otherwise uses an existing secret.",
-                      "title": "create",
                       "type": "boolean"
                     },
                     "key": {
                       "default": "",
-                      "title": "key",
                       "type": "string"
                     },
                     "name": {
                       "default": "",
-                      "title": "name",
                       "type": "string"
                     },
                     "value": {
                       "default": "",
-                      "title": "value",
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "create",
-                    "name",
-                    "key",
-                    "value"
-                  ],
-                  "title": "endpointCA",
+                  "required": [],
                   "type": "object"
                 },
                 "google": {
                   "properties": {
                     "applicationCredentials": {
                       "default": "",
-                      "title": "applicationCredentials",
                       "type": "string"
                     },
                     "bucket": {
                       "default": "",
-                      "title": "bucket",
                       "type": "string"
                     },
                     "gkeEnvironment": {
                       "default": false,
-                      "title": "gkeEnvironment",
                       "type": "boolean"
                     },
                     "path": {
                       "default": "/",
-                      "title": "path",
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "path",
-                    "bucket",
-                    "gkeEnvironment",
-                    "applicationCredentials"
-                  ],
-                  "title": "google",
+                  "required": [],
                   "type": "object"
                 },
                 "provider": {
                   "default": "",
                   "description": "One of `s3`, `azure` or `google`",
-                  "title": "provider",
                   "type": "string"
                 },
                 "s3": {
                   "properties": {
                     "accessKey": {
                       "default": "",
-                      "title": "accessKey",
                       "type": "string"
                     },
                     "bucket": {
                       "default": "",
-                      "title": "bucket",
                       "type": "string"
                     },
                     "inheritFromIAMRole": {
                       "default": false,
                       "description": "Use the role based authentication without providing explicitly the keys",
-                      "title": "inheritFromIAMRole",
                       "type": "boolean"
                     },
                     "path": {
                       "default": "/",
-                      "title": "path",
                       "type": "string"
                     },
                     "region": {
                       "default": "",
-                      "title": "region",
                       "type": "string"
                     },
                     "secretKey": {
                       "default": "",
-                      "title": "secretKey",
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "region",
-                    "bucket",
-                    "path",
-                    "accessKey",
-                    "secretKey",
-                    "inheritFromIAMRole"
-                  ],
-                  "title": "s3",
+                  "required": [],
                   "type": "object"
                 },
                 "secret": {
@@ -1759,201 +1245,129 @@
                     "create": {
                       "default": true,
                       "description": "Whether to create a secret for the backup credentials",
-                      "title": "create",
                       "type": "boolean"
                     },
                     "name": {
                       "default": "",
                       "description": "Name of the backup credentials secret",
-                      "title": "name",
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "create",
-                    "name"
-                  ],
-                  "title": "secret",
+                  "required": [],
                   "type": "object"
                 }
               },
-              "required": [
-                "clusterName",
-                "destinationPath",
-                "endpointCA",
-                "provider",
-                "s3",
-                "azure",
-                "google",
-                "secret"
-              ],
-              "title": "objectStore",
+              "required": [],
               "type": "object"
             },
             "pg_basebackup": {
               "properties": {
                 "database": {
                   "default": "",
-                  "title": "database",
                   "type": "string"
                 },
                 "host": {
                   "default": "",
-                  "title": "host",
                   "type": "string"
                 },
                 "passwordSecret": {
                   "properties": {
                     "key": {
                       "default": "",
-                      "title": "key",
                       "type": "string"
                     },
                     "name": {
                       "default": "",
-                      "title": "name",
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "name",
-                    "key"
-                  ],
-                  "title": "passwordSecret",
+                  "required": [],
                   "type": "object"
                 },
                 "port": {
                   "default": 5432,
-                  "title": "port",
                   "type": "integer"
                 },
                 "sslCertSecret": {
                   "properties": {
                     "key": {
                       "default": "",
-                      "title": "key",
                       "type": "string"
                     },
                     "name": {
                       "default": "",
-                      "title": "name",
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "name",
-                    "key"
-                  ],
-                  "title": "sslCertSecret",
+                  "required": [],
                   "type": "object"
                 },
                 "sslKeySecret": {
                   "properties": {
                     "key": {
                       "default": "",
-                      "title": "key",
                       "type": "string"
                     },
                     "name": {
                       "default": "",
-                      "title": "name",
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "name",
-                    "key"
-                  ],
-                  "title": "sslKeySecret",
+                  "required": [],
                   "type": "object"
                 },
                 "sslMode": {
                   "default": "verify-full",
-                  "title": "sslMode",
                   "type": "string"
                 },
                 "sslRootCertSecret": {
                   "properties": {
                     "key": {
                       "default": "",
-                      "title": "key",
                       "type": "string"
                     },
                     "name": {
                       "default": "",
-                      "title": "name",
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "name",
-                    "key"
-                  ],
-                  "title": "sslRootCertSecret",
+                  "required": [],
                   "type": "object"
                 },
                 "username": {
                   "default": "",
-                  "title": "username",
                   "type": "string"
                 }
               },
-              "required": [
-                "host",
-                "port",
-                "username",
-                "sslMode",
-                "database",
-                "sslKeySecret",
-                "sslCertSecret",
-                "sslRootCertSecret",
-                "passwordSecret"
-              ],
-              "title": "pg_basebackup",
+              "required": [],
               "type": "object"
             }
           },
-          "required": [
-            "objectStore",
-            "pg_basebackup"
-          ],
-          "title": "origin",
+          "required": [],
           "type": "object"
         },
         "primary": {
           "default": "",
           "description": "Primary defines which Cluster is defined to be the primary in the distributed PostgreSQL cluster, based on the topology specified in externalClusters",
-          "title": "primary",
           "type": "string"
         },
         "promotionToken": {
           "default": "",
           "description": "A demotion token generated by an external cluster used to check if the promotion requirements are met.",
-          "title": "promotionToken",
           "type": "string"
         },
         "self": {
           "default": "",
           "description": " Defines the name of this cluster. It is used to determine if this is a primary or a replica cluster, comparing it with primary. Leave empty by default.",
-          "title": "self",
           "type": "string"
         }
       },
-      "required": [
-        "self",
-        "primary",
-        "promotionToken",
-        "minApplyDelay",
-        "bootstrap",
-        "origin"
-      ],
-      "title": "replica",
+      "required": [],
       "type": "object"
     },
     "type": {
       "default": "postgresql",
       "description": "##\nType of the CNPG database. Available types:\n* `postgresql`\n* `postgis`\n* `timescaledb`",
-      "title": "type",
       "type": "string"
     },
     "version": {
@@ -1961,45 +1375,23 @@
         "postgis": {
           "default": "3.4",
           "description": "If using PostGIS, specify the version",
-          "title": "postgis",
           "type": "string"
         },
         "postgresql": {
           "default": "16",
           "description": "PostgreSQL major version to use",
-          "title": "postgresql",
           "type": "string"
         },
         "timescaledb": {
           "default": "2.15",
           "description": "If using TimescaleDB, specify the version",
-          "title": "timescaledb",
           "type": "string"
         }
       },
-      "required": [
-        "postgresql",
-        "timescaledb",
-        "postgis"
-      ],
-      "title": "version",
+      "required": [],
       "type": "object"
     }
   },
-  "required": [
-    "nameOverride",
-    "fullnameOverride",
-    "namespaceOverride",
-    "type",
-    "version",
-    "mode",
-    "recovery",
-    "cluster",
-    "backups",
-    "replica",
-    "databases",
-    "imageCatalog",
-    "poolers"
-  ],
+  "required": [],
   "type": "object"
 }

--- a/charts/cluster/values.schema.json
+++ b/charts/cluster/values.schema.json
@@ -64,7 +64,7 @@
         },
         "destinationPath": {
           "default": "",
-          "description": "Overrides the provider specific default path. Defaults to:\nS3: s3://\u003cbucket\u003e\u003cpath\u003e\nAzure: https://\u003cstorageAccount\u003e.\u003cserviceName\u003e.core.windows.net/\u003ccontainerName\u003e\u003cpath\u003e\nGoogle: gs://\u003cbucket\u003e\u003cpath\u003e",
+          "description": "Overrides the provider specific default path.",
           "type": "string"
         },
         "enabled": {
@@ -98,7 +98,7 @@
         },
         "endpointURL": {
           "default": "",
-          "description": "Overrides the provider specific default endpoint. Defaults to:\nS3: https://s3.\u003cregion\u003e.amazonaws.com\"",
+          "description": "Overrides the provider specific default endpoint.",
           "type": "string"
         },
         "google": {
@@ -679,7 +679,7 @@
         },
         "destinationPath": {
           "default": "",
-          "description": "Overrides the provider specific default path. Defaults to:\nS3: s3://\u003cbucket\u003e\u003cpath\u003e\nAzure: https://\u003cstorageAccount\u003e.\u003cserviceName\u003e.core.windows.net/\u003ccontainerName\u003e\u003cpath\u003e\nGoogle: gs://\u003cbucket\u003e\u003cpath\u003e",
+          "description": "Overrides the provider specific default path.",
           "type": "string"
         },
         "endpointCA": {
@@ -708,7 +708,7 @@
         },
         "endpointURL": {
           "default": "",
-          "description": "Overrides the provider specific default endpoint. Defaults to:\nS3: https://s3.\u003cregion\u003e.amazonaws.com\"\nLeave empty if using the default S3 endpoint",
+          "description": "Overrides the provider specific default endpoint.",
           "type": "string"
         },
         "google": {
@@ -1155,7 +1155,7 @@
                 },
                 "destinationPath": {
                   "default": "",
-                  "description": "Overrides the provider specific default path. Defaults to:\nS3: s3://\u003cbucket\u003e\u003cpath\u003e\nAzure: https://\u003cstorageAccount\u003e.\u003cserviceName\u003e.core.windows.net/\u003ccontainerName\u003e\u003cpath\u003e\nGoogle: gs://\u003cbucket\u003e\u003cpath\u003e",
+                  "description": "Overrides the provider specific default path.",
                   "type": "string"
                 },
                 "endpointCA": {

--- a/charts/cluster/values.schema.json
+++ b/charts/cluster/values.schema.json
@@ -46,17 +46,17 @@
             "compression": {
               "default": "gzip",
               "description": "Data compression method. One of `` (for no compression), `gzip`, `bzip2` or `snappy`.",
-              "required": []
+              "type": "string"
             },
             "encryption": {
               "default": "AES256",
               "description": "Whether to instruct the storage provider to encrypt data files. One of `` (use the storage container default), `AES256` or `aws:kms`.",
-              "required": []
+              "type": "string"
             },
             "jobs": {
-              "default": "2",
+              "default": 2,
               "description": "Number of data files to be archived or restored in parallel.",
-              "required": []
+              "type": "integer"
             }
           },
           "required": [],
@@ -64,21 +64,21 @@
         },
         "destinationPath": {
           "default": "",
-          "description": "Overrides the provider specific default path. Defaults to: S3: s3://\u003cbucket\u003e\u003cpath\u003e Azure: https://\u003cstorageAccount\u003e.\u003cserviceName\u003e.core.windows.net/\u003ccontainerName\u003e\u003cpath\u003e Google: gs://\u003cbucket\u003e\u003cpath\u003e",
-          "required": []
+          "description": "Overrides the provider specific default path. Defaults to:\nS3: s3://\u003cbucket\u003e\u003cpath\u003e\nAzure: https://\u003cstorageAccount\u003e.\u003cserviceName\u003e.core.windows.net/\u003ccontainerName\u003e\u003cpath\u003e\nGoogle: gs://\u003cbucket\u003e\u003cpath\u003e",
+          "type": "string"
         },
         "enabled": {
-          "default": "false",
+          "default": false,
           "description": "You need to configure backups manually, so backups are disabled by default.",
-          "required": []
+          "type": "boolean"
         },
         "endpointCA": {
           "description": "Specifies a CA bundle to validate a privately signed certificate.",
           "properties": {
             "create": {
-              "default": "false",
+              "default": false,
               "description": "Creates a secret with the given value if true, otherwise uses an existing secret.",
-              "required": []
+              "type": "boolean"
             },
             "key": {
               "default": "",
@@ -93,12 +93,13 @@
               "type": "string"
             }
           },
-          "required": []
+          "required": [],
+          "type": "object"
         },
         "endpointURL": {
           "default": "",
-          "description": "Overrides the provider specific default endpoint. Defaults to: S3: https://s3.\u003cregion\u003e.amazonaws.com\"",
-          "required": []
+          "description": "Overrides the provider specific default endpoint. Defaults to:\nS3: https://s3.\u003cregion\u003e.amazonaws.com\"",
+          "type": "string"
         },
         "google": {
           "properties": {
@@ -125,12 +126,12 @@
         "provider": {
           "default": "s3",
           "description": "One of `s3`, `azure` or `google`",
-          "required": []
+          "type": "string"
         },
         "retentionPolicy": {
           "default": "30d",
           "description": "Retention policy for backups",
-          "required": []
+          "type": "string"
         },
         "s3": {
           "properties": {
@@ -143,9 +144,9 @@
               "type": "string"
             },
             "inheritFromIAMRole": {
-              "default": "false",
+              "default": false,
               "description": "Use the role based authentication without providing explicitly the keys",
-              "required": []
+              "type": "boolean"
             },
             "path": {
               "default": "/",
@@ -171,22 +172,22 @@
                   "backupOwnerReference": {
                     "default": "self",
                     "description": "Backup owner reference",
-                    "required": []
+                    "type": "string"
                   },
                   "method": {
                     "default": "barmanObjectStore",
                     "description": "Backup method, can be `barmanObjectStore` (default) or `volumeSnapshot`",
-                    "required": []
+                    "type": "string"
                   },
                   "name": {
                     "default": "daily-backup",
                     "description": "Scheduled backup name",
-                    "required": []
+                    "type": "string"
                   },
                   "schedule": {
                     "default": "0 0 0 * * *",
                     "description": "Schedule in cron format",
-                    "required": []
+                    "type": "string"
                   }
                 },
                 "required": [],
@@ -200,14 +201,14 @@
         "secret": {
           "properties": {
             "create": {
-              "default": "true",
+              "default": true,
               "description": "Whether to create a secret for the backup credentials",
-              "required": []
+              "type": "boolean"
             },
             "name": {
               "default": "",
               "description": "Name of the backup credentials secret",
-              "required": []
+              "type": "string"
             }
           },
           "required": [],
@@ -218,17 +219,17 @@
             "compression": {
               "default": "gzip",
               "description": "WAL compression method. One of `` (for no compression), `gzip`, `bzip2` or `snappy`.",
-              "required": []
+              "type": "string"
             },
             "encryption": {
               "default": "AES256",
               "description": "Whether to instruct the storage provider to encrypt WAL files. One of `` (use the storage container default), `AES256` or `aws:kms`.",
-              "required": []
+              "type": "string"
             },
             "maxParallel": {
-              "default": "1",
+              "default": 1,
               "description": "Number of WAL files to be archived or restored in parallel.",
-              "required": []
+              "type": "integer"
             }
           },
           "required": [],
@@ -245,126 +246,130 @@
           "type": "object"
         },
         "affinity": {
-          "description": "Affinity/Anti-affinity rules for Pods. See: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-AffinityConfiguration",
+          "description": "Affinity/Anti-affinity rules for Pods.\nSee: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-AffinityConfiguration",
           "properties": {
             "topologyKey": {
               "default": "topology.kubernetes.io/zone",
               "type": "string"
             }
           },
-          "required": []
+          "required": [],
+          "type": "object"
         },
         "annotations": {
           "required": [],
           "type": "object"
         },
         "certificates": {
-          "description": "The configuration for the CA and related certificates. See: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-CertificatesConfiguration",
-          "required": []
+          "description": "The configuration for the CA and related certificates.\nSee: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-CertificatesConfiguration",
+          "required": [],
+          "type": "object"
         },
         "console": {
           "properties": {
             "enabled": {
-              "default": "false",
+              "default": false,
               "description": "Deploys a console StatefulSet to run long-running commands against the cluster (e.g. `CREATE INDEX`).",
-              "required": []
+              "type": "boolean"
             }
           },
           "required": [],
           "type": "object"
         },
         "enablePDB": {
-          "default": "true",
-          "description": "Allow to disable PDB, mainly useful for upgrade of single-instance clusters or development purposes See: https://cloudnative-pg.io/documentation/current/kubernetes_upgrade/#pod-disruption-budgets",
-          "required": []
+          "default": true,
+          "description": "Allow to disable PDB, mainly useful for upgrade of single-instance clusters or development purposes\nSee: https://cloudnative-pg.io/documentation/current/kubernetes_upgrade/#pod-disruption-budgets",
+          "type": "boolean"
         },
         "enableSuperuserAccess": {
-          "default": "true",
-          "description": "When this option is enabled, the operator will use the SuperuserSecret to update the postgres user password. If the secret is not present, the operator will automatically create one. When this option is disabled, the operator will ignore the SuperuserSecret content, delete it when automatically created, and then blank the password of the postgres user by setting it to NULL.",
-          "required": []
+          "default": true,
+          "description": "When this option is enabled, the operator will use the SuperuserSecret to update the postgres user password.\nIf the secret is not present, the operator will automatically create one.\nWhen this option is disabled, the operator will ignore the SuperuserSecret content, delete it when automatically created,\nand then blank the password of the postgres user by setting it to NULL.",
+          "type": "boolean"
         },
         "env": {
           "description": "Env follows the Env format to pass environment variables to the pods created in the cluster",
           "items": {
             "required": []
           },
-          "required": []
+          "type": "array"
         },
         "envFrom": {
           "description": "EnvFrom follows the EnvFrom format to pass environment variables sources to the pods to be used by Env",
           "items": {
             "required": []
           },
-          "required": []
+          "type": "array"
         },
         "imageCatalogRef": {
           "description": "Reference to `ImageCatalog` of `ClusterImageCatalog`, if specified takes precedence over `cluster.imageName`",
-          "required": []
+          "required": [],
+          "type": "object"
         },
         "imageName": {
           "default": "",
-          "description": "Name of the container image, supporting both tags (\u003cimage\u003e:\u003ctag\u003e) and digests for deterministic and repeatable deployments: \u003cimage\u003e:\u003ctag\u003e@sha256:\u003cdigestValue\u003e",
-          "required": []
+          "description": "Name of the container image, supporting both tags (\u003cimage\u003e:\u003ctag\u003e) and digests for deterministic and repeatable deployments:\n\u003cimage\u003e:\u003ctag\u003e",
+          "type": "string"
         },
         "imagePullPolicy": {
           "default": "IfNotPresent",
-          "description": "Image pull policy. One of Always, Never or IfNotPresent. If not defined, it defaults to IfNotPresent. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
-          "required": []
+          "description": "Image pull policy. One of Always, Never or IfNotPresent. If not defined, it defaults to IfNotPresent. Cannot be updated.\nMore info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+          "type": "string"
         },
         "imagePullSecrets": {
-          "description": "The list of pull secrets to be used to pull the images. See: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-LocalObjectReference",
+          "description": "The list of pull secrets to be used to pull the images.\nSee: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-LocalObjectReference",
           "items": {
             "required": []
           },
-          "required": []
+          "type": "array"
         },
         "initdb": {
-          "description": "BootstrapInitDB is the configuration of the bootstrap process when initdb is used. See: https://cloudnative-pg.io/documentation/current/bootstrap/ See: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-bootstrapinitdb",
-          "required": []
+          "description": "BootstrapInitDB is the configuration of the bootstrap process when initdb is used.\nSee: https://cloudnative-pg.io/documentation/current/bootstrap/\nSee: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-bootstrapinitdb",
+          "required": [],
+          "type": "object"
         },
         "instances": {
-          "default": "3",
+          "default": 3,
           "description": "Number of instances",
-          "required": []
+          "type": "integer"
         },
         "logLevel": {
           "default": "info",
           "description": "The instances' log level, one of the following values: error, warning, info (default), debug, trace",
-          "required": []
+          "type": "string"
         },
         "monitoring": {
           "properties": {
             "customQueries": {
-              "description": "Custom Prometheus metrics Will be stored in the ConfigMap",
+              "description": "Custom Prometheus metrics\nWill be stored in the ConfigMap",
               "items": {
                 "required": []
               },
-              "required": []
+              "type": "array"
             },
             "customQueriesSecret": {
               "description": "The list of secrets containing the custom queries",
               "items": {
                 "required": []
               },
-              "required": []
+              "type": "array"
             },
             "disableDefaultQueries": {
-              "default": "false",
-              "description": "Whether the default queries should be injected. Set it to true if you don't want to inject default queries into the cluster.",
-              "required": []
+              "default": false,
+              "description": "Whether the default queries should be injected.\nSet it to true if you don't want to inject default queries into the cluster.",
+              "type": "boolean"
             },
             "enabled": {
-              "default": "false",
+              "default": false,
               "description": "Whether to enable monitoring",
-              "required": []
+              "type": "boolean"
             },
             "instrumentation": {
               "description": "Additional instrumentation via custom metrics",
               "properties": {
                 "logicalReplication": {
-                  "default": "true",
+                  "default": true,
                   "description": "Enable logical replication metrics",
-                  "required": []
+                  "type": "boolean"
                 }
               },
               "required": [],
@@ -373,27 +378,28 @@
             "podMonitor": {
               "properties": {
                 "enabled": {
-                  "default": "true",
+                  "default": true,
                   "description": "Whether to enable the PodMonitor",
-                  "required": []
+                  "type": "boolean"
                 },
                 "labels": {
-                  "description": "Additional labels to set on the generated PodMonitor resource. Add labels your monitoring stack requires (for example `team-name`).",
-                  "required": []
+                  "description": "Additional labels to set on the generated PodMonitor resource.\nAdd labels your monitoring stack requires (for example `team-name`).",
+                  "required": [],
+                  "type": "object"
                 },
                 "metricRelabelings": {
-                  "description": "The list of metric relabelings for the PodMonitor. Applied to samples before ingestion.",
+                  "description": "The list of metric relabelings for the PodMonitor.\nApplied to samples before ingestion.",
                   "items": {
                     "required": []
                   },
-                  "required": []
+                  "type": "array"
                 },
                 "relabelings": {
-                  "description": "The list of relabelings for the PodMonitor. Applied to samples before scraping.",
+                  "description": "The list of relabelings for the PodMonitor.\nApplied to samples before scraping.",
                   "items": {
                     "required": []
                   },
-                  "required": []
+                  "type": "array"
                 }
               },
               "required": [],
@@ -402,16 +408,16 @@
             "prometheusRule": {
               "properties": {
                 "enabled": {
-                  "default": "true",
+                  "default": true,
                   "description": "Whether to enable the PrometheusRule automated alerts",
-                  "required": []
+                  "type": "boolean"
                 },
                 "excludeRules": {
                   "description": "Exclude specified rules",
                   "items": {
                     "required": []
                   },
-                  "required": []
+                  "type": "array"
                 }
               },
               "required": [],
@@ -422,53 +428,57 @@
           "type": "object"
         },
         "podSecurityContext": {
-          "description": "Configure the Pod Security Context. See: https://cloudnative-pg.io/documentation/preview/security/",
-          "required": []
+          "description": "Configure the Pod Security Context.\nSee: https://cloudnative-pg.io/documentation/preview/security/",
+          "required": [],
+          "type": "object"
         },
         "postgresGID": {
-          "default": "-1",
+          "default": -1,
           "description": "The GID of the postgres user inside the image, defaults to 26",
-          "required": []
+          "type": "integer"
         },
         "postgresUID": {
-          "default": "-1",
+          "default": -1,
           "description": "The UID of the postgres user inside the image, defaults to 26",
-          "required": []
+          "type": "integer"
         },
         "postgresql": {
           "properties": {
             "ldap": {
               "description": "PostgreSQL LDAP configuration (see https://cloudnative-pg.io/documentation/current/postgresql_conf/#ldap-configuration)",
-              "required": []
+              "required": [],
+              "type": "object"
             },
             "parameters": {
               "description": "PostgreSQL configuration options (postgresql.conf)",
-              "required": []
+              "required": [],
+              "type": "object"
             },
             "pg_hba": {
               "description": "PostgreSQL Host Based Authentication rules (lines to be appended to the pg_hba.conf file)",
               "items": {
                 "required": []
               },
-              "required": []
+              "type": "array"
             },
             "pg_ident": {
               "description": "PostgreSQL User Name Maps rules (lines to be appended to the pg_ident.conf file)",
               "items": {
                 "required": []
               },
-              "required": []
+              "type": "array"
             },
             "shared_preload_libraries": {
               "description": "Lists of shared preload libraries to add to the default ones",
               "items": {
                 "required": []
               },
-              "required": []
+              "type": "array"
             },
             "synchronous": {
               "description": "Quorum-based Synchronous Replication",
-              "required": []
+              "required": [],
+              "type": "object"
             }
           },
           "required": [],
@@ -476,40 +486,44 @@
         },
         "primaryUpdateMethod": {
           "default": "switchover",
-          "description": "Method to follow to upgrade the primary server during a rolling update procedure, after all replicas have been successfully updated. It can be switchover (default) or restart.",
-          "required": []
+          "description": "Method to follow to upgrade the primary server during a rolling update procedure, after all replicas have been\nsuccessfully updated. It can be switchover (default) or restart.",
+          "type": "string"
         },
         "primaryUpdateStrategy": {
           "default": "unsupervised",
-          "description": "Strategy to follow to upgrade the primary server during a rolling update procedure, after all replicas have been successfully updated: it can be automated (unsupervised - default) or manual (supervised)",
-          "required": []
+          "description": "Strategy to follow to upgrade the primary server during a rolling update procedure, after all replicas have been\nsuccessfully updated: it can be automated (unsupervised - default) or manual (supervised)",
+          "type": "string"
         },
         "priorityClassName": {
           "default": "",
           "type": "string"
         },
         "resources": {
-          "description": "Resources requirements of every generated Pod. Please refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ for more information. We strongly advise you use the same setting for limits and requests so that your cluster pods are given a Guaranteed QoS. See: https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/",
-          "required": []
+          "description": "Resources requirements of every generated Pod.\nPlease refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ for more information.\nWe strongly advise you use the same setting for limits and requests so that your cluster pods are given a Guaranteed QoS.\nSee: https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/",
+          "required": [],
+          "type": "object"
         },
         "roles": {
-          "description": "This feature enables declarative management of existing roles, as well as the creation of new roles if they are not already present in the database. See: https://cloudnative-pg.io/documentation/current/declarative_role_management/",
+          "description": "This feature enables declarative management of existing roles, as well as the creation of new roles if they are not\nalready present in the database.\nSee: https://cloudnative-pg.io/documentation/current/declarative_role_management/",
           "items": {
             "required": []
           },
-          "required": []
+          "type": "array"
         },
         "securityContext": {
-          "description": "Configure Container Security Context. See: https://cloudnative-pg.io/documentation/preview/security/",
-          "required": []
+          "description": "Configure Container Security Context.\nSee: https://cloudnative-pg.io/documentation/preview/security/",
+          "required": [],
+          "type": "object"
         },
         "serviceAccountTemplate": {
           "description": "Configure the metadata of the generated service account",
-          "required": []
+          "required": [],
+          "type": "object"
         },
         "services": {
           "description": "Customization of service definitions. Please refer to https://cloudnative-pg.io/documentation/current/service_management/",
-          "required": []
+          "required": [],
+          "type": "object"
         },
         "storage": {
           "properties": {
@@ -552,16 +566,16 @@
       "type": "object"
     },
     "databases": {
-      "description": " Database management configuration",
+      "description": "Database management configuration.",
       "items": {
         "required": []
       },
-      "required": []
+      "type": "array"
     },
     "fullnameOverride": {
       "default": "",
       "description": "Override the full name of the chart",
-      "required": []
+      "type": "string"
     },
     "global": {
       "description": "Global values are values that can be accessed from any chart or subchart by exactly the same name.",
@@ -571,16 +585,16 @@
     "imageCatalog": {
       "properties": {
         "create": {
-          "default": "true",
+          "default": true,
           "description": "Whether to provision an image catalog. If imageCatalog.images is empty this option will be ignored.",
-          "required": []
+          "type": "boolean"
         },
         "images": {
           "description": "List of images to be provisioned in an image catalog.",
           "items": {
             "required": []
           },
-          "required": []
+          "type": "array"
         }
       },
       "required": [],
@@ -588,25 +602,25 @@
     },
     "mode": {
       "default": "standalone",
-      "description": "Cluster mode of operation. Available modes: * `standalone` - default mode. Creates new or updates an existing CNPG cluster. * `replica` - Creates a replica cluster from an existing CNPG cluster. * `recovery` - Same as standalone but creates a cluster from a backup, object store or via pg_basebackup.",
-      "required": []
+      "description": "Cluster mode of operation. Available modes:\n* `standalone` - default mode. Creates new or updates an existing CNPG cluster.\n* `replica` - Creates a replica cluster from an existing CNPG cluster.\n* `recovery` - Same as standalone but creates a cluster from a backup, object store or via pg_basebackup.",
+      "type": "string"
     },
     "nameOverride": {
       "default": "",
       "description": "Override the name of the chart",
-      "required": []
+      "type": "string"
     },
     "namespaceOverride": {
       "default": "",
       "description": "Override the namespace of the chart",
-      "required": []
+      "type": "string"
     },
     "poolers": {
       "description": "List of PgBouncer poolers",
       "items": {
         "required": []
       },
-      "required": []
+      "type": "array"
     },
     "recovery": {
       "properties": {
@@ -651,30 +665,30 @@
         "backupName": {
           "default": "",
           "description": "Backup Recovery Method",
-          "required": []
+          "type": "string"
         },
         "clusterName": {
           "default": "",
           "description": "The original cluster name when used in backups. Also known as serverName.",
-          "required": []
+          "type": "string"
         },
         "database": {
           "default": "app",
           "description": "Name of the database used by the application. Default: `app`.",
-          "required": []
+          "type": "string"
         },
         "destinationPath": {
           "default": "",
-          "description": "Overrides the provider specific default path. Defaults to: S3: s3://\u003cbucket\u003e\u003cpath\u003e Azure: https://\u003cstorageAccount\u003e.\u003cserviceName\u003e.core.windows.net/\u003ccontainerName\u003e\u003cpath\u003e Google: gs://\u003cbucket\u003e\u003cpath\u003e",
-          "required": []
+          "description": "Overrides the provider specific default path. Defaults to:\nS3: s3://\u003cbucket\u003e\u003cpath\u003e\nAzure: https://\u003cstorageAccount\u003e.\u003cserviceName\u003e.core.windows.net/\u003ccontainerName\u003e\u003cpath\u003e\nGoogle: gs://\u003cbucket\u003e\u003cpath\u003e",
+          "type": "string"
         },
         "endpointCA": {
           "description": "Specifies a CA bundle to validate a privately signed certificate.",
           "properties": {
             "create": {
-              "default": "false",
+              "default": false,
               "description": "Creates a secret with the given value if true, otherwise uses an existing secret.",
-              "required": []
+              "type": "boolean"
             },
             "key": {
               "default": "",
@@ -689,12 +703,13 @@
               "type": "string"
             }
           },
-          "required": []
+          "required": [],
+          "type": "object"
         },
         "endpointURL": {
           "default": "",
-          "description": "Overrides the provider specific default endpoint. Defaults to: S3: https://s3.\u003cregion\u003e.amazonaws.com\" Leave empty if using the default S3 endpoint",
-          "required": []
+          "description": "Overrides the provider specific default endpoint. Defaults to:\nS3: https://s3.\u003cregion\u003e.amazonaws.com\"\nLeave empty if using the default S3 endpoint",
+          "type": "string"
         },
         "google": {
           "properties": {
@@ -726,40 +741,40 @@
               "items": {
                 "required": []
               },
-              "required": []
+              "type": "array"
             },
             "pgDumpExtraOptions": {
-              "description": "List of custom options to pass to the `pg_dump` command. IMPORTANT: Use these options with caution and at your own risk, as the operator does not validate their content. Be aware that certain options may conflict with the operator's intended functionality or design.",
+              "description": "List of custom options to pass to the `pg_dump` command. IMPORTANT: Use these options with caution and at your\nown risk, as the operator does not validate their content. Be aware that certain options may conflict with the\noperator's intended functionality or design.",
               "items": {
                 "required": []
               },
-              "required": []
+              "type": "array"
             },
             "pgRestoreExtraOptions": {
-              "description": "List of custom options to pass to the `pg_restore` command. IMPORTANT: Use these options with caution and at your own risk, as the operator does not validate their content. Be aware that certain options may conflict with the operator's intended functionality or design.",
+              "description": "List of custom options to pass to the `pg_restore` command. IMPORTANT: Use these options with caution and at\nyour own risk, as the operator does not validate their content. Be aware that certain options may conflict with the\noperator's intended functionality or design.",
               "items": {
                 "required": []
               },
-              "required": []
+              "type": "array"
             },
             "postImportApplicationSQL": {
-              "description": "List of SQL queries to be executed as a superuser in the application database right after is imported. To be used with extreme care. Only available in microservice type.",
+              "description": "List of SQL queries to be executed as a superuser in the application database right after is imported.\nTo be used with extreme care. Only available in microservice type.",
               "items": {
                 "required": []
               },
-              "required": []
+              "type": "array"
             },
             "roles": {
               "description": "Roles to import",
               "items": {
                 "required": []
               },
-              "required": []
+              "type": "array"
             },
             "schemaOnly": {
-              "default": "false",
+              "default": false,
               "description": "When set to true, only the pre-data and post-data sections of pg_restore are invoked, avoiding data import.",
-              "required": []
+              "type": "boolean"
             },
             "source": {
               "properties": {
@@ -774,24 +789,24 @@
                 "passwordSecret": {
                   "properties": {
                     "create": {
-                      "default": "false",
+                      "default": false,
                       "description": "Whether to create a secret for the password",
-                      "required": []
+                      "type": "boolean"
                     },
                     "key": {
                       "default": "password",
                       "description": "The key in the secret containing the password",
-                      "required": []
+                      "type": "string"
                     },
                     "name": {
                       "default": "",
                       "description": "Name of the secret containing the password",
-                      "required": []
+                      "type": "string"
                     },
                     "value": {
                       "default": "",
                       "description": "The password value to use when creating the secret",
-                      "required": []
+                      "type": "string"
                     }
                   },
                   "required": [],
@@ -857,8 +872,8 @@
             },
             "type": {
               "default": "microservice",
-              "description": "One of `microservice` or `monolith.` See: https://cloudnative-pg.io/documentation/current/database_import/#how-it-works",
-              "required": []
+              "description": "One of `microservice` or `monolith.`\nSee: https://cloudnative-pg.io/documentation/current/database_import/#how-it-works",
+              "type": "string"
             }
           },
           "required": [],
@@ -866,13 +881,13 @@
         },
         "method": {
           "default": "backup",
-          "description": "Available recovery methods: * `backup` - Recovers a CNPG cluster from a CNPG backup (PITR supported) Needs to be on the same cluster in the same namespace. * `object_store` - Recovers a CNPG cluster from a barman object store (PITR supported). * `pg_basebackup` - Recovers a CNPG cluster viaa streaming replication protocol. Useful if you want to        migrate databases to CloudNativePG, even from outside Kubernetes. * `import` - Import one or more databases from an existing Postgres cluster.",
-          "required": []
+          "description": "Available recovery methods:\n* `backup` - Recovers a CNPG cluster from a CNPG backup (PITR supported) Needs to be on the same cluster in the same namespace.\n* `object_store` - Recovers a CNPG cluster from a barman object store (PITR supported).\n* `pg_basebackup` - Recovers a CNPG cluster viaa streaming replication protocol. Useful if you want to\n       migrate databases to CloudNativePG, even from outside Kubernetes.\n* `import` - Import one or more databases from an existing Postgres cluster.",
+          "type": "string"
         },
         "owner": {
           "default": "",
           "description": "Name of the owner of the database in the instance to be used by applications. Defaults to the value of the `database` key.",
-          "required": []
+          "type": "string"
         },
         "pgBaseBackup": {
           "description": "See https://cloudnative-pg.io/documentation/current/bootstrap/#bootstrap-from-a-live-cluster-pg_basebackup",
@@ -880,17 +895,17 @@
             "database": {
               "default": "app",
               "description": "Name of the database used by the application. Default: `app`.",
-              "required": []
+              "type": "string"
             },
             "owner": {
               "default": "",
               "description": "Name of the owner of the database in the instance to be used by applications. Defaults to the value of the `database` key.",
-              "required": []
+              "type": "string"
             },
             "secretName": {
               "default": "",
               "description": "Name of the kubernetes.io/basic-auth secret containing the initial credentials for the owner of the user database. If empty a new secret will be created from scratch.",
-              "required": []
+              "type": "string"
             },
             "source": {
               "properties": {
@@ -905,24 +920,24 @@
                 "passwordSecret": {
                   "properties": {
                     "create": {
-                      "default": "false",
+                      "default": false,
                       "description": "Whether to create a secret for the password",
-                      "required": []
+                      "type": "boolean"
                     },
                     "key": {
                       "default": "password",
                       "description": "The key in the secret containing the password",
-                      "required": []
+                      "type": "string"
                     },
                     "name": {
                       "default": "",
                       "description": "Name of the secret containing the password",
-                      "required": []
+                      "type": "string"
                     },
                     "value": {
                       "default": "",
                       "description": "The password value to use when creating the secret",
-                      "required": []
+                      "type": "string"
                     }
                   },
                   "required": [],
@@ -996,15 +1011,16 @@
             "time": {
               "default": "",
               "description": "Time in RFC3339 format",
-              "required": []
+              "type": "string"
             }
           },
-          "required": []
+          "required": [],
+          "type": "object"
         },
         "provider": {
           "default": "s3",
           "description": "One of `s3`, `azure` or `google`",
-          "required": []
+          "type": "string"
         },
         "s3": {
           "properties": {
@@ -1017,9 +1033,9 @@
               "type": "string"
             },
             "inheritFromIAMRole": {
-              "default": "false",
+              "default": false,
               "description": "Use the role based authentication without providing explicitly the keys",
-              "required": []
+              "type": "boolean"
             },
             "path": {
               "default": "/",
@@ -1040,14 +1056,14 @@
         "secret": {
           "properties": {
             "create": {
-              "default": "true",
+              "default": true,
               "description": "Whether to create a secret for the backup credentials",
-              "required": []
+              "type": "boolean"
             },
             "name": {
               "default": "",
               "description": "Name of the backup credentials secret",
-              "required": []
+              "type": "string"
             }
           },
           "required": [],
@@ -1064,22 +1080,22 @@
             "database": {
               "default": "",
               "description": "Name of the database used by the application",
-              "required": []
+              "type": "string"
             },
             "owner": {
               "default": "",
               "description": "Name of the owner of the database in the instance to be used by applications. Defaults to the value of the `database` key.",
-              "required": []
+              "type": "string"
             },
             "secret": {
               "default": "",
               "description": "Name of the secret containing the initial credentials for the owner of the user database. If empty a new secret will be created from scratch",
-              "required": []
+              "type": "string"
             },
             "source": {
               "default": "",
-              "description": "One of `object_store` or `pg_basebackup`. Method to use for bootstrap.",
-              "required": []
+              "description": " One of `object_store` or `pg_basebackup`. Method to use for bootstrap.",
+              "type": "string"
             }
           },
           "required": [],
@@ -1088,7 +1104,7 @@
         "minApplyDelay": {
           "default": "",
           "description": "When replica mode is enabled, this parameter allows you to replay transactions only when the system time is at least the configured time past the commit time. This provides an opportunity to correct data loss errors. Note that when this parameter is set, a promotion token cannot be used.",
-          "required": []
+          "type": "string"
         },
         "origin": {
           "properties": {
@@ -1135,20 +1151,20 @@
                 "clusterName": {
                   "default": "",
                   "description": "The original cluster name when used in backups. Also known as serverName.",
-                  "required": []
+                  "type": "string"
                 },
                 "destinationPath": {
                   "default": "",
-                  "description": "Overrides the provider specific default path. Defaults to: S3: s3://\u003cbucket\u003e\u003cpath\u003e Azure: https://\u003cstorageAccount\u003e.\u003cserviceName\u003e.core.windows.net/\u003ccontainerName\u003e\u003cpath\u003e Google: gs://\u003cbucket\u003e\u003cpath\u003e",
-                  "required": []
+                  "description": "Overrides the provider specific default path. Defaults to:\nS3: s3://\u003cbucket\u003e\u003cpath\u003e\nAzure: https://\u003cstorageAccount\u003e.\u003cserviceName\u003e.core.windows.net/\u003ccontainerName\u003e\u003cpath\u003e\nGoogle: gs://\u003cbucket\u003e\u003cpath\u003e",
+                  "type": "string"
                 },
                 "endpointCA": {
                   "description": "Specifies a CA bundle to validate a privately signed certificate.",
                   "properties": {
                     "create": {
-                      "default": "false",
+                      "default": false,
                       "description": "Creates a secret with the given value if true, otherwise uses an existing secret.",
-                      "required": []
+                      "type": "boolean"
                     },
                     "key": {
                       "default": "",
@@ -1163,7 +1179,8 @@
                       "type": "string"
                     }
                   },
-                  "required": []
+                  "required": [],
+                  "type": "object"
                 },
                 "google": {
                   "properties": {
@@ -1190,7 +1207,7 @@
                 "provider": {
                   "default": "",
                   "description": "One of `s3`, `azure` or `google`",
-                  "required": []
+                  "type": "string"
                 },
                 "s3": {
                   "properties": {
@@ -1203,9 +1220,9 @@
                       "type": "string"
                     },
                     "inheritFromIAMRole": {
-                      "default": "false",
+                      "default": false,
                       "description": "Use the role based authentication without providing explicitly the keys",
-                      "required": []
+                      "type": "boolean"
                     },
                     "path": {
                       "default": "/",
@@ -1226,14 +1243,14 @@
                 "secret": {
                   "properties": {
                     "create": {
-                      "default": "true",
+                      "default": true,
                       "description": "Whether to create a secret for the backup credentials",
-                      "required": []
+                      "type": "boolean"
                     },
                     "name": {
                       "default": "",
                       "description": "Name of the backup credentials secret",
-                      "required": []
+                      "type": "string"
                     }
                   },
                   "required": [],
@@ -1332,17 +1349,17 @@
         "primary": {
           "default": "",
           "description": "Primary defines which Cluster is defined to be the primary in the distributed PostgreSQL cluster, based on the topology specified in externalClusters",
-          "required": []
+          "type": "string"
         },
         "promotionToken": {
           "default": "",
           "description": "A demotion token generated by an external cluster used to check if the promotion requirements are met.",
-          "required": []
+          "type": "string"
         },
         "self": {
           "default": "",
-          "description": "Defines the name of this cluster. It is used to determine if this is a primary or a replica cluster, comparing it with primary. Leave empty by default.",
-          "required": []
+          "description": " Defines the name of this cluster. It is used to determine if this is a primary or a replica cluster, comparing it with primary. Leave empty by default.",
+          "type": "string"
         }
       },
       "required": [],
@@ -1350,25 +1367,25 @@
     },
     "type": {
       "default": "postgresql",
-      "description": "Type of the CNPG database. Available types: * `postgresql` * `postgis` * `timescaledb`",
-      "required": []
+      "description": "Type of the CNPG database. Available types:\n* `postgresql`\n* `postgis`\n* `timescaledb`",
+      "type": "string"
     },
     "version": {
       "properties": {
         "postgis": {
           "default": "3.4",
           "description": "If using PostGIS, specify the version",
-          "required": []
+          "type": "string"
         },
         "postgresql": {
           "default": "16",
           "description": "PostgreSQL major version to use",
-          "required": []
+          "type": "string"
         },
         "timescaledb": {
           "default": "2.15",
           "description": "If using TimescaleDB, specify the version",
-          "required": []
+          "type": "string"
         }
       },
       "required": [],

--- a/charts/cluster/values.yaml
+++ b/charts/cluster/values.yaml
@@ -5,7 +5,6 @@ fullnameOverride: ""
 # -- Override the namespace of the chart
 namespaceOverride: ""
 
-###
 # -- Type of the CNPG database. Available types:
 # * `postgresql`
 # * `postgis`
@@ -20,7 +19,6 @@ version:
   # -- If using PostGIS, specify the version
   postgis: "3.4"
 
-###
 # -- Cluster mode of operation. Available modes:
 # * `standalone` - default mode. Creates new or updates an existing CNPG cluster.
 # * `replica` - Creates a replica cluster from an existing CNPG cluster.
@@ -28,7 +26,6 @@ version:
 mode: standalone
 
 recovery:
-  ##
   # -- Available recovery methods:
   # * `backup` - Recovers a CNPG cluster from a CNPG backup (PITR supported) Needs to be on the same cluster in the same namespace.
   # * `object_store` - Recovers a CNPG cluster from a barman object store (PITR supported).
@@ -37,16 +34,14 @@ recovery:
   # * `import` - Import one or more databases from an existing Postgres cluster.
   method: backup
 
-  ## -- Point in time recovery target. Specify one of the following:
+  # -- Point in time recovery target. Specify one of the following:
   pitrTarget:
     # -- Time in RFC3339 format
     time: ""
 
-  ##
   # -- Backup Recovery Method
   backupName: ""  # Name of the backup to recover from. Required if method is `backup`.
 
-  ##
   # -- The original cluster name when used in backups. Also known as serverName.
   clusterName: ""
   # -- Name of the database used by the application. Default: `app`.
@@ -345,6 +340,7 @@ cluster:
     #      - ratio:
     #          usage: GAUGE
     #          description: "Cache hit ratio"
+
     # -- The list of secrets containing the custom queries
     customQueriesSecret: []
     #  - name: custom-queries-secret
@@ -354,19 +350,24 @@ cluster:
     # -- PostgreSQL configuration options (postgresql.conf)
     parameters: {}
       # max_connections: 300
+
     # -- Quorum-based Synchronous Replication
     synchronous: {}
      # method: any
      # number: 1
+
     # -- PostgreSQL Host Based Authentication rules (lines to be appended to the pg_hba.conf file)
     pg_hba: []
       # - host all all 10.244.0.0/16 md5
+
     # -- PostgreSQL User Name Maps rules (lines to be appended to the pg_ident.conf file)
     pg_ident: []
       # - mymap   /^(.*)@mydomain\.com$      \1
+
     # -- Lists of shared preload libraries to add to the default ones
     shared_preload_libraries: []
       # - pgaudit
+
     # -- PostgreSQL LDAP configuration (see https://cloudnative-pg.io/documentation/current/postgresql_conf/#ldap-configuration)
     ldap: {}
       # https://cloudnative-pg.io/documentation/current/postgresql_conf/#ldap-configuration
@@ -573,8 +574,8 @@ replica:
       passwordSecret:
         name: ""
         key: ""
-##
-# Database management configuration
+
+# -- Database management configuration.
 databases: []
  # - name: app                      # -- Name of the database to be created.
  #   ensure: present                # -- Ensure the PostgreSQL database is present or absent - defaults to "present".

--- a/charts/cluster/values.yaml
+++ b/charts/cluster/values.yaml
@@ -48,10 +48,12 @@ recovery:
   database: app
   # -- Name of the owner of the database in the instance to be used by applications. Defaults to the value of the `database` key.
   owner: ""
-  # -- Overrides the provider specific default endpoint. Defaults to:
+  # -- Overrides the provider specific default endpoint.
+  endpointURL: ""
+  # Defaults to:
   # S3: https://s3.<region>.amazonaws.com"
   # Leave empty if using the default S3 endpoint
-  endpointURL: ""
+
   # -- Specifies a CA bundle to validate a privately signed certificate.
   endpointCA:
     # -- Creates a secret with the given value if true, otherwise uses an existing secret.
@@ -59,11 +61,13 @@ recovery:
     name: ""
     key: ""
     value: ""
-  # -- Overrides the provider specific default path. Defaults to:
+  # -- Overrides the provider specific default path.
+  destinationPath: ""
+  # Defaults to:
   # S3: s3://<bucket><path>
   # Azure: https://<storageAccount>.<serviceName>.core.windows.net/<containerName><path>
   # Google: gs://<bucket><path>
-  destinationPath: ""
+
   # -- One of `s3`, `azure` or `google`
   provider: s3
   s3:
@@ -418,9 +422,12 @@ backups:
   # -- You need to configure backups manually, so backups are disabled by default.
   enabled: false
 
-  # -- Overrides the provider specific default endpoint. Defaults to:
+  # -- Overrides the provider specific default endpoint.
+  endpointURL: ""
+  # Defaults to:
   # S3: https://s3.<region>.amazonaws.com"
-  endpointURL: ""  # Leave empty if using the default S3 endpoint
+  # Leave empty if using the default S3 endpoint
+
   # -- Specifies a CA bundle to validate a privately signed certificate.
   endpointCA:
     # -- Creates a secret with the given value if true, otherwise uses an existing secret.
@@ -429,11 +436,13 @@ backups:
     key: ""
     value: ""
 
-  # -- Overrides the provider specific default path. Defaults to:
+  # -- Overrides the provider specific default path.
+  destinationPath: ""
+  # Defaults to:
   # S3: s3://<bucket><path>
   # Azure: https://<storageAccount>.<serviceName>.core.windows.net/<containerName><path>
   # Google: gs://<bucket><path>
-  destinationPath: ""
+
   # -- One of `s3`, `azure` or `google`
   provider: s3
   s3:
@@ -515,11 +524,13 @@ replica:
     objectStore:
       # -- The original cluster name when used in backups. Also known as serverName.
       clusterName: ""
-      # -- Overrides the provider specific default path. Defaults to:
+      # -- Overrides the provider specific default path.
+      destinationPath: ""
+      # Defaults to:
       # S3: s3://<bucket><path>
       # Azure: https://<storageAccount>.<serviceName>.core.windows.net/<containerName><path>
       # Google: gs://<bucket><path>
-      destinationPath: ""
+
       # -- Specifies a CA bundle to validate a privately signed certificate.
       endpointCA:
         # -- Creates a secret with the given value if true, otherwise uses an existing secret.

--- a/charts/plugin-barman-cloud/README.md
+++ b/charts/plugin-barman-cloud/README.md
@@ -27,7 +27,7 @@ Kubernetes: `>=1.29.0-0`
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | additionalArgs | list | `[]` | Additional arguments to be added to the operator's args list. |
-| additionalEnv | list | `[]` | Array containing extra environment variables which can be templated. For example:  - name: RELEASE_NAME    value: "{{ .Release.Name }}"  - name: MY_VAR    value: "mySpecialKey" |
+| additionalEnv | list | `[]` | Array containing extra environment variables which can be templated. |
 | affinity | object | `{}` | Affinity for the operator to be installed. |
 | certificate.createClientCertificate | bool | `true` | Specifies whether the client certificate should be created. |
 | certificate.createServerCertificate | bool | `true` | Specifies whether the server certificate should be created. |
@@ -66,4 +66,4 @@ Kubernetes: `>=1.29.0-0`
 | sidecarImage.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | tolerations | list | `[]` | Tolerations for the operator to be installed. |
 | topologySpreadConstraints | list | `[]` | Topology Spread Constraints for the operator to be installed. |
-| updateStrategy | object | `{}` | Update strategy for the operator. ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy For example:  type: RollingUpdate  rollingUpdate:    maxSurge: 25%    maxUnavailable: 25%  WARNING: the RollingUpdate strategy is not supported by the operator yet so it can currently only use the Recreate strategy. |
+| updateStrategy | object | `{}` | Update strategy for the operator. ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy |

--- a/charts/plugin-barman-cloud/values.schema.json
+++ b/charts/plugin-barman-cloud/values.schema.json
@@ -30,35 +30,30 @@
         "createClientCertificate": {
           "default": true,
           "description": "Specifies whether the client certificate should be created.",
-          "required": [],
           "title": "createClientCertificate",
           "type": "boolean"
         },
         "createServerCertificate": {
           "default": true,
           "description": "Specifies whether the server certificate should be created.",
-          "required": [],
           "title": "createServerCertificate",
           "type": "boolean"
         },
         "duration": {
           "default": "2160h",
           "description": "The duration of the certificates.",
-          "required": [],
           "title": "duration",
           "type": "string"
         },
         "issuerName": {
           "default": "selfsigned-issuer",
           "description": "The name of the issuer to use for the certificates.",
-          "required": [],
           "title": "issuerName",
           "type": "string"
         },
         "renewBefore": {
           "default": "360h",
           "description": "The renew before time for the certificates.",
-          "required": [],
           "title": "renewBefore",
           "type": "string"
         }
@@ -84,7 +79,6 @@
       "properties": {
         "allowPrivilegeEscalation": {
           "default": false,
-          "required": [],
           "title": "allowPrivilegeEscalation",
           "type": "boolean"
         },
@@ -94,13 +88,11 @@
               "items": {
                 "anyOf": [
                   {
-                    "required": [],
                     "type": "string"
                   }
                 ],
                 "required": []
               },
-              "required": [],
               "title": "drop",
               "type": "array"
             }
@@ -113,19 +105,16 @@
         },
         "readOnlyRootFilesystem": {
           "default": true,
-          "required": [],
           "title": "readOnlyRootFilesystem",
           "type": "boolean"
         },
         "runAsGroup": {
           "default": 10001,
-          "required": [],
           "title": "runAsGroup",
           "type": "integer"
         },
         "runAsUser": {
           "default": 10001,
-          "required": [],
           "title": "runAsUser",
           "type": "integer"
         },
@@ -133,7 +122,6 @@
           "properties": {
             "type": {
               "default": "RuntimeDefault",
-              "required": [],
               "title": "type",
               "type": "string"
             }
@@ -161,7 +149,6 @@
         "create": {
           "default": true,
           "description": "Specifies whether the CRDs should be created when installing the chart.",
-          "required": [],
           "title": "create",
           "type": "boolean"
         }
@@ -174,13 +161,11 @@
     },
     "dnsPolicy": {
       "default": "",
-      "required": [],
       "title": "dnsPolicy",
       "type": "string"
     },
     "fullnameOverride": {
       "default": "",
-      "required": [],
       "title": "fullnameOverride",
       "type": "string"
     },
@@ -192,7 +177,6 @@
     },
     "hostNetwork": {
       "default": false,
-      "required": [],
       "title": "hostNetwork",
       "type": "boolean"
     },
@@ -200,26 +184,22 @@
       "properties": {
         "pullPolicy": {
           "default": "IfNotPresent",
-          "required": [],
           "title": "pullPolicy",
           "type": "string"
         },
         "registry": {
           "default": "ghcr.io",
-          "required": [],
           "title": "registry",
           "type": "string"
         },
         "repository": {
           "default": "cloudnative-pg/plugin-barman-cloud",
-          "required": [],
           "title": "repository",
           "type": "string"
         },
         "tag": {
           "default": "",
           "description": "Overrides the image tag whose default is the chart appVersion.",
-          "required": [],
           "title": "tag",
           "type": "string"
         }
@@ -243,13 +223,11 @@
     },
     "nameOverride": {
       "default": "",
-      "required": [],
       "title": "nameOverride",
       "type": "string"
     },
     "namespaceOverride": {
       "default": "",
-      "required": [],
       "title": "namespaceOverride",
       "type": "string"
     },
@@ -276,7 +254,6 @@
       "properties": {
         "runAsNonRoot": {
           "default": true,
-          "required": [],
           "title": "runAsNonRoot",
           "type": "boolean"
         },
@@ -284,7 +261,6 @@
           "properties": {
             "type": {
               "default": "RuntimeDefault",
-              "required": [],
               "title": "type",
               "type": "string"
             }
@@ -306,7 +282,6 @@
     "priorityClassName": {
       "default": "",
       "description": "Priority indicates the importance of a Pod relative to other Pods.",
-      "required": [],
       "title": "priorityClassName",
       "type": "string"
     },
@@ -315,7 +290,6 @@
         "create": {
           "default": true,
           "description": "Specifies whether Role and RoleBinding should be created.",
-          "required": [],
           "title": "create",
           "type": "boolean"
         }
@@ -328,7 +302,6 @@
     },
     "replicaCount": {
       "default": 1,
-      "required": [],
       "title": "replicaCount",
       "type": "integer"
     },
@@ -348,27 +321,23 @@
             ],
             "required": []
           },
-          "required": [],
           "title": "ipFamilies",
           "type": "array"
         },
         "ipFamilyPolicy": {
           "default": "",
           "description": "Set the ip family policy to configure dual-stack see [Configure dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services)",
-          "required": [],
           "title": "ipFamilyPolicy",
           "type": "string"
         },
         "name": {
           "default": "barman-cloud",
           "description": "DO NOT CHANGE THE SERVICE NAME as it is currently used to generate the certificate\nand can not be configured",
-          "required": [],
           "title": "name",
           "type": "string"
         },
         "port": {
           "default": 9090,
-          "required": [],
           "title": "port",
           "type": "integer"
         }
@@ -386,14 +355,12 @@
         "create": {
           "default": true,
           "description": "Specifies whether the service account should be created.",
-          "required": [],
           "title": "create",
           "type": "boolean"
         },
         "name": {
           "default": "",
           "description": "The name of the service account to use.\nIf not set and create is true, a name is generated using the fullname template.",
-          "required": [],
           "title": "name",
           "type": "string"
         }
@@ -409,20 +376,17 @@
       "properties": {
         "registry": {
           "default": "ghcr.io",
-          "required": [],
           "title": "registry",
           "type": "string"
         },
         "repository": {
           "default": "cloudnative-pg/plugin-barman-cloud-sidecar",
-          "required": [],
           "title": "repository",
           "type": "string"
         },
         "tag": {
           "default": "",
           "description": "Overrides the image tag whose default is the chart appVersion.",
-          "required": [],
           "title": "tag",
           "type": "string"
         }

--- a/charts/plugin-barman-cloud/values.schema.json
+++ b/charts/plugin-barman-cloud/values.schema.json
@@ -7,8 +7,7 @@
       "items": {
         "required": []
       },
-      "required": [],
-      "title": "additionalArgs"
+      "required": []
     },
     "additionalEnv": {
       "additionalProperties": true,
@@ -16,70 +15,54 @@
       "items": {
         "required": []
       },
-      "required": [],
-      "title": "additionalEnv"
+      "required": []
     },
     "affinity": {
       "additionalProperties": true,
       "description": "Affinity for the operator to be installed.",
-      "required": [],
-      "title": "affinity"
+      "required": []
     },
     "certificate": {
       "properties": {
         "createClientCertificate": {
           "default": true,
           "description": "Specifies whether the client certificate should be created.",
-          "title": "createClientCertificate",
           "type": "boolean"
         },
         "createServerCertificate": {
           "default": true,
           "description": "Specifies whether the server certificate should be created.",
-          "title": "createServerCertificate",
           "type": "boolean"
         },
         "duration": {
           "default": "2160h",
           "description": "The duration of the certificates.",
-          "title": "duration",
           "type": "string"
         },
         "issuerName": {
           "default": "selfsigned-issuer",
           "description": "The name of the issuer to use for the certificates.",
-          "title": "issuerName",
           "type": "string"
         },
         "renewBefore": {
           "default": "360h",
           "description": "The renew before time for the certificates.",
-          "title": "renewBefore",
           "type": "string"
         }
       },
-      "required": [
-        "createClientCertificate",
-        "createServerCertificate",
-        "issuerName",
-        "duration",
-        "renewBefore"
-      ],
-      "title": "certificate",
+      "required": [],
       "type": "object"
     },
     "commonAnnotations": {
       "additionalProperties": true,
       "description": "Annotations to be added to all other resources.",
-      "required": [],
-      "title": "commonAnnotations"
+      "required": []
     },
     "containerSecurityContext": {
       "description": "Container Security Context.",
       "properties": {
         "allowPrivilegeEscalation": {
           "default": false,
-          "title": "allowPrivilegeEscalation",
           "type": "boolean"
         },
         "capabilities": {
@@ -93,55 +76,36 @@
                 ],
                 "required": []
               },
-              "title": "drop",
               "type": "array"
             }
           },
-          "required": [
-            "drop"
-          ],
-          "title": "capabilities",
+          "required": [],
           "type": "object"
         },
         "readOnlyRootFilesystem": {
           "default": true,
-          "title": "readOnlyRootFilesystem",
           "type": "boolean"
         },
         "runAsGroup": {
           "default": 10001,
-          "title": "runAsGroup",
           "type": "integer"
         },
         "runAsUser": {
           "default": 10001,
-          "title": "runAsUser",
           "type": "integer"
         },
         "seccompProfile": {
           "properties": {
             "type": {
               "default": "RuntimeDefault",
-              "title": "type",
               "type": "string"
             }
           },
-          "required": [
-            "type"
-          ],
-          "title": "seccompProfile",
+          "required": [],
           "type": "object"
         }
       },
-      "required": [
-        "allowPrivilegeEscalation",
-        "readOnlyRootFilesystem",
-        "runAsUser",
-        "runAsGroup",
-        "seccompProfile",
-        "capabilities"
-      ],
-      "title": "containerSecurityContext",
+      "required": [],
       "type": "object"
     },
     "crds": {
@@ -149,68 +113,50 @@
         "create": {
           "default": true,
           "description": "Specifies whether the CRDs should be created when installing the chart.",
-          "title": "create",
           "type": "boolean"
         }
       },
-      "required": [
-        "create"
-      ],
-      "title": "crds",
+      "required": [],
       "type": "object"
     },
     "dnsPolicy": {
       "default": "",
-      "title": "dnsPolicy",
       "type": "string"
     },
     "fullnameOverride": {
       "default": "",
-      "title": "fullnameOverride",
       "type": "string"
     },
     "global": {
       "description": "Global values are values that can be accessed from any chart or subchart by exactly the same name.",
       "required": [],
-      "title": "global",
       "type": "object"
     },
     "hostNetwork": {
       "default": false,
-      "title": "hostNetwork",
       "type": "boolean"
     },
     "image": {
       "properties": {
         "pullPolicy": {
           "default": "IfNotPresent",
-          "title": "pullPolicy",
           "type": "string"
         },
         "registry": {
           "default": "ghcr.io",
-          "title": "registry",
           "type": "string"
         },
         "repository": {
           "default": "cloudnative-pg/plugin-barman-cloud",
-          "title": "repository",
           "type": "string"
         },
         "tag": {
           "default": "",
           "description": "Overrides the image tag whose default is the chart appVersion.",
-          "title": "tag",
           "type": "string"
         }
       },
-      "required": [
-        "registry",
-        "repository",
-        "pullPolicy",
-        "tag"
-      ],
-      "title": "image",
+      "required": [],
       "type": "object"
     },
     "imagePullSecrets": {
@@ -218,71 +164,55 @@
       "items": {
         "required": []
       },
-      "required": [],
-      "title": "imagePullSecrets"
+      "required": []
     },
     "nameOverride": {
       "default": "",
-      "title": "nameOverride",
       "type": "string"
     },
     "namespaceOverride": {
       "default": "",
-      "title": "namespaceOverride",
       "type": "string"
     },
     "nodeSelector": {
       "additionalProperties": true,
       "description": "Nodeselector for the operator to be installed.",
-      "required": [],
-      "title": "nodeSelector"
+      "required": []
     },
     "podAnnotations": {
       "additionalProperties": true,
       "description": "Annotations to be added to the pod.",
-      "required": [],
-      "title": "podAnnotations"
+      "required": []
     },
     "podLabels": {
       "additionalProperties": true,
       "description": "Labels to be added to the pod.",
-      "required": [],
-      "title": "podLabels"
+      "required": []
     },
     "podSecurityContext": {
       "description": "Security Context for the whole pod.",
       "properties": {
         "runAsNonRoot": {
           "default": true,
-          "title": "runAsNonRoot",
           "type": "boolean"
         },
         "seccompProfile": {
           "properties": {
             "type": {
               "default": "RuntimeDefault",
-              "title": "type",
               "type": "string"
             }
           },
-          "required": [
-            "type"
-          ],
-          "title": "seccompProfile",
+          "required": [],
           "type": "object"
         }
       },
-      "required": [
-        "runAsNonRoot",
-        "seccompProfile"
-      ],
-      "title": "podSecurityContext",
+      "required": [],
       "type": "object"
     },
     "priorityClassName": {
       "default": "",
       "description": "Priority indicates the importance of a Pod relative to other Pods.",
-      "title": "priorityClassName",
       "type": "string"
     },
     "rbac": {
@@ -290,25 +220,19 @@
         "create": {
           "default": true,
           "description": "Specifies whether Role and RoleBinding should be created.",
-          "title": "create",
           "type": "boolean"
         }
       },
-      "required": [
-        "create"
-      ],
-      "title": "rbac",
+      "required": [],
       "type": "object"
     },
     "replicaCount": {
       "default": 1,
-      "title": "replicaCount",
       "type": "integer"
     },
     "resources": {
       "additionalProperties": true,
-      "required": [],
-      "title": "resources"
+      "required": []
     },
     "service": {
       "properties": {
@@ -321,33 +245,24 @@
             ],
             "required": []
           },
-          "title": "ipFamilies",
           "type": "array"
         },
         "ipFamilyPolicy": {
           "default": "",
           "description": "Set the ip family policy to configure dual-stack see [Configure dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services)",
-          "title": "ipFamilyPolicy",
           "type": "string"
         },
         "name": {
           "default": "barman-cloud",
           "description": "DO NOT CHANGE THE SERVICE NAME as it is currently used to generate the certificate\nand can not be configured",
-          "title": "name",
           "type": "string"
         },
         "port": {
           "default": 9090,
-          "title": "port",
           "type": "integer"
         }
       },
-      "required": [
-        "name",
-        "port",
-        "ipFamilyPolicy"
-      ],
-      "title": "service",
+      "required": [],
       "type": "object"
     },
     "serviceAccount": {
@@ -355,48 +270,34 @@
         "create": {
           "default": true,
           "description": "Specifies whether the service account should be created.",
-          "title": "create",
           "type": "boolean"
         },
         "name": {
           "default": "",
           "description": "The name of the service account to use.\nIf not set and create is true, a name is generated using the fullname template.",
-          "title": "name",
           "type": "string"
         }
       },
-      "required": [
-        "create",
-        "name"
-      ],
-      "title": "serviceAccount",
+      "required": [],
       "type": "object"
     },
     "sidecarImage": {
       "properties": {
         "registry": {
           "default": "ghcr.io",
-          "title": "registry",
           "type": "string"
         },
         "repository": {
           "default": "cloudnative-pg/plugin-barman-cloud-sidecar",
-          "title": "repository",
           "type": "string"
         },
         "tag": {
           "default": "",
           "description": "Overrides the image tag whose default is the chart appVersion.",
-          "title": "tag",
           "type": "string"
         }
       },
-      "required": [
-        "registry",
-        "repository",
-        "tag"
-      ],
-      "title": "sidecarImage",
+      "required": [],
       "type": "object"
     },
     "tolerations": {
@@ -405,8 +306,7 @@
       "items": {
         "required": []
       },
-      "required": [],
-      "title": "tolerations"
+      "required": []
     },
     "topologySpreadConstraints": {
       "additionalProperties": true,
@@ -414,33 +314,14 @@
       "items": {
         "required": []
       },
-      "required": [],
-      "title": "topologySpreadConstraints"
+      "required": []
     },
     "updateStrategy": {
       "additionalProperties": true,
       "description": "Update strategy for the operator.\nref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy\nFor example:\n type: RollingUpdate\n rollingUpdate:\n   maxSurge: 25%\n   maxUnavailable: 25%\n\nWARNING: the RollingUpdate strategy is not supported by the operator yet so it can\ncurrently only use the Recreate strategy.",
-      "required": [],
-      "title": "updateStrategy"
+      "required": []
     }
   },
-  "required": [
-    "replicaCount",
-    "image",
-    "sidecarImage",
-    "nameOverride",
-    "fullnameOverride",
-    "namespaceOverride",
-    "hostNetwork",
-    "dnsPolicy",
-    "crds",
-    "serviceAccount",
-    "rbac",
-    "containerSecurityContext",
-    "podSecurityContext",
-    "priorityClassName",
-    "service",
-    "certificate"
-  ],
+  "required": [],
   "type": "object"
 }

--- a/charts/plugin-barman-cloud/values.schema.json
+++ b/charts/plugin-barman-cloud/values.schema.json
@@ -11,7 +11,7 @@
     },
     "additionalEnv": {
       "additionalProperties": true,
-      "description": "Array containing extra environment variables which can be templated.\nFor example:\n - name: RELEASE_NAME\n   value: \"{{ .Release.Name }}\"\n - name: MY_VAR\n   value: \"mySpecialKey\"",
+      "description": "Array containing extra environment variables which can be templated.",
       "items": {
         "required": []
       },
@@ -318,7 +318,7 @@
     },
     "updateStrategy": {
       "additionalProperties": true,
-      "description": "Update strategy for the operator.\nref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy\nFor example:\n type: RollingUpdate\n rollingUpdate:\n   maxSurge: 25%\n   maxUnavailable: 25%\n\nWARNING: the RollingUpdate strategy is not supported by the operator yet so it can\ncurrently only use the Recreate strategy.",
+      "description": "Update strategy for the operator.\nref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy",
       "required": []
     }
   },

--- a/charts/plugin-barman-cloud/values.schema.json
+++ b/charts/plugin-barman-cloud/values.schema.json
@@ -11,7 +11,7 @@
     },
     "additionalEnv": {
       "additionalProperties": true,
-      "description": "Array containing extra environment variables which can be templated.\nFor example:\n - name: RELEASE_NAME\n   value: \"{{ .Release.Name }}\"\n - name: MY_VAR\n   value: \"mySpecialKey\"",
+      "description": "Array containing extra environment variables which can be templated. For example:  - name: RELEASE_NAME    value: \"{{ .Release.Name }}\"  - name: MY_VAR    value: \"mySpecialKey\"",
       "items": {
         "required": []
       },
@@ -25,29 +25,29 @@
     "certificate": {
       "properties": {
         "createClientCertificate": {
-          "default": true,
+          "default": "true",
           "description": "Specifies whether the client certificate should be created.",
-          "type": "boolean"
+          "required": []
         },
         "createServerCertificate": {
-          "default": true,
+          "default": "true",
           "description": "Specifies whether the server certificate should be created.",
-          "type": "boolean"
+          "required": []
         },
         "duration": {
           "default": "2160h",
           "description": "The duration of the certificates.",
-          "type": "string"
+          "required": []
         },
         "issuerName": {
           "default": "selfsigned-issuer",
           "description": "The name of the issuer to use for the certificates.",
-          "type": "string"
+          "required": []
         },
         "renewBefore": {
           "default": "360h",
           "description": "The renew before time for the certificates.",
-          "type": "string"
+          "required": []
         }
       },
       "required": [],
@@ -105,15 +105,14 @@
           "type": "object"
         }
       },
-      "required": [],
-      "type": "object"
+      "required": []
     },
     "crds": {
       "properties": {
         "create": {
-          "default": true,
+          "default": "true",
           "description": "Specifies whether the CRDs should be created when installing the chart.",
-          "type": "boolean"
+          "required": []
         }
       },
       "required": [],
@@ -153,7 +152,7 @@
         "tag": {
           "default": "",
           "description": "Overrides the image tag whose default is the chart appVersion.",
-          "type": "string"
+          "required": []
         }
       },
       "required": [],
@@ -161,6 +160,7 @@
     },
     "imagePullSecrets": {
       "additionalProperties": true,
+      "description": " additionalProperties: true @schema",
       "items": {
         "required": []
       },
@@ -207,20 +207,19 @@
           "type": "object"
         }
       },
-      "required": [],
-      "type": "object"
+      "required": []
     },
     "priorityClassName": {
       "default": "",
       "description": "Priority indicates the importance of a Pod relative to other Pods.",
-      "type": "string"
+      "required": []
     },
     "rbac": {
       "properties": {
         "create": {
-          "default": true,
+          "default": "true",
           "description": "Specifies whether Role and RoleBinding should be created.",
-          "type": "boolean"
+          "required": []
         }
       },
       "required": [],
@@ -232,6 +231,7 @@
     },
     "resources": {
       "additionalProperties": true,
+      "description": " additionalProperties: true @schema",
       "required": []
     },
     "service": {
@@ -250,12 +250,12 @@
         "ipFamilyPolicy": {
           "default": "",
           "description": "Set the ip family policy to configure dual-stack see [Configure dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services)",
-          "type": "string"
+          "required": []
         },
         "name": {
           "default": "barman-cloud",
-          "description": "DO NOT CHANGE THE SERVICE NAME as it is currently used to generate the certificate\nand can not be configured",
-          "type": "string"
+          "description": "DO NOT CHANGE THE SERVICE NAME as it is currently used to generate the certificate and can not be configured",
+          "required": []
         },
         "port": {
           "default": 9090,
@@ -268,14 +268,14 @@
     "serviceAccount": {
       "properties": {
         "create": {
-          "default": true,
+          "default": "true",
           "description": "Specifies whether the service account should be created.",
-          "type": "boolean"
+          "required": []
         },
         "name": {
           "default": "",
-          "description": "The name of the service account to use.\nIf not set and create is true, a name is generated using the fullname template.",
-          "type": "string"
+          "description": "The name of the service account to use. If not set and create is true, a name is generated using the fullname template.",
+          "required": []
         }
       },
       "required": [],
@@ -294,7 +294,7 @@
         "tag": {
           "default": "",
           "description": "Overrides the image tag whose default is the chart appVersion.",
-          "type": "string"
+          "required": []
         }
       },
       "required": [],
@@ -318,7 +318,7 @@
     },
     "updateStrategy": {
       "additionalProperties": true,
-      "description": "Update strategy for the operator.\nref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy\nFor example:\n type: RollingUpdate\n rollingUpdate:\n   maxSurge: 25%\n   maxUnavailable: 25%\n\nWARNING: the RollingUpdate strategy is not supported by the operator yet so it can\ncurrently only use the Recreate strategy.",
+      "description": "Update strategy for the operator. ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy For example:  type: RollingUpdate  rollingUpdate:    maxSurge: 25%    maxUnavailable: 25%  WARNING: the RollingUpdate strategy is not supported by the operator yet so it can currently only use the Recreate strategy.",
       "required": []
     }
   },

--- a/charts/plugin-barman-cloud/values.schema.json
+++ b/charts/plugin-barman-cloud/values.schema.json
@@ -11,7 +11,7 @@
     },
     "additionalEnv": {
       "additionalProperties": true,
-      "description": "Array containing extra environment variables which can be templated. For example:  - name: RELEASE_NAME    value: \"{{ .Release.Name }}\"  - name: MY_VAR    value: \"mySpecialKey\"",
+      "description": "Array containing extra environment variables which can be templated.\nFor example:\n - name: RELEASE_NAME\n   value: \"{{ .Release.Name }}\"\n - name: MY_VAR\n   value: \"mySpecialKey\"",
       "items": {
         "required": []
       },
@@ -25,29 +25,29 @@
     "certificate": {
       "properties": {
         "createClientCertificate": {
-          "default": "true",
+          "default": true,
           "description": "Specifies whether the client certificate should be created.",
-          "required": []
+          "type": "boolean"
         },
         "createServerCertificate": {
-          "default": "true",
+          "default": true,
           "description": "Specifies whether the server certificate should be created.",
-          "required": []
+          "type": "boolean"
         },
         "duration": {
           "default": "2160h",
           "description": "The duration of the certificates.",
-          "required": []
+          "type": "string"
         },
         "issuerName": {
           "default": "selfsigned-issuer",
           "description": "The name of the issuer to use for the certificates.",
-          "required": []
+          "type": "string"
         },
         "renewBefore": {
           "default": "360h",
           "description": "The renew before time for the certificates.",
-          "required": []
+          "type": "string"
         }
       },
       "required": [],
@@ -105,14 +105,15 @@
           "type": "object"
         }
       },
-      "required": []
+      "required": [],
+      "type": "object"
     },
     "crds": {
       "properties": {
         "create": {
-          "default": "true",
+          "default": true,
           "description": "Specifies whether the CRDs should be created when installing the chart.",
-          "required": []
+          "type": "boolean"
         }
       },
       "required": [],
@@ -152,7 +153,7 @@
         "tag": {
           "default": "",
           "description": "Overrides the image tag whose default is the chart appVersion.",
-          "required": []
+          "type": "string"
         }
       },
       "required": [],
@@ -160,7 +161,6 @@
     },
     "imagePullSecrets": {
       "additionalProperties": true,
-      "description": " additionalProperties: true @schema",
       "items": {
         "required": []
       },
@@ -207,19 +207,20 @@
           "type": "object"
         }
       },
-      "required": []
+      "required": [],
+      "type": "object"
     },
     "priorityClassName": {
       "default": "",
       "description": "Priority indicates the importance of a Pod relative to other Pods.",
-      "required": []
+      "type": "string"
     },
     "rbac": {
       "properties": {
         "create": {
-          "default": "true",
+          "default": true,
           "description": "Specifies whether Role and RoleBinding should be created.",
-          "required": []
+          "type": "boolean"
         }
       },
       "required": [],
@@ -231,7 +232,6 @@
     },
     "resources": {
       "additionalProperties": true,
-      "description": " additionalProperties: true @schema",
       "required": []
     },
     "service": {
@@ -250,12 +250,12 @@
         "ipFamilyPolicy": {
           "default": "",
           "description": "Set the ip family policy to configure dual-stack see [Configure dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services)",
-          "required": []
+          "type": "string"
         },
         "name": {
           "default": "barman-cloud",
-          "description": "DO NOT CHANGE THE SERVICE NAME as it is currently used to generate the certificate and can not be configured",
-          "required": []
+          "description": "DO NOT CHANGE THE SERVICE NAME as it is currently used to generate the certificate\nand can not be configured",
+          "type": "string"
         },
         "port": {
           "default": 9090,
@@ -268,14 +268,14 @@
     "serviceAccount": {
       "properties": {
         "create": {
-          "default": "true",
+          "default": true,
           "description": "Specifies whether the service account should be created.",
-          "required": []
+          "type": "boolean"
         },
         "name": {
           "default": "",
-          "description": "The name of the service account to use. If not set and create is true, a name is generated using the fullname template.",
-          "required": []
+          "description": "The name of the service account to use.\nIf not set and create is true, a name is generated using the fullname template.",
+          "type": "string"
         }
       },
       "required": [],
@@ -294,7 +294,7 @@
         "tag": {
           "default": "",
           "description": "Overrides the image tag whose default is the chart appVersion.",
-          "required": []
+          "type": "string"
         }
       },
       "required": [],
@@ -318,7 +318,7 @@
     },
     "updateStrategy": {
       "additionalProperties": true,
-      "description": "Update strategy for the operator. ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy For example:  type: RollingUpdate  rollingUpdate:    maxSurge: 25%    maxUnavailable: 25%  WARNING: the RollingUpdate strategy is not supported by the operator yet so it can currently only use the Recreate strategy.",
+      "description": "Update strategy for the operator.\nref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy\nFor example:\n type: RollingUpdate\n rollingUpdate:\n   maxSurge: 25%\n   maxUnavailable: 25%\n\nWARNING: the RollingUpdate strategy is not supported by the operator yet so it can\ncurrently only use the Recreate strategy.",
       "required": []
     }
   },

--- a/charts/plugin-barman-cloud/values.yaml
+++ b/charts/plugin-barman-cloud/values.yaml
@@ -51,6 +51,7 @@ dnsPolicy: ""
 # @schema
 # -- Update strategy for the operator.
 # ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+updateStrategy: {}
 # For example:
 #  type: RollingUpdate
 #  rollingUpdate:
@@ -59,7 +60,6 @@ dnsPolicy: ""
 #
 # WARNING: the RollingUpdate strategy is not supported by the operator yet so it can
 # currently only use the Recreate strategy.
-updateStrategy: {}
 
 crds:
   # -- Specifies whether the CRDs should be created when installing the chart.
@@ -75,12 +75,12 @@ additionalArgs: []
 # additionalProperties: true
 # @schema
 # -- Array containing extra environment variables which can be templated.
+additionalEnv: []
 # For example:
 #  - name: RELEASE_NAME
 #    value: "{{ .Release.Name }}"
 #  - name: MY_VAR
 #    value: "mySpecialKey"
-additionalEnv: []
 
 serviceAccount:
   # -- Specifies whether the service account should be created.


### PR DESCRIPTION
Currently the cloudnative-pg chart and cluster chart are using karuppiah7890/helm-schema-gen  for shcema generation,
The tool is currently not maintained actively. 
Replacing it with dadav/helm-schema which is being used by plugin-barman-cloud chart currently.

Closes #885
Closes #74
Closes #854

Signed-off-by: danishedb <danish.khan@enterprisedb.com>