### PR TITLE
ci: wrong syntax in tests-plugin-barman-cloud.yaml

### DIFF
--- a/.github/workflows/tests-plugin-barman-cloud.yaml
+++ b/.github/workflows/tests-plugin-barman-cloud.yaml
@@ -28,7 +28,7 @@ jobs:
       matrix: ${{ fromJson(needs.test-list.outputs.tests) }}
     env:
       MATRIX_TEST: ${{ matrix.test }}
-    name: ${{ env.MATRIX_TEST }}
+    name: ${{ matrix.test }}
     steps:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1


### PR DESCRIPTION
Closes #902 