### PR TITLE
fix[plugin-barman-cloud]: align name of the workflow with the chart name

### DIFF
--- a/.github/workflows/tests-operator.yml
+++ b/.github/workflows/tests-operator.yml
@@ -1,4 +1,4 @@
-name: tests-operator
+name: test( operator )
 
 on:
   pull_request:

--- a/.github/workflows/tests-plugin-barman-cloud.yaml
+++ b/.github/workflows/tests-plugin-barman-cloud.yaml
@@ -1,4 +1,4 @@
-name: test( cluster )
+name: test( plugin-barman-cloud )
 
 on:
   pull_request:


### PR DESCRIPTION
Small change to fix the name of the workflow which tests the plugin-barman-cloud.

Earlier the name was cluster.
Now it will be test( plugin-barman-cloud )
Also align operator workflow with rest.

closes #901 
Signed-off-by: danishedb <danish.khan@enterprisedb.com>