### PR TITLE
chore: scope @phisco code ownership to charts/cluster

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,6 +2,6 @@
 # responsible for code in a repository. For details, please refer to
 # https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-*               @fcanovai @gbartolini @leonardoce @mnencia @phisco @itay-grudev
-/.github        @fcanovai @gbartolini @leonardoce @mnencia @phisco @itay-grudev
-/charts/cluster @itay-grudev
+*               @fcanovai @gbartolini @leonardoce @mnencia @itay-grudev
+/.github        @fcanovai @gbartolini @leonardoce @mnencia @itay-grudev
+/charts/cluster @itay-grudev @phisco


### PR DESCRIPTION
Removes `@phisco` as a catch-all code owner (the `*` and `/.github` rules) and scopes ownership to `charts/cluster`, to stop blanket review requests across the repo.