### PR TITLE
Add Barman Cloud plugin cluster support

### DIFF
--- a/charts/cluster/README.md
+++ b/charts/cluster/README.md
@@ -97,6 +97,16 @@ Each backup adapter takes it's own set of parameters, listed in the [Configurati
 section. Refer to the table for the full list of parameters and place the configuration under the appropriate key: `backups.s3`,
 `backups.azure`, or `backups.google`.
 
+### Barman Cloud Plugin integration
+
+The chart can configure a cluster to use the CNPG-I Barman Cloud plugin as the WAL archiver by enabling
+`barmanCloudPlugin.enabled`. This renders a plugin `ObjectStore`, configures `spec.plugins` on the `Cluster`, and can
+optionally create plugin-based scheduled backups. The Barman Cloud plugin and its CRDs must already be installed, for
+example with the `plugin-barman-cloud` chart.
+
+`barmanCloudPlugin.enabled` is mutually exclusive with `backups.enabled`, because the CloudNativePG API does not allow a
+WAL archiver plugin and `spec.backup.barmanObjectStore` to be configured at the same time.
+
 Recovery
 --------
 
@@ -153,6 +163,58 @@ Kubernetes: `>=1.29.0-0`
 | backups.wal.compression | string | `"gzip"` | WAL compression method. One of `` (for no compression), `gzip`, `bzip2` or `snappy`. |
 | backups.wal.encryption | string | `"AES256"` | Whether to instruct the storage provider to encrypt WAL files. One of `` (use the storage container default), `AES256` or `aws:kms`. |
 | backups.wal.maxParallel | int | `1` | Number of WAL files to be archived or restored in parallel. |
+| barmanCloudPlugin.additionalConfiguration | object | `{}` | Additional fields rendered under ObjectStore spec.configuration. |
+| barmanCloudPlugin.additionalPluginParameters | object | `{}` | Additional plugin parameters rendered under spec.plugins[].parameters. |
+| barmanCloudPlugin.data.compression | string | `""` | Data compression method. One of `` (for no compression), `gzip`, `bzip2`, `lz4` or `snappy`. |
+| barmanCloudPlugin.data.encryption | string | `""` | Whether to instruct the storage provider to encrypt data files. One of `` (use the storage container default), `AES256` or `aws:kms`. |
+| barmanCloudPlugin.data.jobs | int | `0` | Number of data files to be archived in parallel. Set to 0 to omit the field. |
+| barmanCloudPlugin.destinationPath | string | `""` | Full object store destination path. If empty, s3.bucket and s3.path are used. |
+| barmanCloudPlugin.enabled | bool | `false` | Enable the Barman Cloud CNPG-I plugin integration. |
+| barmanCloudPlugin.endpointCA | object | `{}` | Optional endpoint CA reference. |
+| barmanCloudPlugin.endpointURL | string | `""` | Object store endpoint URL. If empty and s3.region is set, AWS S3 endpoint is derived. |
+| barmanCloudPlugin.instanceSidecarConfiguration | object | `{}` | Optional ObjectStore spec.instanceSidecarConfiguration. |
+| barmanCloudPlugin.objectStore.annotations | object | `{}` |  |
+| barmanCloudPlugin.objectStore.name | string | `""` | Name of the ObjectStore resource. Defaults to <release>-barman-store. |
+| barmanCloudPlugin.pluginName | string | `"barman-cloud.cloudnative-pg.io"` | Name of the installed CNPG-I plugin. |
+| barmanCloudPlugin.retentionPolicy | string | `"30d"` | ObjectStore retention policy. |
+| barmanCloudPlugin.s3.accessKey | string | `""` | Access key value, only used when s3.secret.create is true. |
+| barmanCloudPlugin.s3.bucket | string | `""` | S3 bucket used when destinationPath is empty. |
+| barmanCloudPlugin.s3.externalSecret.annotations | object | `{}` |  |
+| barmanCloudPlugin.s3.externalSecret.enabled | bool | `false` | Whether the chart should create an ExternalSecret for S3 credentials. |
+| barmanCloudPlugin.s3.externalSecret.labels | object | `{}` |  |
+| barmanCloudPlugin.s3.externalSecret.name | string | `""` | Name of the ExternalSecret resource. Defaults to <secret name>-external-secret. |
+| barmanCloudPlugin.s3.externalSecret.refreshInterval | string | `"168h"` |  |
+| barmanCloudPlugin.s3.externalSecret.remoteRefs.accessKeyId.conversionStrategy | string | `"Default"` |  |
+| barmanCloudPlugin.s3.externalSecret.remoteRefs.accessKeyId.decodingStrategy | string | `"None"` |  |
+| barmanCloudPlugin.s3.externalSecret.remoteRefs.accessKeyId.key | string | `""` |  |
+| barmanCloudPlugin.s3.externalSecret.remoteRefs.accessKeyId.metadataPolicy | string | `"None"` |  |
+| barmanCloudPlugin.s3.externalSecret.remoteRefs.accessKeyId.property | string | `""` |  |
+| barmanCloudPlugin.s3.externalSecret.remoteRefs.secretAccessKey.conversionStrategy | string | `"Default"` |  |
+| barmanCloudPlugin.s3.externalSecret.remoteRefs.secretAccessKey.decodingStrategy | string | `"None"` |  |
+| barmanCloudPlugin.s3.externalSecret.remoteRefs.secretAccessKey.key | string | `""` |  |
+| barmanCloudPlugin.s3.externalSecret.remoteRefs.secretAccessKey.metadataPolicy | string | `"None"` |  |
+| barmanCloudPlugin.s3.externalSecret.remoteRefs.secretAccessKey.property | string | `""` |  |
+| barmanCloudPlugin.s3.externalSecret.secretStoreRef.kind | string | `"ClusterSecretStore"` |  |
+| barmanCloudPlugin.s3.externalSecret.secretStoreRef.name | string | `""` |  |
+| barmanCloudPlugin.s3.externalSecret.target.creationPolicy | string | `"Owner"` |  |
+| barmanCloudPlugin.s3.externalSecret.target.deletionPolicy | string | `"Retain"` |  |
+| barmanCloudPlugin.s3.externalSecret.target.name | string | `""` | Target Secret name. Defaults to barmanCloudPlugin.s3.secret.name or <release>-barman-s3-creds. |
+| barmanCloudPlugin.s3.inheritFromIAMRole | bool | `false` | Use role-based authentication instead of explicit credentials. |
+| barmanCloudPlugin.s3.path | string | `"/"` | S3 path used when destinationPath is empty. |
+| barmanCloudPlugin.s3.region | string | `""` | AWS region used to derive the default S3 endpoint when endpointURL is empty. |
+| barmanCloudPlugin.s3.secret.accessKeyIdKey | string | `"ACCESS_KEY_ID"` |  |
+| barmanCloudPlugin.s3.secret.create | bool | `false` | Whether the chart should create a Kubernetes Secret for S3 credentials. |
+| barmanCloudPlugin.s3.secret.name | string | `""` | Name of the Secret containing S3 credentials. Defaults to <release>-barman-s3-creds. |
+| barmanCloudPlugin.s3.secret.secretAccessKeyKey | string | `"ACCESS_SECRET_KEY"` |  |
+| barmanCloudPlugin.s3.secretKey | string | `""` | Secret key value, only used when s3.secret.create is true. |
+| barmanCloudPlugin.scheduledBackups[0].backupOwnerReference | string | `"self"` | Backup owner reference |
+| barmanCloudPlugin.scheduledBackups[0].name | string | `"daily-backup"` | Scheduled backup name |
+| barmanCloudPlugin.scheduledBackups[0].pluginName | string | `""` | Plugin name override. Defaults to barmanCloudPlugin.pluginName. |
+| barmanCloudPlugin.scheduledBackups[0].schedule | string | `"0 0 0 * * *"` | Schedule in cron format |
+| barmanCloudPlugin.serverName | string | `""` | Optional server name plugin parameter. Leave empty for the cluster name default. |
+| barmanCloudPlugin.wal.compression | string | `""` | WAL compression method. One of `` (for no compression), `gzip`, `bzip2`, `lz4`, `snappy`, `xz` or `zstd`. |
+| barmanCloudPlugin.wal.encryption | string | `""` | Whether to instruct the storage provider to encrypt WAL files. One of `` (use the storage container default), `AES256` or `aws:kms`. |
+| barmanCloudPlugin.wal.maxParallel | int | `0` | Number of WAL files to be archived or restored in parallel. Set to 0 to omit the field. |
 | cluster.additionalLabels | object | `{}` |  |
 | cluster.affinity | object | `{"topologyKey":"topology.kubernetes.io/zone"}` | Affinity/Anti-affinity rules for Pods. See: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-AffinityConfiguration |
 | cluster.annotations | object | `{}` |  |

--- a/charts/cluster/README.md.gotmpl
+++ b/charts/cluster/README.md.gotmpl
@@ -105,6 +105,16 @@ Each backup adapter takes it's own set of parameters, listed in the [Configurati
 section. Refer to the table for the full list of parameters and place the configuration under the appropriate key: `backups.s3`,
 `backups.azure`, or `backups.google`.
 
+### Barman Cloud Plugin integration
+
+The chart can configure a cluster to use the CNPG-I Barman Cloud plugin as the WAL archiver by enabling
+`barmanCloudPlugin.enabled`. This renders a plugin `ObjectStore`, configures `spec.plugins` on the `Cluster`, and can
+optionally create plugin-based scheduled backups. The Barman Cloud plugin and its CRDs must already be installed, for
+example with the `plugin-barman-cloud` chart.
+
+`barmanCloudPlugin.enabled` is mutually exclusive with `backups.enabled`, because the CloudNativePG API does not allow a
+WAL archiver plugin and `spec.backup.barmanObjectStore` to be configured at the same time.
+
 
 Recovery
 --------

--- a/charts/cluster/examples/barman-cloud-plugin.yaml
+++ b/charts/cluster/examples/barman-cloud-plugin.yaml
@@ -1,0 +1,25 @@
+type: postgresql
+mode: standalone
+
+cluster:
+  instances: 3
+  storage:
+    size: 8Gi
+
+barmanCloudPlugin:
+  enabled: true
+  s3:
+    region: eu-west-1
+    bucket: mybucket
+    path: /cluster
+    inheritFromIAMRole: true
+  wal:
+    compression: gzip
+    maxParallel: 2
+  data:
+    compression: gzip
+    jobs: 2
+  scheduledBackups:
+    - name: daily-backup
+      schedule: "0 0 0 * * *"
+      backupOwnerReference: self

--- a/charts/cluster/templates/_barman_cloud_plugin.tpl
+++ b/charts/cluster/templates/_barman_cloud_plugin.tpl
@@ -1,0 +1,13 @@
+{{/*
+Name of the Barman Cloud Plugin ObjectStore resource.
+*/}}
+{{- define "cluster.barmanCloudPlugin.objectStoreName" -}}
+{{- default (printf "%s-barman-store" (include "cluster.fullname" .)) .Values.barmanCloudPlugin.objectStore.name -}}
+{{- end -}}
+
+{{/*
+Name of the Secret containing Barman Cloud Plugin object store credentials.
+*/}}
+{{- define "cluster.barmanCloudPlugin.secretName" -}}
+{{- default (printf "%s-barman-s3-creds" (include "cluster.fullname" .)) .Values.barmanCloudPlugin.s3.secret.name -}}
+{{- end -}}

--- a/charts/cluster/templates/barman-cloud-external-secret.yaml
+++ b/charts/cluster/templates/barman-cloud-external-secret.yaml
@@ -1,0 +1,41 @@
+{{- if and .Values.barmanCloudPlugin.enabled (not .Values.barmanCloudPlugin.s3.inheritFromIAMRole) .Values.barmanCloudPlugin.s3.externalSecret.enabled }}
+{{- $secretName := include "cluster.barmanCloudPlugin.secretName" . -}}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ default (printf "%s-external-secret" $secretName) .Values.barmanCloudPlugin.s3.externalSecret.name }}
+  namespace: {{ include "cluster.namespace" . }}
+  labels:
+  {{- include "cluster.labels" . | nindent 4 }}
+  {{- with .Values.barmanCloudPlugin.s3.externalSecret.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.barmanCloudPlugin.s3.externalSecret.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  data:
+    - remoteRef:
+        conversionStrategy: {{ .Values.barmanCloudPlugin.s3.externalSecret.remoteRefs.accessKeyId.conversionStrategy }}
+        decodingStrategy: {{ .Values.barmanCloudPlugin.s3.externalSecret.remoteRefs.accessKeyId.decodingStrategy }}
+        key: {{ required ".Values.barmanCloudPlugin.s3.externalSecret.remoteRefs.accessKeyId.key is required when barmanCloudPlugin.s3.externalSecret.enabled is true." .Values.barmanCloudPlugin.s3.externalSecret.remoteRefs.accessKeyId.key }}
+        metadataPolicy: {{ .Values.barmanCloudPlugin.s3.externalSecret.remoteRefs.accessKeyId.metadataPolicy }}
+        property: {{ required ".Values.barmanCloudPlugin.s3.externalSecret.remoteRefs.accessKeyId.property is required when barmanCloudPlugin.s3.externalSecret.enabled is true." .Values.barmanCloudPlugin.s3.externalSecret.remoteRefs.accessKeyId.property }}
+      secretKey: {{ .Values.barmanCloudPlugin.s3.secret.accessKeyIdKey }}
+    - remoteRef:
+        conversionStrategy: {{ .Values.barmanCloudPlugin.s3.externalSecret.remoteRefs.secretAccessKey.conversionStrategy }}
+        decodingStrategy: {{ .Values.barmanCloudPlugin.s3.externalSecret.remoteRefs.secretAccessKey.decodingStrategy }}
+        key: {{ required ".Values.barmanCloudPlugin.s3.externalSecret.remoteRefs.secretAccessKey.key is required when barmanCloudPlugin.s3.externalSecret.enabled is true." .Values.barmanCloudPlugin.s3.externalSecret.remoteRefs.secretAccessKey.key }}
+        metadataPolicy: {{ .Values.barmanCloudPlugin.s3.externalSecret.remoteRefs.secretAccessKey.metadataPolicy }}
+        property: {{ required ".Values.barmanCloudPlugin.s3.externalSecret.remoteRefs.secretAccessKey.property is required when barmanCloudPlugin.s3.externalSecret.enabled is true." .Values.barmanCloudPlugin.s3.externalSecret.remoteRefs.secretAccessKey.property }}
+      secretKey: {{ .Values.barmanCloudPlugin.s3.secret.secretAccessKeyKey }}
+  refreshInterval: {{ .Values.barmanCloudPlugin.s3.externalSecret.refreshInterval }}
+  secretStoreRef:
+    kind: {{ required ".Values.barmanCloudPlugin.s3.externalSecret.secretStoreRef.kind is required when barmanCloudPlugin.s3.externalSecret.enabled is true." .Values.barmanCloudPlugin.s3.externalSecret.secretStoreRef.kind }}
+    name: {{ required ".Values.barmanCloudPlugin.s3.externalSecret.secretStoreRef.name is required when barmanCloudPlugin.s3.externalSecret.enabled is true." .Values.barmanCloudPlugin.s3.externalSecret.secretStoreRef.name }}
+  target:
+    creationPolicy: {{ .Values.barmanCloudPlugin.s3.externalSecret.target.creationPolicy }}
+    deletionPolicy: {{ .Values.barmanCloudPlugin.s3.externalSecret.target.deletionPolicy }}
+    name: {{ default $secretName .Values.barmanCloudPlugin.s3.externalSecret.target.name }}
+{{- end }}

--- a/charts/cluster/templates/barman-cloud-objectstore.yaml
+++ b/charts/cluster/templates/barman-cloud-objectstore.yaml
@@ -1,0 +1,76 @@
+{{- if .Values.barmanCloudPlugin.enabled }}
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: {{ include "cluster.barmanCloudPlugin.objectStoreName" . }}
+  namespace: {{ include "cluster.namespace" . }}
+  labels:
+  {{- include "cluster.labels" . | nindent 4 }}
+  {{- with .Values.barmanCloudPlugin.objectStore.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.barmanCloudPlugin.retentionPolicy }}
+  retentionPolicy: {{ . | quote }}
+  {{- end }}
+  configuration:
+    {{- if .Values.barmanCloudPlugin.destinationPath }}
+    destinationPath: {{ .Values.barmanCloudPlugin.destinationPath | quote }}
+    {{- else }}
+    destinationPath: {{ printf "s3://%s%s" (required ".Values.barmanCloudPlugin.s3.bucket is required when barmanCloudPlugin is enabled and destinationPath is empty." .Values.barmanCloudPlugin.s3.bucket) .Values.barmanCloudPlugin.s3.path | quote }}
+    {{- end }}
+    {{- if .Values.barmanCloudPlugin.endpointURL }}
+    endpointURL: {{ .Values.barmanCloudPlugin.endpointURL | quote }}
+    {{- else if .Values.barmanCloudPlugin.s3.region }}
+    endpointURL: {{ printf "https://s3.%s.amazonaws.com" .Values.barmanCloudPlugin.s3.region | quote }}
+    {{- end }}
+    {{- with .Values.barmanCloudPlugin.endpointCA }}
+    endpointCA:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    s3Credentials:
+      {{- if .Values.barmanCloudPlugin.s3.inheritFromIAMRole }}
+      inheritFromIAMRole: true
+      {{- else }}
+      accessKeyId:
+        name: {{ include "cluster.barmanCloudPlugin.secretName" . }}
+        key: {{ .Values.barmanCloudPlugin.s3.secret.accessKeyIdKey }}
+      secretAccessKey:
+        name: {{ include "cluster.barmanCloudPlugin.secretName" . }}
+        key: {{ .Values.barmanCloudPlugin.s3.secret.secretAccessKeyKey }}
+      {{- end }}
+    {{- $wal := .Values.barmanCloudPlugin.wal }}
+    {{- if or $wal.compression $wal.encryption $wal.maxParallel }}
+    wal:
+      {{- with $wal.compression }}
+      compression: {{ . }}
+      {{- end }}
+      {{- with $wal.encryption }}
+      encryption: {{ . }}
+      {{- end }}
+      {{- with $wal.maxParallel }}
+      maxParallel: {{ . }}
+      {{- end }}
+    {{- end }}
+    {{- $data := .Values.barmanCloudPlugin.data }}
+    {{- if or $data.compression $data.encryption $data.jobs }}
+    data:
+      {{- with $data.compression }}
+      compression: {{ . }}
+      {{- end }}
+      {{- with $data.encryption }}
+      encryption: {{ . }}
+      {{- end }}
+      {{- with $data.jobs }}
+      jobs: {{ . }}
+      {{- end }}
+    {{- end }}
+    {{- with .Values.barmanCloudPlugin.additionalConfiguration }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.barmanCloudPlugin.instanceSidecarConfiguration }}
+  instanceSidecarConfiguration:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/cluster/templates/barman-cloud-s3-creds.yaml
+++ b/charts/cluster/templates/barman-cloud-s3-creds.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.barmanCloudPlugin.enabled (not .Values.barmanCloudPlugin.s3.inheritFromIAMRole) .Values.barmanCloudPlugin.s3.secret.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "cluster.barmanCloudPlugin.secretName" . }}
+  namespace: {{ include "cluster.namespace" . }}
+  labels:
+  {{- include "cluster.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{ .Values.barmanCloudPlugin.s3.secret.accessKeyIdKey }}: {{ required ".Values.barmanCloudPlugin.s3.accessKey is required when barmanCloudPlugin.s3.secret.create is true." .Values.barmanCloudPlugin.s3.accessKey | b64enc | quote }}
+  {{ .Values.barmanCloudPlugin.s3.secret.secretAccessKeyKey }}: {{ required ".Values.barmanCloudPlugin.s3.secretKey is required when barmanCloudPlugin.s3.secret.create is true." .Values.barmanCloudPlugin.s3.secretKey | b64enc | quote }}
+{{- end }}

--- a/charts/cluster/templates/barman-cloud-scheduled-backups.yaml
+++ b/charts/cluster/templates/barman-cloud-scheduled-backups.yaml
@@ -1,21 +1,20 @@
-{{ if .Values.backups.enabled }}
+{{- if .Values.barmanCloudPlugin.enabled }}
 {{ $context := . -}}
-{{ range .Values.backups.scheduledBackups -}}
+{{ range .Values.barmanCloudPlugin.scheduledBackups -}}
 ---
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:
-  name: {{ include "cluster.fullname" $context  }}-{{ .name }}
+  name: {{ include "cluster.fullname" $context }}-{{ .name }}
   namespace: {{ include "cluster.namespace" $ }}
-  labels: {{ include "cluster.labels" $context | nindent 4 }}
+  labels:
+  {{- include "cluster.labels" $context | nindent 4 }}
 spec:
   immediate: true
   schedule: {{ .schedule | quote }}
-  method: {{ .method }}
-  {{- if eq .method "plugin" }}
+  method: plugin
   pluginConfiguration:
-    name: {{ default $.Values.barmanCloudPlugin.pluginName .pluginName }}
-  {{- end }}
+    name: {{ default $context.Values.barmanCloudPlugin.pluginName .pluginName }}
   backupOwnerReference: {{ .backupOwnerReference }}
   cluster:
     name: {{ include "cluster.fullname" $context }}

--- a/charts/cluster/templates/cluster.yaml
+++ b/charts/cluster/templates/cluster.yaml
@@ -53,6 +53,22 @@ spec:
   {{- if .Values.cluster.priorityClassName }}
   priorityClassName: {{ .Values.cluster.priorityClassName }}
   {{- end }}
+  {{- if and .Values.barmanCloudPlugin.enabled .Values.backups.enabled }}
+  {{- fail "barmanCloudPlugin.enabled and backups.enabled cannot both be true because a WAL archiver plugin cannot be used with spec.backup.barmanObjectStore." }}
+  {{- end }}
+  {{- if .Values.barmanCloudPlugin.enabled }}
+  plugins:
+    - name: {{ .Values.barmanCloudPlugin.pluginName }}
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: {{ include "cluster.barmanCloudPlugin.objectStoreName" . }}
+        {{- with .Values.barmanCloudPlugin.serverName }}
+        serverName: {{ . }}
+        {{- end }}
+        {{- with .Values.barmanCloudPlugin.additionalPluginParameters }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+  {{- end }}
 
   primaryUpdateMethod: {{ .Values.cluster.primaryUpdateMethod }}
   primaryUpdateStrategy: {{ .Values.cluster.primaryUpdateStrategy }}

--- a/charts/cluster/values.schema.json
+++ b/charts/cluster/values.schema.json
@@ -239,6 +239,332 @@
       "required": [],
       "type": "object"
     },
+    "barmanCloudPlugin": {
+      "properties": {
+        "additionalConfiguration": {
+          "description": "Additional fields rendered under ObjectStore spec.configuration.",
+          "required": [],
+          "type": "object"
+        },
+        "additionalPluginParameters": {
+          "description": "Additional plugin parameters rendered under spec.plugins[].parameters.",
+          "required": [],
+          "type": "object"
+        },
+        "data": {
+          "properties": {
+            "compression": {
+              "default": "",
+              "description": "Data compression method. One of `` (for no compression), `gzip`, `bzip2`, `lz4` or `snappy`.",
+              "type": "string"
+            },
+            "encryption": {
+              "default": "",
+              "description": "Whether to instruct the storage provider to encrypt data files. One of `` (use the storage container default), `AES256` or `aws:kms`.",
+              "type": "string"
+            },
+            "jobs": {
+              "default": 0,
+              "description": "Number of data files to be archived in parallel. Set to 0 to omit the field.",
+              "type": "integer"
+            }
+          },
+          "required": [],
+          "type": "object"
+        },
+        "destinationPath": {
+          "default": "",
+          "description": "Full object store destination path. If empty, s3.bucket and s3.path are used.",
+          "type": "string"
+        },
+        "enabled": {
+          "default": false,
+          "description": "Enable the Barman Cloud CNPG-I plugin integration.",
+          "type": "boolean"
+        },
+        "endpointCA": {
+          "description": "Optional endpoint CA reference.",
+          "required": [],
+          "type": "object"
+        },
+        "endpointURL": {
+          "default": "",
+          "description": "Object store endpoint URL. If empty and s3.region is set, AWS S3 endpoint is derived.",
+          "type": "string"
+        },
+        "instanceSidecarConfiguration": {
+          "description": "Optional ObjectStore spec.instanceSidecarConfiguration.",
+          "required": [],
+          "type": "object"
+        },
+        "objectStore": {
+          "properties": {
+            "annotations": {
+              "required": [],
+              "type": "object"
+            },
+            "name": {
+              "default": "",
+              "description": "Name of the ObjectStore resource. Defaults to \u003crelease\u003e-barman-store.",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "type": "object"
+        },
+        "pluginName": {
+          "default": "barman-cloud.cloudnative-pg.io",
+          "description": "Name of the installed CNPG-I plugin.",
+          "type": "string"
+        },
+        "retentionPolicy": {
+          "default": "30d",
+          "description": "ObjectStore retention policy.",
+          "type": "string"
+        },
+        "s3": {
+          "properties": {
+            "accessKey": {
+              "default": "",
+              "description": "Access key value, only used when s3.secret.create is true.",
+              "type": "string"
+            },
+            "bucket": {
+              "default": "",
+              "description": "S3 bucket used when destinationPath is empty.",
+              "type": "string"
+            },
+            "externalSecret": {
+              "properties": {
+                "annotations": {
+                  "required": [],
+                  "type": "object"
+                },
+                "enabled": {
+                  "default": false,
+                  "description": "Whether the chart should create an ExternalSecret for S3 credentials.",
+                  "type": "boolean"
+                },
+                "labels": {
+                  "required": [],
+                  "type": "object"
+                },
+                "name": {
+                  "default": "",
+                  "description": "Name of the ExternalSecret resource. Defaults to \u003csecret name\u003e-external-secret.",
+                  "type": "string"
+                },
+                "refreshInterval": {
+                  "default": "168h",
+                  "type": "string"
+                },
+                "remoteRefs": {
+                  "properties": {
+                    "accessKeyId": {
+                      "properties": {
+                        "conversionStrategy": {
+                          "default": "Default",
+                          "type": "string"
+                        },
+                        "decodingStrategy": {
+                          "default": "None",
+                          "type": "string"
+                        },
+                        "key": {
+                          "default": "",
+                          "type": "string"
+                        },
+                        "metadataPolicy": {
+                          "default": "None",
+                          "type": "string"
+                        },
+                        "property": {
+                          "default": "",
+                          "type": "string"
+                        }
+                      },
+                      "required": [],
+                      "type": "object"
+                    },
+                    "secretAccessKey": {
+                      "properties": {
+                        "conversionStrategy": {
+                          "default": "Default",
+                          "type": "string"
+                        },
+                        "decodingStrategy": {
+                          "default": "None",
+                          "type": "string"
+                        },
+                        "key": {
+                          "default": "",
+                          "type": "string"
+                        },
+                        "metadataPolicy": {
+                          "default": "None",
+                          "type": "string"
+                        },
+                        "property": {
+                          "default": "",
+                          "type": "string"
+                        }
+                      },
+                      "required": [],
+                      "type": "object"
+                    }
+                  },
+                  "required": [],
+                  "type": "object"
+                },
+                "secretStoreRef": {
+                  "properties": {
+                    "kind": {
+                      "default": "ClusterSecretStore",
+                      "type": "string"
+                    },
+                    "name": {
+                      "default": "",
+                      "type": "string"
+                    }
+                  },
+                  "required": [],
+                  "type": "object"
+                },
+                "target": {
+                  "properties": {
+                    "creationPolicy": {
+                      "default": "Owner",
+                      "type": "string"
+                    },
+                    "deletionPolicy": {
+                      "default": "Retain",
+                      "type": "string"
+                    },
+                    "name": {
+                      "default": "",
+                      "description": "Target Secret name. Defaults to barmanCloudPlugin.s3.secret.name or \u003crelease\u003e-barman-s3-creds.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [],
+                  "type": "object"
+                }
+              },
+              "required": [],
+              "type": "object"
+            },
+            "inheritFromIAMRole": {
+              "default": false,
+              "description": "Use role-based authentication instead of explicit credentials.",
+              "type": "boolean"
+            },
+            "path": {
+              "default": "/",
+              "description": "S3 path used when destinationPath is empty.",
+              "type": "string"
+            },
+            "region": {
+              "default": "",
+              "description": "AWS region used to derive the default S3 endpoint when endpointURL is empty.",
+              "type": "string"
+            },
+            "secret": {
+              "properties": {
+                "accessKeyIdKey": {
+                  "default": "ACCESS_KEY_ID",
+                  "type": "string"
+                },
+                "create": {
+                  "default": false,
+                  "description": "Whether the chart should create a Kubernetes Secret for S3 credentials.",
+                  "type": "boolean"
+                },
+                "name": {
+                  "default": "",
+                  "description": "Name of the Secret containing S3 credentials. Defaults to \u003crelease\u003e-barman-s3-creds.",
+                  "type": "string"
+                },
+                "secretAccessKeyKey": {
+                  "default": "ACCESS_SECRET_KEY",
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "type": "object"
+            },
+            "secretKey": {
+              "default": "",
+              "description": "Secret key value, only used when s3.secret.create is true.",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "type": "object"
+        },
+        "scheduledBackups": {
+          "items": {
+            "anyOf": [
+              {
+                "properties": {
+                  "backupOwnerReference": {
+                    "default": "self",
+                    "description": "Backup owner reference",
+                    "type": "string"
+                  },
+                  "name": {
+                    "default": "daily-backup",
+                    "description": "Scheduled backup name",
+                    "type": "string"
+                  },
+                  "pluginName": {
+                    "default": "",
+                    "description": "Plugin name override. Defaults to barmanCloudPlugin.pluginName.",
+                    "type": "string"
+                  },
+                  "schedule": {
+                    "default": "0 0 0 * * *",
+                    "description": "Schedule in cron format",
+                    "type": "string"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              }
+            ],
+            "required": []
+          },
+          "type": "array"
+        },
+        "serverName": {
+          "default": "",
+          "description": "Optional server name plugin parameter. Leave empty for the cluster name default.",
+          "type": "string"
+        },
+        "wal": {
+          "properties": {
+            "compression": {
+              "default": "",
+              "description": "WAL compression method. One of `` (for no compression), `gzip`, `bzip2`, `lz4`, `snappy`, `xz` or `zstd`.",
+              "type": "string"
+            },
+            "encryption": {
+              "default": "",
+              "description": "Whether to instruct the storage provider to encrypt WAL files. One of `` (use the storage container default), `AES256` or `aws:kms`.",
+              "type": "string"
+            },
+            "maxParallel": {
+              "default": 0,
+              "description": "Number of WAL files to be archived or restored in parallel. Set to 0 to omit the field.",
+              "type": "integer"
+            }
+          },
+          "required": [],
+          "type": "object"
+        }
+      },
+      "required": [],
+      "type": "object"
+    },
     "cluster": {
       "properties": {
         "additionalLabels": {

--- a/charts/cluster/values.yaml
+++ b/charts/cluster/values.yaml
@@ -502,6 +502,105 @@ backups:
   # -- Retention policy for backups
   retentionPolicy: "30d"
 
+barmanCloudPlugin:
+  # -- Enable the Barman Cloud CNPG-I plugin integration.
+  enabled: false
+  # -- Name of the installed CNPG-I plugin.
+  pluginName: barman-cloud.cloudnative-pg.io
+  # -- Optional server name plugin parameter. Leave empty for the cluster name default.
+  serverName: ""
+  # -- Additional plugin parameters rendered under spec.plugins[].parameters.
+  additionalPluginParameters: {}
+  objectStore:
+    # -- Name of the ObjectStore resource. Defaults to <release>-barman-store.
+    name: ""
+    annotations: {}
+  # -- ObjectStore retention policy.
+  retentionPolicy: "30d"
+  # -- Full object store destination path. If empty, s3.bucket and s3.path are used.
+  destinationPath: ""
+  # -- Object store endpoint URL. If empty and s3.region is set, AWS S3 endpoint is derived.
+  endpointURL: ""
+  # -- Optional endpoint CA reference.
+  endpointCA: {}
+  s3:
+    # -- AWS region used to derive the default S3 endpoint when endpointURL is empty.
+    region: ""
+    # -- S3 bucket used when destinationPath is empty.
+    bucket: ""
+    # -- S3 path used when destinationPath is empty.
+    path: "/"
+    # -- Use role-based authentication instead of explicit credentials.
+    inheritFromIAMRole: false
+    # -- Access key value, only used when s3.secret.create is true.
+    accessKey: ""
+    # -- Secret key value, only used when s3.secret.create is true.
+    secretKey: ""
+    secret:
+      # -- Whether the chart should create a Kubernetes Secret for S3 credentials.
+      create: false
+      # -- Name of the Secret containing S3 credentials. Defaults to <release>-barman-s3-creds.
+      name: ""
+      accessKeyIdKey: ACCESS_KEY_ID
+      secretAccessKeyKey: ACCESS_SECRET_KEY
+    externalSecret:
+      # -- Whether the chart should create an ExternalSecret for S3 credentials.
+      enabled: false
+      # -- Name of the ExternalSecret resource. Defaults to <secret name>-external-secret.
+      name: ""
+      annotations: {}
+      labels: {}
+      refreshInterval: 168h
+      secretStoreRef:
+        kind: ClusterSecretStore
+        name: ""
+      target:
+        creationPolicy: Owner
+        deletionPolicy: Retain
+        # -- Target Secret name. Defaults to barmanCloudPlugin.s3.secret.name or <release>-barman-s3-creds.
+        name: ""
+      remoteRefs:
+        accessKeyId:
+          key: ""
+          property: ""
+          conversionStrategy: Default
+          decodingStrategy: None
+          metadataPolicy: None
+        secretAccessKey:
+          key: ""
+          property: ""
+          conversionStrategy: Default
+          decodingStrategy: None
+          metadataPolicy: None
+  wal:
+    # -- WAL compression method. One of `` (for no compression), `gzip`, `bzip2`, `lz4`, `snappy`, `xz` or `zstd`.
+    compression: ""
+    # -- Whether to instruct the storage provider to encrypt WAL files. One of `` (use the storage container default), `AES256` or `aws:kms`.
+    encryption: ""
+    # -- Number of WAL files to be archived or restored in parallel. Set to 0 to omit the field.
+    maxParallel: 0
+  data:
+    # -- Data compression method. One of `` (for no compression), `gzip`, `bzip2`, `lz4` or `snappy`.
+    compression: ""
+    # -- Whether to instruct the storage provider to encrypt data files. One of `` (use the storage container default), `AES256` or `aws:kms`.
+    encryption: ""
+    # -- Number of data files to be archived in parallel. Set to 0 to omit the field.
+    jobs: 0
+  scheduledBackups:
+    -
+      # -- Scheduled backup name
+      name: daily-backup
+      # -- Schedule in cron format
+      schedule: "0 0 0 * * *"
+      # -- Backup owner reference
+      backupOwnerReference: self
+      # -- Plugin name override. Defaults to barmanCloudPlugin.pluginName.
+      pluginName: ""
+  # -- Additional fields rendered under ObjectStore spec.configuration.
+  additionalConfiguration: {}
+  # -- Optional ObjectStore spec.instanceSidecarConfiguration.
+  instanceSidecarConfiguration: {}
+
 replica:
   # --  Defines the name of this cluster. It is used to determine if this is a primary or a replica cluster, comparing it with primary. Leave empty by default.
   self: ""


### PR DESCRIPTION
## Summary

Add optional Barman Cloud CNPG-I plugin support to the cluster chart.

The new `barmanCloudPlugin` values block can:

- configure `Cluster.spec.plugins` with the Barman Cloud plugin as WAL archiver
- render a plugin `ObjectStore`
- create S3 credentials either as a Kubernetes `Secret` or an optional `ExternalSecret`
- create plugin-based `ScheduledBackup` resources

The feature is mutually exclusive with `backups.enabled`, because the CloudNativePG API does not allow a WAL archiver plugin and `spec.backup.barmanObjectStore` to be configured at the same time.

## Validation

- `make docs schema`
- `helm lint charts/cluster`
- `helm lint charts/cluster --values charts/cluster/examples/barman-cloud-plugin.yaml`
- `helm template test charts/cluster`
- `helm template test charts/cluster --set barmanCloudPlugin.enabled=true --set barmanCloudPlugin.s3.bucket=my-bucket --set barmanCloudPlugin.s3.inheritFromIAMRole=true`
- `helm template test charts/cluster --set barmanCloudPlugin.enabled=true --set barmanCloudPlugin.s3.bucket=my-bucket --set barmanCloudPlugin.s3.secret.create=true --set barmanCloudPlugin.s3.accessKey=access --set barmanCloudPlugin.s3.secretKey=secret`
- `helm template test charts/cluster --set barmanCloudPlugin.enabled=true --set barmanCloudPlugin.s3.bucket=my-bucket --set barmanCloudPlugin.s3.externalSecret.enabled=true --set barmanCloudPlugin.s3.externalSecret.secretStoreRef.name=my-store --set barmanCloudPlugin.s3.externalSecret.remoteRefs.accessKeyId.key=secret/data/s3 --set barmanCloudPlugin.s3.externalSecret.remoteRefs.accessKeyId.property=accessKey --set barmanCloudPlugin.s3.externalSecret.remoteRefs.secretAccessKey.key=secret/data/s3 --set barmanCloudPlugin.s3.externalSecret.remoteRefs.secretAccessKey.property=secretKey`
- `helm template barman-example charts/cluster --values charts/cluster/examples/barman-cloud-plugin.yaml`
