### PR TITLE
fix(cloudnative-pg): set deployment label selector env var to cloudnative-pg.name (#351)

### DIFF
--- a/charts/cloudnative-pg/templates/deployment.yaml
+++ b/charts/cloudnative-pg/templates/deployment.yaml
@@ -81,6 +81,8 @@ spec:
         command:
         - /manager
         env:
+        - name: DEPLOYMENT_LABEL_SELECTOR
+          value: "app.kubernetes.io/name={{ include "cloudnative-pg.name" . }}"
         - name: OPERATOR_IMAGE_NAME
           value: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         - name: OPERATOR_NAMESPACE


### PR DESCRIPTION
Allow for nameOverride and fullnameOverride to change the deployment name without causing an operator crash by specifying the `DEPLOYMENT_LABEL_SELECTOR` env var introduced by cloudnative-pg/cloudnative-pg#10965

Depends on mentioned PR on operator repository being merged.

Closes #351 