### PR TITLE
feat(#850): add extraObjects support to all charts

### DIFF
--- a/charts/cloudnative-pg/README.md
+++ b/charts/cloudnative-pg/README.md
@@ -128,6 +128,7 @@ Kubernetes: `>=1.29.0-0`
 | containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":10001,"runAsUser":10001,"seccompProfile":{"type":"RuntimeDefault"}}` | Container Security Context. |
 | crds.create | bool | `true` | Specifies whether the CRDs should be created when installing the chart. |
 | dnsPolicy | string | `""` |  |
+| extraObjects | list | `[]` | Extra Kubernetes manifests to deploy alongside this chart. Each entry is passed through `tpl`, so Helm templating is supported. |
 | fullnameOverride | string | `""` |  |
 | hostNetwork | bool | `false` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/cloudnative-pg/templates/extra-manifests.yaml
+++ b/charts/cloudnative-pg/templates/extra-manifests.yaml
@@ -1,0 +1,15 @@
+{{- /* Normalize extraObjects to a list, easier to loop over */ -}}
+{{- $extraObjects := .Values.extraObjects | default (list) -}}
+
+{{- if kindIs "map" $extraObjects -}}
+  {{- $extraObjects = values $extraObjects -}}
+{{- end -}}
+
+{{- range $extraObjects }}
+---
+  {{- if kindIs "map" . }}
+    {{- tpl (toYaml .) $ | nindent 0 }}
+  {{- else if kindIs "string" . }}
+    {{- tpl . $ | nindent 0 }}
+  {{- end }}
+{{- end }}

--- a/charts/cloudnative-pg/values.schema.json
+++ b/charts/cloudnative-pg/values.schema.json
@@ -127,6 +127,13 @@
       "default": "",
       "type": "string"
     },
+    "extraObjects": {
+      "description": "Extra Kubernetes manifests to deploy alongside the cloudnative-pg operator.\nEach entry is passed through `tpl`, so Helm templating is supported.",
+      "items": {
+        "required": []
+      },
+      "type": "array"
+    },
     "fullnameOverride": {
       "default": "",
       "type": "string"

--- a/charts/cloudnative-pg/values.yaml
+++ b/charts/cloudnative-pg/values.yaml
@@ -694,3 +694,23 @@ monitoringQueriesConfigMap:
             description: "An update is available"
       target_databases:
         - '*'
+
+# -- Extra Kubernetes manifests to deploy alongside this chart. Each entry is passed through `tpl`, so Helm templating is supported.
+extraObjects: []
+# - apiVersion: v1
+#   kind: ConfigMap
+#   metadata:
+#     name: "{{ include \"cloudnative-pg.fullname\" . }}-grafana-dashboard"
+#     labels:
+#       grafana_dashboard: "1"
+#   data:
+#     cnpg-dashboard.json: |-
+#       { ... }
+# - |
+#     apiVersion: v1
+#     kind: Secret
+#     type: Opaque
+#     metadata:
+#       name: cnpg-secret
+#     data:
+#       { ... }

--- a/charts/cluster/README.md
+++ b/charts/cluster/README.md
@@ -207,6 +207,7 @@ Kubernetes: `>=1.29.0-0`
 | cluster.walStorage.size | string | `"1Gi"` |  |
 | cluster.walStorage.storageClass | string | `""` |  |
 | databases | list | `[]` | Database management configuration. |
+| extraObjects | list | `[]` | Extra Kubernetes manifests to deploy alongside this chart. Each entry is passed through `tpl`, so Helm templating is supported. |
 | fullnameOverride | string | `""` | Override the full name of the chart |
 | imageCatalog.create | bool | `true` | Whether to provision an image catalog. If imageCatalog.images is empty this option will be ignored. |
 | imageCatalog.images | list | `[]` | List of images to be provisioned in an image catalog. |

--- a/charts/cluster/templates/extra-manifests.yaml
+++ b/charts/cluster/templates/extra-manifests.yaml
@@ -1,0 +1,15 @@
+{{- /* Normalize extraObjects to a list, easier to loop over */ -}}
+{{- $extraObjects := .Values.extraObjects | default (list) -}}
+
+{{- if kindIs "map" $extraObjects -}}
+  {{- $extraObjects = values $extraObjects -}}
+{{- end -}}
+
+{{- range $extraObjects }}
+---
+  {{- if kindIs "map" . }}
+    {{- tpl (toYaml .) $ | nindent 0 }}
+  {{- else if kindIs "string" . }}
+    {{- tpl . $ | nindent 0 }}
+  {{- end }}
+{{- end }}

--- a/charts/cluster/values.schema.json
+++ b/charts/cluster/values.schema.json
@@ -594,6 +594,13 @@
       },
       "type": "array"
     },
+    "extraObjects": {
+      "description": "Extra Kubernetes manifests to deploy alongside the cluster.\nEach entry is passed through `tpl`, so Helm templating is supported.",
+      "items": {
+        "required": []
+      },
+      "type": "array"
+    },
     "fullnameOverride": {
       "default": "",
       "description": "Override the full name of the chart",

--- a/charts/cluster/values.yaml
+++ b/charts/cluster/values.yaml
@@ -707,3 +707,23 @@ poolers: []
   #   # -- Custom PgBouncer deployment template.
   #   # Use to override image, specify resources, etc.
   #   template: {}
+
+# -- Extra Kubernetes manifests to deploy alongside this chart. Each entry is passed through `tpl`, so Helm templating is supported.
+extraObjects: []
+# - apiVersion: v1
+#   kind: ConfigMap
+#   metadata:
+#     name: "{{ include \"cluster.fullname\" . }}-grafana-dashboard"
+#     labels:
+#       grafana_dashboard: "1"
+#   data:
+#     cluster-dashboard.json: |-
+#       { ... }
+# - |
+#     apiVersion: v1
+#     kind: Secret
+#     type: Opaque
+#     metadata:
+#       name: cnpg-cluster-secret
+#     data:
+#       { ... }

--- a/charts/plugin-barman-cloud/README.md
+++ b/charts/plugin-barman-cloud/README.md
@@ -95,6 +95,7 @@ Kubernetes: `>=1.29.0-0`
 | containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":10001,"runAsUser":10001,"seccompProfile":{"type":"RuntimeDefault"}}` | Container Security Context. |
 | crds.create | bool | `true` | Specifies whether the CRDs should be created when installing the chart. |
 | dnsPolicy | string | `""` |  |
+| extraObjects | list | `[]` | Extra Kubernetes manifests to deploy alongside this chart. Each entry is passed through `tpl`, so Helm templating is supported. |
 | fullnameOverride | string | `""` |  |
 | hostNetwork | bool | `false` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/plugin-barman-cloud/templates/extra-manifests.yaml
+++ b/charts/plugin-barman-cloud/templates/extra-manifests.yaml
@@ -1,0 +1,15 @@
+{{- /* Normalize extraObjects to a list, easier to loop over */ -}}
+{{- $extraObjects := .Values.extraObjects | default (list) -}}
+
+{{- if kindIs "map" $extraObjects -}}
+  {{- $extraObjects = values $extraObjects -}}
+{{- end -}}
+
+{{- range $extraObjects }}
+---
+  {{- if kindIs "map" . }}
+    {{- tpl (toYaml .) $ | nindent 0 }}
+  {{- else if kindIs "string" . }}
+    {{- tpl . $ | nindent 0 }}
+  {{- end }}
+{{- end }}

--- a/charts/plugin-barman-cloud/values.schema.json
+++ b/charts/plugin-barman-cloud/values.schema.json
@@ -123,6 +123,13 @@
       "default": "",
       "type": "string"
     },
+    "extraObjects": {
+      "description": "Extra Kubernetes manifests to deploy alongside the barman cloud plugin.\nEach entry is passed through `tpl`, so Helm templating is supported.",
+      "items": {
+        "required": []
+      },
+      "type": "array"
+    },
     "fullnameOverride": {
       "default": "",
       "type": "string"

--- a/charts/plugin-barman-cloud/values.yaml
+++ b/charts/plugin-barman-cloud/values.yaml
@@ -195,3 +195,23 @@ certificate:
   duration: 2160h
   # -- The renew before time for the certificates.
   renewBefore: 360h
+
+# -- Extra Kubernetes manifests to deploy alongside this chart. Each entry is passed through `tpl`, so Helm templating is supported.
+extraObjects: []
+# - apiVersion: v1
+#   kind: ConfigMap
+#   metadata:
+#     name: "{{ include \"plugin-barman-cloud.fullname\" . }}-grafana-dashboard"
+#     labels:
+#       grafana_dashboard: "1"
+#   data:
+#     plugin-barman-cloud-dashboard.json: |-
+#       { ... }
+# - |
+#     apiVersion: v1
+#     kind: Secret
+#     type: Opaque
+#     metadata:
+#       name: plugin-barman-cloud-secret
+#     data:
+#       { ... }


### PR DESCRIPTION
This PR implements the `extraObjects` feature for all charts in this repository !

Initially the issue (#850) was only for the `cluster` chart but for the sake of consistency and because it might be useful for all the charts (for Grafana dashboards for instance) I added it to the other 2 charts as well. If you think that this is not needed in the other charts or if you want to separate the feature in multiple issues/commits/PR for the other charts, I'll remove it from the `cloudnative-pg` and `plugin-barman-cloud` charts.