### PR TITLE
test(cluster): raise scheduledbackups cleanup timeout to 10m

### DIFF
--- a/charts/cluster/test/barman-plugin-scheduledbackups/chainsaw-test.yaml
+++ b/charts/cluster/test/barman-plugin-scheduledbackups/chainsaw-test.yaml
@@ -7,7 +7,7 @@ spec:
   timeouts:
     apply: 1s
     assert: 2m
-    cleanup: 5m
+    cleanup: 10m
   steps:
     - name: Install the cluster with ScheduledBackups
       try:


### PR DESCRIPTION
The `barman-plugin-scheduledbackups` test intermittently fails with `context deadline exceeded` during cleanup. The test logic passes; only namespace teardown exceeds the 5m budget.

**Root cause:** the CNPG instance pod has `terminationGracePeriodSeconds=1800` and graceful Postgres shutdown (bounded by `smartShutdownTimeout` ~180s) takes ~2–3m. On GitHub runners (kind-in-Docker on a constrained VM) that stretches past 5m under load. No stuck finalizer — Cluster and ObjectStore carry none (the plugin sets no ObjectStore finalizer).

Verified by reproducing on an isolated, well-resourced cluster: full cleanup completes in ~3m (pod teardown ~2m + namespace GC ~40s). The 5m budget is simply too tight for the slow-runner case.

**Fix:** raise `cleanup: 5m → 10m`. Shutdown is bounded by `smartShutdownTimeout`, so this will not grow unbounded; 10m gives safe headroom. Confirmed green in fork CI.

Supplements #924.