### PR TITLE
feat(plugin-barman-cloud): make the ClusterRole's CNPG API group configurable

### DIFF
--- a/charts/plugin-barman-cloud/README.md
+++ b/charts/plugin-barman-cloud/README.md
@@ -109,6 +109,7 @@ Kubernetes: `>=1.29.0-0`
 | podLabels | object | `{}` | Labels to be added to the pod. |
 | podSecurityContext | object | `{"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Security Context for the whole pod. |
 | priorityClassName | string | `""` | Priority indicates the importance of a Pod relative to other Pods. |
+| rbac.cnpgGroup | string | `"postgresql.cnpg.io"` | The API group of the Cluster CRD the plugin is granted access to (get/list/watch on backups, update on clusters/finalizers). Override this if you run a CloudNativePG-based operator whose Cluster CRD lives under a different API group. |
 | rbac.create | bool | `true` | Specifies whether Role and RoleBinding should be created. |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |

--- a/charts/plugin-barman-cloud/templates/rbac.yaml
+++ b/charts/plugin-barman-cloud/templates/rbac.yaml
@@ -74,7 +74,7 @@ rules:
   - patch
   - update
 - apiGroups:
-  - postgresql.cnpg.io
+  - {{ .Values.rbac.cnpgGroup }}
   resources:
   - backups
   verbs:
@@ -82,7 +82,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - postgresql.cnpg.io
+  - {{ .Values.rbac.cnpgGroup }}
   resources:
   - clusters/finalizers
   verbs:

--- a/charts/plugin-barman-cloud/values.schema.json
+++ b/charts/plugin-barman-cloud/values.schema.json
@@ -217,6 +217,11 @@
     },
     "rbac": {
       "properties": {
+        "cnpgGroup": {
+          "default": "postgresql.cnpg.io",
+          "description": "The API group of the Cluster CRD the plugin is granted access to\n(get/list/watch on backups, update on clusters/finalizers). Override\nthis if you run a CloudNativePG-based operator whose Cluster CRD lives\nunder a different API group.",
+          "type": "string"
+        },
         "create": {
           "default": true,
           "description": "Specifies whether Role and RoleBinding should be created.",

--- a/charts/plugin-barman-cloud/values.yaml
+++ b/charts/plugin-barman-cloud/values.yaml
@@ -92,6 +92,11 @@ serviceAccount:
 rbac:
   # -- Specifies whether Role and RoleBinding should be created.
   create: true
+  # -- The API group of the Cluster CRD the plugin is granted access to
+  # (get/list/watch on backups, update on clusters/finalizers). Override
+  # this if you run a CloudNativePG-based operator whose Cluster CRD lives
+  # under a different API group.
+  cnpgGroup: postgresql.cnpg.io
 
 # @schema
 # additionalProperties: true


### PR DESCRIPTION
The ClusterRole grants get/list/watch on backups and update on clusters/finalizers only in the postgresql.cnpg.io API group. Any CloudNativePG-based operator whose Cluster CRD lives under a different API group can never satisfy Kubernetes' OwnerReferencesPermissionEnforcement admission check when the plugin creates its per-Cluster Role/RoleBinding with blockOwnerDeletion: true, so reconciliation gets stuck permanently for every plugin-backed Cluster.

Add rbac.cnpgGroup (default postgresql.cnpg.io) and template both rules with it, so operators built on a renamed CRD group can install this chart with one value set instead of hand-patching the ClusterRole after install.