### PR TITLE
feat(cluster): add tolerations support for cluster (#834)

### DIFF
--- a/charts/cluster/README.md
+++ b/charts/cluster/README.md
@@ -203,6 +203,7 @@ Kubernetes: `>=1.29.0-0`
 | cluster.storage.size | string | `"8Gi"` |  |
 | cluster.storage.storageClass | string | `""` |  |
 | cluster.superuserSecret | string | `""` |  |
+| cluster.tolerations | list | `[]` | Tolerations for Pods. |
 | cluster.walStorage.enabled | bool | `false` |  |
 | cluster.walStorage.size | string | `"1Gi"` |  |
 | cluster.walStorage.storageClass | string | `""` |  |

--- a/charts/cluster/templates/cluster.yaml
+++ b/charts/cluster/templates/cluster.yaml
@@ -38,6 +38,10 @@ spec:
   resources:
     {{- toYaml . | nindent 4 }}
   {{ end }}
+  {{- with .Values.cluster.tolerations }}
+  tolerations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.cluster.affinity }}
   affinity:
     {{- toYaml . | nindent 4 }}

--- a/charts/cluster/values.schema.json
+++ b/charts/cluster/values.schema.json
@@ -565,6 +565,13 @@
           "default": "",
           "type": "string"
         },
+        "tolerations": {
+          "description": "Tolerations for Pods.",
+          "items": {
+            "required": []
+          },
+          "type": "array"
+        },
         "walStorage": {
           "properties": {
             "enabled": {

--- a/charts/cluster/values.yaml
+++ b/charts/cluster/values.yaml
@@ -243,6 +243,9 @@ cluster:
   # -- The instances' log level, one of the following values: error, warning, info (default), debug, trace
   logLevel: "info"
 
+  # -- Tolerations for Pods.
+  tolerations: []
+
   # -- Affinity/Anti-affinity rules for Pods.
   # See: https://cloudnative-pg.io/documentation/current/cloudnative-pg.v1/#postgresql-cnpg-io-v1-AffinityConfiguration
   affinity:


### PR DESCRIPTION
# Summary

Adds `tolerations` as a configurable chart value for the cluster chart

# Motivation

Affinity is configurable for the chart but not tolerations. The #834 issue was opened and closed automatically as there was no activity. It seems logical to be able to configure this option in the chart.

## Backwards compatibility

-   No breaking changes