### PR TITLE
chore(cluster): tidy stray whitespace in rendered manifests

### DIFF
--- a/charts/cluster/templates/_backup.tpl
+++ b/charts/cluster/templates/_backup.tpl
@@ -18,6 +18,6 @@ backup:
       jobs: {{ .Values.backups.data.jobs }}
 
     {{- $d := dict "chartFullname" (include "cluster.fullname" .) "scope" .Values.backups "secretPrefix" "backup" }}
-    {{- include "cluster.barmanObjectStoreConfig" $d | nindent 2 }}
+    {{- include "cluster.barmanObjectStoreConfig" $d | trimPrefix "\n" | nindent 2 }}
 {{- end }}
 {{- end }}

--- a/charts/cluster/templates/_bootstrap.tpl
+++ b/charts/cluster/templates/_bootstrap.tpl
@@ -33,13 +33,13 @@ bootstrap:
   {{- if eq .Values.recovery.method "pg_basebackup" }}
   pg_basebackup:
     source: pgBaseBackupSource
-    {{ with .Values.recovery.pgBaseBackup.database }}
+    {{- with .Values.recovery.pgBaseBackup.database }}
     database: {{ . }}
     {{- end }}
-    {{ with .Values.recovery.pgBaseBackup.owner }}
+    {{- with .Values.recovery.pgBaseBackup.owner }}
     owner: {{ . }}
     {{- end }}
-    {{ with .Values.recovery.pgBaseBackup.secretName }}
+    {{- with .Values.recovery.pgBaseBackup.secretName }}
     secret:
       name: {{ . }}
     {{- end }}
@@ -58,19 +58,19 @@ bootstrap:
         externalCluster: importSource
       type: {{ .Values.recovery.import.type }}
       databases: {{ .Values.recovery.import.databases | toJson }}
-      {{ with .Values.recovery.import.roles }}
+      {{- with .Values.recovery.import.roles }}
       roles: {{ . | toJson }}
       {{- end }}
-      {{ with .Values.recovery.import.postImportApplicationSQL }}
+      {{- with .Values.recovery.import.postImportApplicationSQL }}
       postImportApplicationSQL:
         {{- . | toYaml | nindent 6 }}
       {{- end }}
       schemaOnly: {{ .Values.recovery.import.schemaOnly }}
-      {{ with .Values.recovery.import.pgDumpExtraOptions }}
+      {{- with .Values.recovery.import.pgDumpExtraOptions }}
       pgDumpExtraOptions:
         {{- . | toYaml | nindent 6 }}
       {{- end }}
-      {{ with .Values.recovery.import.pgRestoreExtraOptions }}
+      {{- with .Values.recovery.import.pgRestoreExtraOptions }}
       pgRestoreExtraOptions:
         {{- . | toYaml | nindent 6 }}
       {{- end }}
@@ -80,10 +80,10 @@ bootstrap:
     recoveryTarget:
       targetTime: {{ . }}
     {{- end }}
-    {{ with .Values.recovery.database }}
+    {{- with .Values.recovery.database }}
     database: {{ . }}
     {{- end }}
-    {{ with .Values.recovery.owner }}
+    {{- with .Values.recovery.owner }}
     owner: {{ . }}
     {{- end }}
     {{- if eq .Values.recovery.method "backup" }}
@@ -99,26 +99,26 @@ bootstrap:
   {{- if eq .Values.replica.bootstrap.source "pg_basebackup" }}
   pg_basebackup:
     source: originCluster
-    {{ with .Values.replica.bootstrap.database }}
+    {{- with .Values.replica.bootstrap.database }}
     database: {{ . }}
     {{- end }}
-    {{ with .Values.replica.bootstrap.owner }}
+    {{- with .Values.replica.bootstrap.owner }}
     owner: {{ . }}
     {{- end }}
-    {{ with .Values.replica.bootstrap.secret }}
+    {{- with .Values.replica.bootstrap.secret }}
     secret:
       {{- toYaml . | nindent 6 }}
     {{- end }}
   {{- else if eq .Values.replica.bootstrap.source "object_store" }}
   recovery:
     source: originCluster
-    {{ with .Values.replica.bootstrap.database }}
+    {{- with .Values.replica.bootstrap.database }}
     database: {{ . }}
     {{- end }}
-    {{ with .Values.replica.bootstrap.owner }}
+    {{- with .Values.replica.bootstrap.owner }}
     owner: {{ . }}
     {{- end }}
-    {{ with .Values.replica.bootstrap.secret }}
+    {{- with .Values.replica.bootstrap.secret }}
     secret:
       {{- toYaml . | nindent 6 }}
     {{- end }}
@@ -132,16 +132,16 @@ bootstrap:
 replica:
   enabled: true
   source: originCluster
-  {{ with .Values.replica.self }}
+  {{- with .Values.replica.self }}
   self: {{ . }}
   {{- end }}
-  {{ with .Values.replica.primary }}
+  {{- with .Values.replica.primary }}
   primary: {{ . }}
   {{- end }}
-  {{ with .Values.replica.promotionToken }}
+  {{- with .Values.replica.promotionToken }}
   promotionToken: {{ . }}
   {{- end }}
-  {{ with .Values.replica.minApplyDelay }}
+  {{- with .Values.replica.minApplyDelay }}
   minApplyDelay: {{ . }}
   {{- end }}
 {{- end }}

--- a/charts/cluster/templates/_external_clusters.tpl
+++ b/charts/cluster/templates/_external_clusters.tpl
@@ -16,16 +16,16 @@ externalClusters:
     barmanObjectStore:
       serverName: {{ .Values.recovery.clusterName }}
       {{- $d := dict "chartFullname" (include "cluster.fullname" .) "scope" .Values.recovery "secretPrefix" "recovery" -}}
-      {{- include "cluster.barmanObjectStoreConfig" $d | nindent 4 }}
+      {{- include "cluster.barmanObjectStoreConfig" $d | trimPrefix "\n" | nindent 4 }}
   {{- else if and (eq .Values.recovery.method "plugin") (eq .Values.recovery.pluginConfiguration.name "barman-cloud.cloudnative-pg.io") }}
   - name: pluginRecoveryCluster
     plugin:
       {{- omit .Values.recovery.pluginConfiguration "parameters" | toYaml | nindent 6 }}
       parameters:
         {{- $pluginConfigurationParameters := omit (coalesce .Values.recovery.pluginConfiguration.parameters dict) "barmanObjectName" "serverName" -}}
-        {{ with $pluginConfigurationParameters }}
+        {{- with $pluginConfigurationParameters }}
         {{- toYaml . | nindent 8 -}}
-        {{ end }}
+        {{- end }}
         barmanObjectName: {{ include "cluster.fullname" . }}-recovery
         serverName: {{ .Values.recovery.clusterName }}
   {{- end }}
@@ -35,7 +35,7 @@ externalClusters:
     barmanObjectStore:
       serverName: {{ .Values.replica.origin.objectStore.clusterName }}
       {{- $d := dict "chartFullname" (include "cluster.fullname" .) "scope" .Values.replica.origin.objectStore "secretPrefix" "origin" -}}
-      {{- include "cluster.barmanObjectStoreConfig" $d | nindent 4 -}}
+      {{- include "cluster.barmanObjectStoreConfig" $d | trimPrefix "\n" | nindent 4 -}}
   {{- end }}
   {{- if not (empty .Values.replica.origin.pg_basebackup.host) }}
     {{- include "cluster.externalSourceCluster" .Values.replica.origin.pg_basebackup | nindent 4 }}
@@ -44,4 +44,4 @@ externalClusters:
   {{ fail "Invalid cluster mode!" }}
 {{- end }}
 {{- end }}
-{{ end }}
+{{- end }}

--- a/charts/cluster/templates/cluster.yaml
+++ b/charts/cluster/templates/cluster.yaml
@@ -10,11 +10,11 @@ metadata:
   labels:
   {{- include "cluster.labels" . | nindent 4 }}
   {{- with .Values.cluster.additionalLabels }}
-    {{ toYaml . | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   instances: {{ .Values.cluster.instances }}
-  {{- include "cluster.image" . | nindent 2 }}
+  {{- include "cluster.image" . | trim | nindent 2 }}
   imagePullPolicy: {{ .Values.cluster.imagePullPolicy }}
   {{- with .Values.cluster.imagePullSecrets }}
   imagePullSecrets:
@@ -37,7 +37,7 @@ spec:
   {{- with .Values.cluster.resources }}
   resources:
     {{- toYaml . | nindent 4 }}
-  {{ end }}
+  {{- end }}
   {{- with .Values.cluster.affinity }}
   affinity:
     {{- toYaml . | nindent 4 }}
@@ -63,12 +63,12 @@ spec:
   {{- with .Values.cluster.certificates }}
   certificates:
     {{- toYaml . | nindent 4 }}
-  {{ end }}
+  {{- end }}
   enableSuperuserAccess: {{ .Values.cluster.enableSuperuserAccess }}
   {{- with .Values.cluster.superuserSecret }}
   superuserSecret:
     name: {{ . }}
-  {{ end }}
+  {{- end }}
   enablePDB: {{ .Values.cluster.enablePDB }}
   postgresql:
     {{- if or (eq .Values.type "timescaledb") (not (empty .Values.cluster.postgresql.shared_preload_libraries)) .Values.cluster.monitoring.instrumentation.pgStatStatements }}
@@ -98,7 +98,7 @@ spec:
     {{- with .Values.cluster.postgresql.synchronous }}
     synchronous:
       {{- toYaml . | nindent 6 }}
-    {{ end }}
+    {{- end }}
     {{- with .Values.cluster.postgresql.parameters }}
     parameters:
       {{- toYaml . | nindent 6 }}
@@ -114,11 +114,11 @@ spec:
     {{- with .Values.cluster.services }}
     services:
       {{- toYaml . | nindent 6 }}
-    {{ end }}
+    {{- end }}
     {{- with .Values.cluster.roles }}
     roles:
       {{- toYaml . | nindent 6 }}
-    {{ end }}
+    {{- end }}
   {{- end }}
 
   {{- with .Values.cluster.serviceAccountTemplate }}
@@ -129,12 +129,12 @@ spec:
   {{- with .Values.cluster.podSecurityContext }}
   podSecurityContext:
     {{- toYaml . | nindent 4 }}
-  {{ end }}
+  {{- end }}
 
   {{- with .Values.cluster.securityContext }}
   securityContext:
     {{- toYaml . | nindent 4 }}
-  {{ end }}
+  {{- end }}
 
   monitoring:
     disableDefaultQueries: {{ .Values.cluster.monitoring.disableDefaultQueries }}
@@ -147,7 +147,7 @@ spec:
     {{- with .Values.cluster.monitoring.customQueriesSecret }}
     customQueriesSecret:
       {{- toYaml . | nindent 6 }}
-    {{ end }}
+    {{- end }}
     {{- end }}
     tls:
       enabled: {{ .Values.cluster.monitoring.tls.enabled }}

--- a/charts/cluster/templates/databases.yaml
+++ b/charts/cluster/templates/databases.yaml
@@ -12,7 +12,7 @@ metadata:
   labels:
   {{- include "cluster.labels" $ | nindent 4 }}
   {{- with $.Values.cluster.additionalLabels }}
-    {{ toYaml . | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   name: {{ .name }}

--- a/charts/cluster/templates/prometheus-rule.yaml
+++ b/charts/cluster/templates/prometheus-rule.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "cluster.labels" . | nindent 4 }}
     {{- with .Values.cluster.additionalLabels }}
-      {{ toYaml . | nindent 4 }}
+      {{- toYaml . | nindent 4 }}
     {{- end }}
   name: {{ include "cluster.fullname" . }}-alert-rules
   namespace: {{ include "cluster.namespace" . }}
@@ -27,4 +27,4 @@ spec:
         - {{ $tpl }}
         {{- end -}}
         {{- end -}}
-{{ end }}
+{{- end }}

--- a/charts/cluster/templates/scheduled-backups.yaml
+++ b/charts/cluster/templates/scheduled-backups.yaml
@@ -19,6 +19,6 @@ spec:
   {{- with .pluginConfiguration }}
   pluginConfiguration:
     {{- toYaml . | nindent 4 }}
-  {{ end }}
+  {{- end }}
 {{ end -}}
 {{ end }}


### PR DESCRIPTION
I caught these while working on the @paradedb fork. Figured they'd benefit upstream and reduce our diff.

Several `cluster` templates merge their content via Go-template actions that don't trim newlines, so the rendered `Cluster` / `Database` / `ScheduledBackup` / `PrometheusRule` carry stray blank lines — harmless (YAML ignores them) but noisy in `helm diff` plans. This tightens the whitespace control (`{{- … }}`):

- `cluster.yaml`: trim the `{{ end }}` on `resources`/`certificates`/`superuserSecret`/`synchronous`/`services`/`roles`/`podSecurityContext`/`securityContext`/`customQueriesSecret`, the `additionalLabels` `toYaml`, and the leading blank from the `cluster.image` include
- `_bootstrap.tpl`: trim the `{{ with }}` recovery/replica blocks that emitted a blank line for every optional field, even when unset
- `_backup.tpl` / `_external_clusters.tpl`: `trimPrefix "\n"` before `nindent` so the shared `barmanObjectStore` config no longer leaves a blank under `wal`/`data`; trim the plugin-recovery `parameters` `{{ with }}` and its `{{ end }}`
- `databases.yaml`, `prometheus-rule.yaml`, `scheduled-backups.yaml`: trim the `additionalLabels` `toYaml` and trailing `{{ end }}`

No behavioral change — rendered output is byte-identical modulo the removed blanks. Verified by diffing blank-stripped renders of every `charts/cluster/test/**/*_cluster.yaml` fixture (all content-identical, valid YAML, multi-`ScheduledBackup` still 2-in/2-out). `helm lint` passes.

Enjoy!