### PR TITLE
fix(cluster): consistent labels across all cluster chart resources

### DIFF
--- a/charts/cluster/templates/_helpers.tpl
+++ b/charts/cluster/templates/_helpers.tpl
@@ -51,6 +51,9 @@ helm.sh/chart: {{ include "cluster.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.cluster.additionalLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/cluster/templates/backup-azure-creds.yaml
+++ b/charts/cluster/templates/backup-azure-creds.yaml
@@ -4,6 +4,10 @@ kind: Secret
 metadata:
   name: {{ default (printf "%s-backup-azure-creds" (include "cluster.fullname" .)) .Values.backups.secret.name }}
   namespace: {{ include "cluster.namespace" . }}
+  labels:
+    cnpg.io/cluster: {{ include "cluster.fullname" . }}
+    {{- include "cluster.labels" . | nindent 4 }}
+    cnpg.io/reload: "true"
 data:
   AZURE_CONNECTION_STRING: {{ .Values.backups.azure.connectionString | b64enc | quote }}
   AZURE_STORAGE_ACCOUNT: {{ .Values.backups.azure.storageAccount | b64enc | quote }}

--- a/charts/cluster/templates/backup-google-creds.yaml
+++ b/charts/cluster/templates/backup-google-creds.yaml
@@ -4,6 +4,10 @@ kind: Secret
 metadata:
   name: {{ default (printf "%s-backup-google-creds" (include "cluster.fullname" .)) .Values.backups.secret.name }}
   namespace: {{ include "cluster.namespace" . }}
+  labels:
+    cnpg.io/cluster: {{ include "cluster.fullname" . }}
+    {{- include "cluster.labels" . | nindent 4 }}
+    cnpg.io/reload: "true"
 data:
   APPLICATION_CREDENTIALS: {{ .Values.backups.google.applicationCredentials | b64enc | quote }}
 {{- end }}

--- a/charts/cluster/templates/backup-objectstore.yaml
+++ b/charts/cluster/templates/backup-objectstore.yaml
@@ -12,9 +12,6 @@ metadata:
   labels:
     cnpg.io/cluster: {{ include "cluster.fullname" . }}
     {{- include "cluster.labels" . | nindent 4 }}
-    {{- with .Values.cluster.additionalLabels }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
 spec:
   retentionPolicy: {{ .Values.backups.retentionPolicy }}
   configuration:

--- a/charts/cluster/templates/backup-s3-creds.yaml
+++ b/charts/cluster/templates/backup-s3-creds.yaml
@@ -4,6 +4,10 @@ kind: Secret
 metadata:
   name: {{ default (printf "%s-backup-s3-creds" (include "cluster.fullname" .)) .Values.backups.secret.name }}
   namespace: {{ include "cluster.namespace" . }}
+  labels:
+    cnpg.io/cluster: {{ include "cluster.fullname" . }}
+    {{- include "cluster.labels" . | nindent 4 }}
+    cnpg.io/reload: "true"
 data:
   ACCESS_KEY_ID: {{ required ".Values.backups.s3.accessKey is required, but not specified." .Values.backups.s3.accessKey | b64enc | quote }}
   ACCESS_SECRET_KEY: {{ required ".Values.backups.s3.secretKey is required, but not specified." .Values.backups.s3.secretKey | b64enc | quote }}

--- a/charts/cluster/templates/ca-bundle.yaml
+++ b/charts/cluster/templates/ca-bundle.yaml
@@ -5,6 +5,10 @@ kind: Secret
 metadata:
   name: {{ .Values.backups.endpointCA.name | default (printf "%s-ca-bundle" (include "cluster.fullname" .)) | quote }}
   namespace: {{ include "cluster.namespace" . }}
+  labels:
+    cnpg.io/cluster: {{ include "cluster.fullname" . }}
+    {{- include "cluster.labels" . | nindent 4 }}
+    cnpg.io/reload: "true"
 data:
   {{ .Values.backups.endpointCA.key | default "ca-bundle.crt" | quote }}: {{ .Values.backups.endpointCA.value }}
 {{- end }}

--- a/charts/cluster/templates/cluster.yaml
+++ b/charts/cluster/templates/cluster.yaml
@@ -8,10 +8,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
-  {{- include "cluster.labels" . | nindent 4 }}
-  {{- with .Values.cluster.additionalLabels }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- include "cluster.labels" . | nindent 4 }}
 spec:
   instances: {{ .Values.cluster.instances }}
   {{- include "cluster.image" . | trim | nindent 2 }}

--- a/charts/cluster/templates/console-statefulset.yaml
+++ b/charts/cluster/templates/console-statefulset.yaml
@@ -9,10 +9,8 @@ metadata:
     {{- toYaml . | nindent 8 }}
   {{- end }}
   labels:
+    cnpg.io/cluster: {{ include "cluster.fullname" . }}
     {{- include "cluster.labels" . | nindent 4 }}
-    {{- with .Values.cluster.additionalLabels }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
     app.kubernetes.io/component: console
 spec:
   replicas: 1
@@ -37,9 +35,6 @@ spec:
       {{- end }}
       labels:
         {{- include "cluster.labels" . | nindent 8 }}
-        {{- with .Values.cluster.additionalLabels }}
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
         app.kubernetes.io/component: console
     spec:
       terminationGracePeriodSeconds: 2

--- a/charts/cluster/templates/databases.yaml
+++ b/charts/cluster/templates/databases.yaml
@@ -10,10 +10,8 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
-  {{- include "cluster.labels" $ | nindent 4 }}
-  {{- with $.Values.cluster.additionalLabels }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+    cnpg.io/cluster: {{ include "cluster.fullname" $ }}
+    {{- include "cluster.labels" $ | nindent 4 }}
 spec:
   name: {{ .name }}
   cluster:

--- a/charts/cluster/templates/image-catalog-timescaledb-ha.yaml
+++ b/charts/cluster/templates/image-catalog-timescaledb-ha.yaml
@@ -4,6 +4,9 @@ kind: ImageCatalog
 metadata:
   name: {{ include "cluster.fullname" . }}-timescaledb-ha
   namespace: {{ include "cluster.namespace" . }}
+  labels:
+    cnpg.io/cluster: {{ include "cluster.fullname" . }}
+    {{- include "cluster.labels" . | nindent 4 }}
 spec:
   images:
     - major: 12

--- a/charts/cluster/templates/image-catalog.yaml
+++ b/charts/cluster/templates/image-catalog.yaml
@@ -4,6 +4,9 @@ kind: ImageCatalog
 metadata:
   name: {{ include "cluster.fullname" . }}
   namespace: {{ include "cluster.namespace" . }}
+  labels:
+    cnpg.io/cluster: {{ include "cluster.fullname" . }}
+    {{- include "cluster.labels" . | nindent 4 }}
 spec:
   images:
     {{- range $image := .Values.imageCatalog.images }}

--- a/charts/cluster/templates/monitoring-logical-replication.yaml
+++ b/charts/cluster/templates/monitoring-logical-replication.yaml
@@ -5,7 +5,8 @@ metadata:
   name: {{ include "cluster.fullname" . }}-monitoring-logical-replication
   namespace: {{ include "cluster.namespace" . }}
   labels:
-    cnpg.io/reload: ""
+    cnpg.io/reload: "true"
+    cnpg.io/cluster: {{ include "cluster.fullname" . }}
     {{- include "cluster.labels" . | nindent 4 }}
 data:
   custom-queries: |

--- a/charts/cluster/templates/monitoring-pg-stat-statements.yaml
+++ b/charts/cluster/templates/monitoring-pg-stat-statements.yaml
@@ -5,8 +5,9 @@ metadata:
   name: {{ include "cluster.fullname" . }}-monitoring-pg-stat-statements
   namespace: {{ include "cluster.namespace" . }}
   labels:
-    cnpg.io/reload: ""
+    cnpg.io/cluster: {{ include "cluster.fullname" . }}
     {{- include "cluster.labels" . | nindent 4 }}
+    cnpg.io/reload: "true"
 data:
   custom-queries: |
     pg_stat_statements:

--- a/charts/cluster/templates/origin-azure-creds.yaml
+++ b/charts/cluster/templates/origin-azure-creds.yaml
@@ -4,6 +4,10 @@ kind: Secret
 metadata:
   name: {{ default (printf "%s-origin-azure-creds" (include "cluster.fullname" .)) .Values.recovery.secret.name }}
   namespace: {{ include "cluster.namespace" . }}
+  labels:
+    cnpg.io/cluster: {{ include "cluster.fullname" . }}
+    {{- include "cluster.labels" . | nindent 4 }}
+    cnpg.io/reload: "true"
 data:
   AZURE_CONNECTION_STRING: {{ .Values.recovery.azure.connectionString | b64enc | quote }}
   AZURE_STORAGE_ACCOUNT: {{ .Values.recovery.azure.storageAccount | b64enc | quote }}

--- a/charts/cluster/templates/origin-google-creds.yaml
+++ b/charts/cluster/templates/origin-google-creds.yaml
@@ -4,6 +4,10 @@ kind: Secret
 metadata:
   name: {{ default (printf "%s-origin-google-creds" (include "cluster.fullname" .)) .Values.recovery.secret.name }}
   namespace: {{ include "cluster.namespace" . }}
+  labels:
+    cnpg.io/cluster: {{ include "cluster.fullname" . }}
+    {{- include "cluster.labels" . | nindent 4 }}
+    cnpg.io/reload: "true"
 data:
   APPLICATION_CREDENTIALS: {{ .Values.recovery.google.applicationCredentials | b64enc | quote }}
 {{- end }}

--- a/charts/cluster/templates/origin-pg_basebackup-password.yaml
+++ b/charts/cluster/templates/origin-pg_basebackup-password.yaml
@@ -4,6 +4,10 @@ kind: Secret
 metadata:
   name: {{ default (printf "%s-origin-pg-basebackup-password" (include "cluster.fullname" .)) .Values.replica.origin.pg_basebackup.passwordSecret.name }}
   namespace: {{ include "cluster.namespace" . }}
+  labels:
+    cnpg.io/cluster: {{ include "cluster.fullname" . }}
+    {{- include "cluster.labels" . | nindent 4 }}
+    cnpg.io/reload: "true"
 data:
   {{ .Values.replica.origin.pg_basebackup.passwordSecret.key }}: {{ required ".Values.replica.origin.pg_basebackup.passwordSecret.value required when creating a password secret." .Values.replica.origin.pg_basebackup.passwordSecret.value | b64enc | quote }}
 {{- end }}

--- a/charts/cluster/templates/origin-s3-creds.yaml
+++ b/charts/cluster/templates/origin-s3-creds.yaml
@@ -4,6 +4,10 @@ kind: Secret
 metadata:
   name: {{ default (printf "%s-origin-s3-creds" (include "cluster.fullname" .)) .Values.recovery.secret.name }}
   namespace: {{ include "cluster.namespace" . }}
+  labels:
+    cnpg.io/cluster: {{ include "cluster.fullname" . }}
+    {{- include "cluster.labels" . | nindent 4 }}
+    cnpg.io/reload: "true"
 data:
   ACCESS_KEY_ID: {{ required ".Values.replica.origin.objectStore.s3.accessKey is required, but not specified." .Values.replica.origin.objectStore.s3.accessKey | b64enc | quote }}
   ACCESS_SECRET_KEY: {{ required ".Values.replica.origin.objectStore.s3.secretKey is required, but not specified." .Values.replica.origin.objectStore.s3.secretKey | b64enc | quote }}

--- a/charts/cluster/templates/podmonitor-pooler.yaml
+++ b/charts/cluster/templates/podmonitor-pooler.yaml
@@ -16,6 +16,7 @@ metadata:
     {{- with $.Values.cluster.monitoring.podMonitor.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+    app.kubernetes.io/component: pooler
   {{- with $.Values.cluster.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/cluster/templates/pooler.yaml
+++ b/charts/cluster/templates/pooler.yaml
@@ -5,6 +5,10 @@ kind: Pooler
 metadata:
   name: {{ include "cluster.fullname" $  }}-pooler-{{ .name }}
   namespace: {{ include "cluster.namespace" $ }}
+  labels:
+    cnpg.io/cluster: {{ include "cluster.fullname" $ }}
+    {{- include "cluster.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: pooler
 spec:
   cluster:
     name: {{ include "cluster.fullname" $ }}

--- a/charts/cluster/templates/prometheus-rule.yaml
+++ b/charts/cluster/templates/prometheus-rule.yaml
@@ -3,10 +3,8 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   labels:
+    cnpg.io/cluster: {{ include "cluster.fullname" . }}
     {{- include "cluster.labels" . | nindent 4 }}
-    {{- with .Values.cluster.additionalLabels }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
   name: {{ include "cluster.fullname" . }}-alert-rules
   namespace: {{ include "cluster.namespace" . }}
 spec:

--- a/charts/cluster/templates/recovery-azure-creds.yaml
+++ b/charts/cluster/templates/recovery-azure-creds.yaml
@@ -4,6 +4,9 @@ kind: Secret
 metadata:
   name: {{ default (printf "%s-recovery-azure-creds" (include "cluster.fullname" .)) .Values.recovery.secret.name }}
   namespace: {{ include "cluster.namespace" . }}
+  labels:
+    cnpg.io/cluster: {{ include "cluster.fullname" . }}
+    {{- include "cluster.labels" . | nindent 4 }}
 data:
   AZURE_CONNECTION_STRING: {{ .Values.recovery.azure.connectionString | b64enc | quote }}
   AZURE_STORAGE_ACCOUNT: {{ .Values.recovery.azure.storageAccount | b64enc | quote }}

--- a/charts/cluster/templates/recovery-google-creds.yaml
+++ b/charts/cluster/templates/recovery-google-creds.yaml
@@ -4,6 +4,9 @@ kind: Secret
 metadata:
   name: {{ default (printf "%s-recovery-google-creds" (include "cluster.fullname" .)) .Values.recovery.secret.name }}
   namespace: {{ include "cluster.namespace" . }}
+  labels:
+    cnpg.io/cluster: {{ include "cluster.fullname" . }}
+    {{- include "cluster.labels" . | nindent 4 }}
 data:
   APPLICATION_CREDENTIALS: {{ .Values.recovery.google.applicationCredentials | b64enc | quote }}
 {{- end }}

--- a/charts/cluster/templates/recovery-objectstore.yaml
+++ b/charts/cluster/templates/recovery-objectstore.yaml
@@ -12,9 +12,6 @@ metadata:
   labels:
     cnpg.io/cluster: {{ include "cluster.fullname" . }}
     {{- include "cluster.labels" . | nindent 4 }}
-    {{- with .Values.cluster.additionalLabels }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
 spec:
   configuration:
     {{- $d := dict "chartFullname" (include "cluster.fullname" .) "scope" .Values.recovery "secretPrefix" "recovery" -}}

--- a/charts/cluster/templates/recovery-pg_basebackup-password.yaml
+++ b/charts/cluster/templates/recovery-pg_basebackup-password.yaml
@@ -4,6 +4,9 @@ kind: Secret
 metadata:
   name: {{ default (printf "%s-pg-basebackup-password" (include "cluster.fullname" .)) .Values.recovery.pgBaseBackup.source.passwordSecret.name }}
   namespace: {{ include "cluster.namespace" . }}
+  labels:
+    cnpg.io/cluster: {{ include "cluster.fullname" . }}
+    {{- include "cluster.labels" . | nindent 4 }}
 data:
   {{ .Values.recovery.pgBaseBackup.source.passwordSecret.key }}: {{ required ".Values.recovery.pgBaseBackup.source.passwordSecret.value required when creating a password secret." .Values.recovery.pgBaseBackup.source.passwordSecret.value | b64enc | quote }}
 {{- end }}

--- a/charts/cluster/templates/recovery-s3-creds.yaml
+++ b/charts/cluster/templates/recovery-s3-creds.yaml
@@ -4,6 +4,9 @@ kind: Secret
 metadata:
   name: {{ default (printf "%s-recovery-s3-creds" (include "cluster.fullname" .)) .Values.recovery.secret.name }}
   namespace: {{ include "cluster.namespace" . }}
+  labels:
+    cnpg.io/cluster: {{ include "cluster.fullname" . }}
+    {{- include "cluster.labels" . | nindent 4 }}
 data:
   ACCESS_KEY_ID: {{ required ".Values.recovery.s3.accessKey is required, but not specified." .Values.recovery.s3.accessKey | b64enc | quote }}
   ACCESS_SECRET_KEY: {{ required ".Values.recovery.s3.secretKey is required, but not specified." .Values.recovery.s3.secretKey | b64enc | quote }}

--- a/charts/cluster/templates/scheduled-backups.yaml
+++ b/charts/cluster/templates/scheduled-backups.yaml
@@ -1,21 +1,22 @@
 {{ if .Values.backups.enabled }}
-{{ $context := . -}}
 {{ range .Values.backups.scheduledBackups -}}
 ---
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:
-  name: {{ include "cluster.fullname" $context }}-{{ .name }}
-  namespace: {{ include "cluster.namespace" $context }}
+  name: {{ include "cluster.fullname" $ }}-{{ .name }}
+  namespace: {{ include "cluster.namespace" $ }}
   labels:
-    {{- include "cluster.labels" $context | nindent 4 }}
+    cnpg.io/cluster: {{ include "cluster.fullname" $ }}
+    {{- include "cluster.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: backups
 spec:
   immediate: true
   schedule: {{ .schedule | quote }}
   method: {{ .method }}
   backupOwnerReference: {{ .backupOwnerReference }}
   cluster:
-    name: {{ include "cluster.fullname" $context }}
+    name: {{ include "cluster.fullname" $ }}
   {{- with .pluginConfiguration }}
   pluginConfiguration:
     {{- toYaml . | nindent 4 }}

--- a/charts/cluster/templates/tests/ping.yaml
+++ b/charts/cluster/templates/tests/ping.yaml
@@ -4,6 +4,8 @@ metadata:
   name: {{ include "cluster.fullname" . }}-ping-test
   namespace: {{ include "cluster.namespace" . }}
   labels:
+    cnpg.io/cluster: {{ include "cluster.fullname" . }}
+    {{- include "cluster.labels" . | nindent 4 }}
     app.kubernetes.io/component: database-ping-test
   annotations:
     "helm.sh/hook": test

--- a/charts/cluster/templates/user-metrics.yaml
+++ b/charts/cluster/templates/user-metrics.yaml
@@ -5,8 +5,9 @@ metadata:
   name: {{ include "cluster.fullname" . }}-monitoring
   namespace: {{ include "cluster.namespace" . }}
   labels:
-    cnpg.io/reload: ""
+    cnpg.io/cluster: {{ include "cluster.fullname" . }}
     {{- include "cluster.labels" . | nindent 4 }}
+    cnpg.io/reload: "true"
 data:
   custom-queries: |
     {{- range .Values.cluster.monitoring.customQueries }}

--- a/charts/cluster/test/postgresql-cluster-configuration/01-non_default_configuration_cluster-assert.yaml
+++ b/charts/cluster/test/postgresql-cluster-configuration/01-non_default_configuration_cluster-assert.yaml
@@ -154,3 +154,11 @@ spec:
         - NET_BIND_SERVICE
     readOnlyRootFilesystem: true
     runAsNonRoot: true
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    foo: bar
+    cnpg.io/reload: "true"
+    cnpg.io/cluster: non-default-configuration-cluster


### PR DESCRIPTION
Fixes:
* Adds the `cnpg.io/cluster` label on resources created by the chart so they can be pin-pointed to the cluster they blong to.
* Applies `cluster.additionalLabels` to all resources
* Fixes: `cnpg.io/reload: ""` to `cnpg.io/reload: "true"`
* Adds `app.kubernetes.io/component` label to backups, poolers and the helm test

The end objective is to have consistent labels across all resources created by the chart.