### PR TITLE
fix(ci): don't re-push unchanged charts to GHCR

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -80,10 +80,21 @@ jobs:
             if [ -z "${pkg:-}" ]; then
               break
             fi
-            helm push "${pkg}" oci://ghcr.io/"${GITHUB_REPOSITORY}"
             file=${pkg##*/}
             name=${file%-*}
             version=${file%.*}
             version=${version##*-}
+
+            # cr packages any chart with files changed since the last tag, not
+            # just ones whose version was bumped, and CR_SKIP_EXISTING only gates
+            # the GitHub release. Skip versions already in GHCR, otherwise an
+            # unrelated edit republishes a chart under an unchanged tag with a
+            # new digest.
+            if helm show chart oci://ghcr.io/"${GITHUB_REPOSITORY}"/"${name}" --version "${version}" > /dev/null 2>&1; then
+              echo "Skipping ${name} ${version}: already published to GHCR"
+              continue
+            fi
+
+            helm push "${pkg}" oci://ghcr.io/"${GITHUB_REPOSITORY}"
             cosign sign --yes ghcr.io/"${GITHUB_REPOSITORY}"/"${name}":"${version}"
           done

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
 
+# Two quick merges/pushes to main can cause a chart publish race condition
+concurrency:
+  group: chart-release
+  cancel-in-progress: false
+
 permissions: read-all
 
 jobs:
@@ -77,22 +82,25 @@ jobs:
         run: |
           shopt -s nullglob
           for pkg in .cr-release-packages/*.tgz; do
-            if [ -z "${pkg:-}" ]; then
-              break
-            fi
-            file=${pkg##*/}
-            name=${file%-*}
-            version=${file%.*}
-            version=${version##*-}
+            name=$(helm show chart "${pkg}" | yq -r '.name')
+            version=$(helm show chart "${pkg}" | yq -r '.version')
+            repo="${GITHUB_REPOSITORY}/${name}"
 
             # cr packages any chart with files changed since the last tag, not
             # just ones whose version was bumped, and CR_SKIP_EXISTING only gates
             # the GitHub release. Skip versions already in GHCR, otherwise an
             # unrelated edit republishes a chart under an unchanged tag with a
             # new digest.
-            if helm show chart oci://ghcr.io/"${GITHUB_REPOSITORY}"/"${name}" --version "${version}" > /dev/null 2>&1; then
-              echo "Skipping ${name} ${version}: already published to GHCR"
+            if output=$(helm show chart oci://ghcr.io/"${GITHUB_REPOSITORY}"/"${name}" \
+                --version "${version}" 2>&1); then
+              echo "::notice::Skipping ${name} ${version}: already published to GHCR"
               continue
+            elif grep -q "not found" <<< "${output}"; then
+              : # genuinely absent — fall through to push and sign
+            else
+              echo "::error::Cannot verify ${name} ${version} in GHCR; refusing to push blind"
+              echo "${output}"
+              exit 1
             fi
 
             helm push "${pkg}" oci://ghcr.io/"${GITHUB_REPOSITORY}"

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -84,15 +84,14 @@ jobs:
           for pkg in .cr-release-packages/*.tgz; do
             name=$(helm show chart "${pkg}" | yq -r '.name')
             version=$(helm show chart "${pkg}" | yq -r '.version')
-            repo="${GITHUB_REPOSITORY}/${name}"
+            repo="ghcr.io/${GITHUB_REPOSITORY}/${name}"
 
             # cr packages any chart with files changed since the last tag, not
             # just ones whose version was bumped, and CR_SKIP_EXISTING only gates
             # the GitHub release. Skip versions already in GHCR, otherwise an
             # unrelated edit republishes a chart under an unchanged tag with a
             # new digest.
-            if output=$(helm show chart oci://ghcr.io/"${GITHUB_REPOSITORY}"/"${name}" \
-                --version "${version}" 2>&1); then
+            if output=$(helm show chart oci://"${repo}" --version "${version}" 2>&1); then
               echo "::notice::Skipping ${name} ${version}: already published to GHCR"
               continue
             elif grep -q "not found" <<< "${output}"; then
@@ -104,5 +103,5 @@ jobs:
             fi
 
             helm push "${pkg}" oci://ghcr.io/"${GITHUB_REPOSITORY}"
-            cosign sign --yes ghcr.io/"${GITHUB_REPOSITORY}"/"${name}":"${version}"
+            cosign sign --yes "${repo}:${version}"
           done


### PR DESCRIPTION
The `release-publish` workflow re-pushed and re-signed charts to GHCR on every push to `main`, which made the OCI tags effectively mutable. Pulling `oci://ghcr.io/cloudnative-pg/charts/...` by tag could return different content for the same version, digest pins stopped matching what was published under the tag, and the cosign signature for a tag was not stable over time.

This adds a check for whether a version is already published to GHCR, and skips it if so. The name/version parsing moves above the push, since the check needs it.

```bash
if helm show chart oci://ghcr.io/"${GITHUB_REPOSITORY}"/"${name}" --version "${version}" > /dev/null 2>&1; then
  echo "Skipping ${name} ${version}: already published to GHCR"
  continue
fi
```

The fix isn't introducing a new policy so much as restoring parity: `cr` already skips both the GitHub release and the repo index for a version that exists, and the GHCR push was the one publishing path with no equivalent guard. All three targets now agree.

Closes #952. Refs #561, which reported the same root cause and was closed by the stale bot without a fix.

### Root cause

The GHCR push is a custom step bolted on after `cr`, so it sits outside `cr`'s skip-existing logic entirely, and `helm push` has no skip-if-exists semantics — it just overwrites the tag.

One correction to the analysis in #952, from reading `chart-releaser-action` v1.7.0's `cr.sh`: `cr` does **not** package every chart in the repo unconditionally. `lookup_changed_charts` does `git diff --name-only <latest_tag> -- charts/`, so it packages charts with *any file* changed since the last tag. That is still broader than "the version was bumped", so the bug and the reproduction in the issue both stand — a commit touching `charts/plugin-barman-cloud/templates/rbac.yaml` with no `Chart.yaml` bump does get repackaged and re-pushed — but the mechanism is file-level, not unconditional.

### Why the gh-pages Helm repo was never affected

Worth recording, since it explains why this only ever bit the OCI path. In `chart-releaser` v1.7.0:

- `CR_SKIP_EXISTING` makes `CreateReleases` call `GetRelease` and `continue` past `CreateRelease` (`releaser.go:332-337`), so the `.tgz` asset attached to an existing release is never re-uploaded.
- `UpdateIndexFile` only calls `addToIndexFile` when `indexFile.Get(packageName, packageVersion)` returns an error, i.e. only when the entry is missing. For an already-published version nothing is added, `update` stays `false`, and it returns early with "Index did not change" before any write, commit or push.

So `cr` still repackages the chart into `.cr-release-packages/` on a no-bump push, but the classic path simply discards that local `.tgz`. Only the GHCR step consumed it.

### Note on `changed_charts`

The action exposes a `changed_charts` output whose description makes it look like the natural gate here. It isn't usable for this: it's populated from the same file-level diff against the last tag, so it lists charts that were repackaged without a version bump.

### Note on triggering from releases instead

#952 suggests gating the workflow on an actual version change, and triggering from the release/tag events would be the cleaner expression of that — `RELEASE.md` already describes that design ("A release `cloudnative-pg-vX.Y.Z` should be automatically created by an action, which will then trigger the release action").

That is not viable without a token change. `cr` creates the releases with `CR_TOKEN: secrets.GITHUB_TOKEN`, and events triggered by `GITHUB_TOKEN` [do not create new workflow runs](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow) — the exceptions are `workflow_dispatch`, `repository_dispatch` and `pull_request`, not `release` or `push: tags`. An `on: release: published` workflow would silently never fire and charts would stop reaching GHCR altogether.

Making it work needs `CR_TOKEN` switched to a PAT (the repo already has `REPO_GHA_PAT`, used by `release-pr.yml`), which trades the current failure mode for publishing that breaks quietly if the PAT expires. That felt like a maintainer decision rather than something to bundle into this fix, so I've kept the change self-contained. Happy to follow up with the split if you'd prefer it.

The check here also has the property that it self-heals: if a GHCR push fails after the release is created, the next run retries it, whereas a purely event-driven trigger would miss it permanently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
