### PR TITLE
feat(cluster): support named recovery target

### DIFF
--- a/charts/cluster/README.md
+++ b/charts/cluster/README.md
@@ -319,7 +319,9 @@ Kubernetes: `>=1.29.0-0`
 | recovery.pgBaseBackup.source.sslRootCertSecret.key | string | `""` |  |
 | recovery.pgBaseBackup.source.sslRootCertSecret.name | string | `""` |  |
 | recovery.pgBaseBackup.source.username | string | `""` |  |
-| recovery.pitrTarget | object | `{"time":""}` | Point in time recovery target. Specify one of the following: |
+| recovery.pitrTarget | object | `{"backupID":"","name":"","time":""}` | Point in time recovery target. Specify at most one of `time` or `name`. |
+| recovery.pitrTarget.backupID | string | `""` | Backup to start replay from (a Backup's `.status.backupId`); required with `name`, not `time` |
+| recovery.pitrTarget.name | string | `""` | Named restore point (from `pg_create_restore_point`) to recover to; an alternative to `time` |
 | recovery.pitrTarget.time | string | `""` | Time in RFC3339 format |
 | recovery.pluginConfiguration | object | `{}` |  |
 | recovery.provider | string | `"s3"` | One of `s3`, `azure` or `google` |

--- a/charts/cluster/docs/Recovery.md
+++ b/charts/cluster/docs/Recovery.md
@@ -19,7 +19,7 @@ To begin, create a `values.yaml` that contains the following:
 1. Set `mode: recovery` to indicate that you want to bootstrap the new cluster from an existing one.
 2. Set the `recovery.method` to the type of recovery you want to perform.
 3. Set either the `recovery.backupName` or the Barman Object Store configuration - i.e. `recovery.provider` and appropriate S3, Azure or GCS configuration. In case of `pg_basebackup` complete the `recovery.pgBaseBackup` section.
-4. Optionally set the `recovery.pitrTarget.time` in RFC3339 format to perform a point-in-time recovery (not applicable for `pgBaseBackup`).
+4. Optionally perform a point-in-time recovery (not applicable for `pgBaseBackup`) by setting either `recovery.pitrTarget.time` (an RFC3339 timestamp) or `recovery.pitrTarget.name` (a named restore point created with `pg_create_restore_point`). A named target also requires `recovery.pitrTarget.backupID` (the barman backup ID to start the replay from), because (unlike a time) CloudNativePG cannot resolve it to a base backup automatically.
 5. Retain the identical PostgreSQL version and configuration as the original cluster.
 6. Make sure you don't use the same backup section name as the original cluster. We advise you change the `path` within the storage location if you want to reuse the same storage location/bucket.
     One pattern is adding a version number at the end of the path, e.g. `/v1` or `/v2` after each recovery procedure.

--- a/charts/cluster/templates/_bootstrap.tpl
+++ b/charts/cluster/templates/_bootstrap.tpl
@@ -76,9 +76,17 @@ bootstrap:
       {{- end }}
   {{- else }}
   recovery:
-    {{- with .Values.recovery.pitrTarget.time }}
+    {{- if or .Values.recovery.pitrTarget.time .Values.recovery.pitrTarget.name .Values.recovery.pitrTarget.backupID }}
     recoveryTarget:
+      {{- with .Values.recovery.pitrTarget.backupID }}
+      backupID: {{ . }}
+      {{- end }}
+      {{- with .Values.recovery.pitrTarget.time }}
       targetTime: {{ . }}
+      {{- end }}
+      {{- with .Values.recovery.pitrTarget.name }}
+      targetName: {{ . }}
+      {{- end }}
     {{- end }}
     {{- with .Values.recovery.database }}
     database: {{ . }}

--- a/charts/cluster/test/postgresql-minio-backup-restore/04-post_backup_data_write.yaml
+++ b/charts/cluster/test/postgresql-minio-backup-restore/04-post_backup_data_write.yaml
@@ -52,6 +52,7 @@ spec:
            apk --no-cache add postgresql-client kubectl coreutils
            DB_URI=$(echo $DB_URI | sed "s|/\*|/|" )
            DATE_NO_BAD_TABLE=$(date --rfc-3339=ns)
+           psql "$DB_URI" -c "SELECT pg_create_restore_point('no-bad-table');"
            sleep 30
            psql "$DB_URI" -c "CREATE TABLE mybadtable (id serial PRIMARY KEY);"
            kubectl create configmap date-no-bad-table --from-literal=date="$DATE_NO_BAD_TABLE"

--- a/charts/cluster/test/postgresql-minio-backup-restore/11-recovery_pitr_name_cluster-assert.yaml
+++ b/charts/cluster/test/postgresql-minio-backup-restore/11-recovery_pitr_name_cluster-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: recovery-pitr-name-cluster
+status:
+  readyInstances: 1

--- a/charts/cluster/test/postgresql-minio-backup-restore/11-recovery_pitr_name_cluster.yaml
+++ b/charts/cluster/test/postgresql-minio-backup-restore/11-recovery_pitr_name_cluster.yaml
@@ -1,0 +1,51 @@
+type: postgresql
+mode: recovery
+
+cluster:
+  # Single instance keeps this case's CI footprint light.
+  instances: 1
+  storage:
+    size: 256Mi
+
+recovery:
+  method: object_store
+  clusterName: "standalone-cluster"
+  pitrTarget:
+    name: "no-bad-table"
+  provider: s3
+  endpointURL: "https://minio.minio.svc.cluster.local"
+  endpointCA:
+    name: kube-root-ca.crt
+    key: ca.crt
+  wal:
+    encryption: ""
+  data:
+    encryption: ""
+  s3:
+    bucket: "mybucket"
+    path: "/postgresql-minio-backup-restore/v1"
+    accessKey: "minio"
+    secretKey: "minio123"
+    region: "local"
+  scheduledBackups: []
+  retentionPolicy: "30d"
+
+backups:
+  enabled: true
+  provider: s3
+  endpointURL: "https://minio.minio.svc.cluster.local"
+  endpointCA:
+    name: kube-root-ca.crt
+    key: ca.crt
+  wal:
+    encryption: ""
+  data:
+    encryption: ""
+  s3:
+    bucket: "mybucket"
+    path: "/postgresql-minio-backup-restore/v2"
+    accessKey: "minio"
+    secretKey: "minio123"
+    region: "local"
+  scheduledBackups: []
+  retentionPolicy: "30d"

--- a/charts/cluster/test/postgresql-minio-backup-restore/12-data_test-assert.yaml
+++ b/charts/cluster/test/postgresql-minio-backup-restore/12-data_test-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: data-test-pitr-name
+status:
+  succeeded: 1

--- a/charts/cluster/test/postgresql-minio-backup-restore/12-data_test.yaml
+++ b/charts/cluster/test/postgresql-minio-backup-restore/12-data_test.yaml
@@ -1,0 +1,27 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: data-test-pitr-name
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: data-test
+        env:
+          - name: DB_URI
+            valueFrom:
+              secretKeyRef:
+                name: recovery-pitr-name-cluster-superuser
+                key: uri
+        image: alpine:3.19
+        command: ['sh', '-c']
+        args:
+         - |
+           apk --no-cache add postgresql-client
+           DB_URI=$(echo $DB_URI | sed "s|/\*|/|" )
+           set -e
+           test "$(psql $DB_URI -t -c 'SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = $$mygoodtable$$)' --csv -q 2>/dev/null)" = "t"
+           echo "Good table exists"
+           test "$(psql $DB_URI -t -c 'SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = $$mybadtable$$)' --csv -q 2>/dev/null)" = "f"
+           echo "Bad table does not exist"

--- a/charts/cluster/test/postgresql-minio-backup-restore/chainsaw-test.yaml
+++ b/charts/cluster/test/postgresql-minio-backup-restore/chainsaw-test.yaml
@@ -138,6 +138,33 @@ spec:
             selector: batch.kubernetes.io/job-name=data-test-backup-pitr
         - podLogs:
             selector: batch.kubernetes.io/job-name=data-test-backup-pitr
+    - name: Create a recovery cluster from the object store with a named PITR target
+      try:
+        - script:
+            content: |
+              BACKUP_ID=$(kubectl -n $NAMESPACE get backup post-init-backup -o jsonpath='{.status.backupId}')
+              helm upgrade \
+                --install \
+                --namespace $NAMESPACE \
+                --values ./11-recovery_pitr_name_cluster.yaml \
+                --set recovery.pitrTarget.backupID="$BACKUP_ID" \
+                --wait \
+                recovery-pitr-name ../../
+        - assert:
+            file: ./11-recovery_pitr_name_cluster-assert.yaml
+    - name: Verify the pre-restore-point data on the named-PITR recovery cluster exists but not the post-restore-point data
+      try:
+        - apply:
+            file: 12-data_test.yaml
+        - assert:
+            file: 12-data_test-assert.yaml
+      catch:
+        - describe:
+            apiVersion: batch/v1
+            kind: Job
+            selector: batch.kubernetes.io/job-name=data-test-pitr-name
+        - podLogs:
+            selector: batch.kubernetes.io/job-name=data-test-pitr-name
     - name: Cleanup
       try:
         - script:
@@ -146,3 +173,4 @@ spec:
               helm uninstall --namespace $NAMESPACE recovery-backup
               helm uninstall --namespace $NAMESPACE recovery-object-store
               helm uninstall --namespace $NAMESPACE recovery-backup-pitr
+              helm uninstall --namespace $NAMESPACE recovery-pitr-name

--- a/charts/cluster/values.schema.json
+++ b/charts/cluster/values.schema.json
@@ -1066,8 +1066,18 @@
           "type": "object"
         },
         "pitrTarget": {
-          "description": "Point in time recovery target. Specify one of the following:",
+          "description": "Point in time recovery target. Specify at most one of `time` or `name`.",
           "properties": {
+            "backupID": {
+              "default": "",
+              "description": "Backup to start replay from (a Backup's `.status.backupId`); required with `name`, not `time`",
+              "type": "string"
+            },
+            "name": {
+              "default": "",
+              "description": "Named restore point (from `pg_create_restore_point`) to recover to; an alternative to `time`",
+              "type": "string"
+            },
             "time": {
               "default": "",
               "description": "Time in RFC3339 format",

--- a/charts/cluster/values.yaml
+++ b/charts/cluster/values.yaml
@@ -35,10 +35,14 @@ recovery:
   # * `import` - Import one or more databases from an existing Postgres cluster.
   method: backup
 
-  # -- Point in time recovery target. Specify one of the following:
+  # -- Point in time recovery target. Specify at most one of `time` or `name`.
   pitrTarget:
     # -- Time in RFC3339 format
     time: ""
+    # -- Named restore point (from `pg_create_restore_point`) to recover to; an alternative to `time`
+    name: ""
+    # -- Backup to start replay from (a Backup's `.status.backupId`); required with `name`, not `time`
+    backupID: ""
 
   # -- Backup Recovery Method
   backupName: ""  # Name of the backup to recover from. Required if method is `backup`.


### PR DESCRIPTION
## What

- Expose `recovery.pitrTarget.name` -> `recoveryTarget.targetName` and `recovery.pitrTarget.backupID` -> `recoveryTarget.backupID` on the `cluster` chart, alongside the existing `time` -> `targetTime`.
- Document them in `values.yaml`, `values.schema.json`, the README, and `docs/Recovery.md`.
- Extend the `postgresql-minio-backup-restore` chainsaw test to cover the named path.

## Why

`recovery.pitrTarget` only supported a wall-clock `time`. A named restore point (`pg_create_restore_point`) recovers to an exact WAL location, which is deterministic. CloudNativePG can pick the base backup to start replay from for a time target, but not for a name (or LSN/xid), so it rejects a named target with `recoveryTarget: Required value: BackupID is missing` unless `backupID` is given. `backupID` is exposed in the same change for that reason.

## Backwards compatibility

`recovery.pitrTarget.name` and `recovery.pitrTarget.backupID` default to `""`, and the template only emits a field when set. A `pitrTarget` with just `time` (or empty) renders identically to before.

## Tests

- `helm lint charts/cluster`.
- `helm template ... --show-only templates/cluster.yaml` renders `recoveryTarget.targetName`/`backupID` when set, and nothing when `pitrTarget` is empty.
- The `postgresql-minio-backup-restore` chainsaw test creates a `no-bad-table` restore point after the good write, then recovers from the object store with `pitrTarget.name` + `backupID` (read from the source backup's `.status.backupId`), asserting the pre-restore-point table is present and the post-restore-point table absent.