### PR TITLE
fix #963 accept null postgres UID GID

### DIFF
--- a/charts/cloudnative-pg/templates/crds/crds.yaml
+++ b/charts/cloudnative-pg/templates/crds/crds.yaml
@@ -5118,13 +5118,13 @@ spec:
               postgresGID:
                 default: 26
                 description: The GID of the `postgres` user inside the image, defaults
-                  to `26`
+                  to `26`. `-1` is a special value meaning `runAsGroup` and `fsGroup` of `podSecurityContext` must not be defined.
                 format: int64
                 type: integer
               postgresUID:
                 default: 26
                 description: The UID of the `postgres` user inside the image, defaults
-                  to `26`
+                  to `26`. `-1` is a special value meaning `runAsUser` of `podSecurityContext` must not be defined.
                 format: int64
                 type: integer
               postgresql:

--- a/charts/cluster/templates/_helpers.tpl
+++ b/charts/cluster/templates/_helpers.tpl
@@ -126,7 +126,8 @@ imageName: {{ include "cluster.imageName" . }}
 Postgres UID
 */}}
 {{- define "cluster.postgresUID" -}}
-  {{- if ge (int .Values.cluster.postgresUID) 0 -}}
+  // -1 is a special value meaning UID must not be defined in SCC.
+  {{- if ge (int .Values.cluster.postgresUID) -1 -}}
     {{- .Values.cluster.postgresUID }}
   {{- else if and (eq (include "cluster.useTimescaleDBDefaults" .) "true") (eq .Values.type "timescaledb") -}}
     {{- 1000 -}}
@@ -139,7 +140,8 @@ Postgres UID
 Postgres GID
 */}}
 {{- define "cluster.postgresGID" -}}
-  {{- if ge (int .Values.cluster.postgresGID) 0 -}}
+  // -1 is a special value meaning GID must not be defined in SCC.
+  {{- if ge (int .Values.cluster.postgresGID) -1 -}}
     {{- .Values.cluster.postgresGID }}
   {{- else if and (eq (include "cluster.useTimescaleDBDefaults" .) "true") (eq .Values.type "timescaledb") -}}
     {{- 1000 -}}


### PR DESCRIPTION
Fix: https://github.com/cloudnative-pg/charts/issues/963

Description: accept `-1` as value for UID/GID, it has a special meaning: `runAsUser` `runAsGroup` `fsGroup` will not be defined.