### PR TITLE
feat(cloudnative-pg): allow setting scratch-data emptyDir options

### DIFF
--- a/charts/cloudnative-pg/README.md
+++ b/charts/cloudnative-pg/README.md
@@ -158,6 +158,7 @@ Kubernetes: `>=1.29.0-0`
 | rbac.create | bool | `true` | Specifies whether ClusterRole and ClusterRoleBinding should be created. |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
+| scratchData.emptyDir | object | `{}` | EmptyDir options for the scratch-data volume. |
 | service.ipFamilies | list | `[]` | Sets the families that should be supported and the order in which they should be applied to ClusterIP as well. Can be IPv4 and/or IPv6. |
 | service.ipFamilyPolicy | string | `""` | Set the ip family policy to configure dual-stack see [Configure dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services) |
 | service.name | string | `"cnpg-webhook-service"` | The name of the Webhook Service. |

--- a/charts/cloudnative-pg/templates/deployment.yaml
+++ b/charts/cloudnative-pg/templates/deployment.yaml
@@ -166,8 +166,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
-      - emptyDir: {}
-        name: scratch-data
+      - name: scratch-data
+        emptyDir:
+          {{- toYaml .Values.scratchData.emptyDir | nindent 10 }}
       - name: webhook-certificates
         secret:
           defaultMode: 420

--- a/charts/cloudnative-pg/values.schema.json
+++ b/charts/cloudnative-pg/values.schema.json
@@ -325,6 +325,17 @@
       "required": [],
       "type": "object"
     },
+    "scratchData": {
+      "properties": {
+        "emptyDir": {
+          "description": "EmptyDir options for the scratch-data volume.",
+          "required": [],
+          "type": "object"
+        }
+      },
+      "required": [],
+      "type": "object"
+    },
     "service": {
       "properties": {
         "ipFamilies": {

--- a/charts/cloudnative-pg/values.yaml
+++ b/charts/cloudnative-pg/values.yaml
@@ -167,6 +167,10 @@ resources: {}
   #   cpu: 100m
   #   memory: 100Mi
 
+scratchData:
+  # -- EmptyDir options for the scratch-data volume.
+  emptyDir: {}
+
 # -- Nodeselector for the operator to be installed.
 nodeSelector: {}
 


### PR DESCRIPTION
This change allows configuring options (e.g. setting a `sizeLimit`) on the `scratch-data` `emptyDir` volume via the `.scratchData.emptyDir` value.

Default value for `.scratchData.emptyDir` is `{}`, retaining the same behavior as before this change.

closes #979