### PR TITLE
feat(plugin-barman-cloud): add logLevel parameter

### DIFF
--- a/charts/plugin-barman-cloud/README.md
+++ b/charts/plugin-barman-cloud/README.md
@@ -103,7 +103,7 @@ Kubernetes: `>=1.29.0-0`
 | image.repository | string | `"cloudnative-pg/plugin-barman-cloud"` |  |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` |  |
-| logLevel | string | `"debug"` |  |
+| logLevel | string | `"debug"` | Log verbosity level for the plugin barman cloud with values: [error, warning, info, debug, trace]. |
 | nameOverride | string | `""` |  |
 | namespaceOverride | string | `""` |  |
 | nodeSelector | object | `{}` | Nodeselector for the operator to be installed. |

--- a/charts/plugin-barman-cloud/README.md
+++ b/charts/plugin-barman-cloud/README.md
@@ -103,7 +103,7 @@ Kubernetes: `>=1.29.0-0`
 | image.repository | string | `"cloudnative-pg/plugin-barman-cloud"` |  |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` |  |
-| logLevel | string | `"debug"` | Log verbosity level for the plugin barman cloud with values: [error, warning, info, debug, trace]. |
+| logLevel | string | `"info"` | Log verbosity level for the plugin barman cloud with values: [error, warning, info, debug, trace]. |
 | nameOverride | string | `""` |  |
 | namespaceOverride | string | `""` |  |
 | nodeSelector | object | `{}` | Nodeselector for the operator to be installed. |

--- a/charts/plugin-barman-cloud/README.md
+++ b/charts/plugin-barman-cloud/README.md
@@ -103,6 +103,7 @@ Kubernetes: `>=1.29.0-0`
 | image.repository | string | `"cloudnative-pg/plugin-barman-cloud"` |  |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` |  |
+| logLevel | string | `"debug"` |  |
 | nameOverride | string | `""` |  |
 | namespaceOverride | string | `""` |  |
 | nodeSelector | object | `{}` | Nodeselector for the operator to be installed. |

--- a/charts/plugin-barman-cloud/templates/deployment.yaml
+++ b/charts/plugin-barman-cloud/templates/deployment.yaml
@@ -56,7 +56,7 @@ spec:
         - --client-cert=/client/tls.crt
         - --server-address=:9090
         - --leader-elect
-        - --log-level={{ .Values.logLevel }}
+        - --log-level={{ .Values.logLevel | default "debug" }}
         {{- range .Values.additionalArgs }}
         - {{ . }}
         {{- end }}

--- a/charts/plugin-barman-cloud/templates/deployment.yaml
+++ b/charts/plugin-barman-cloud/templates/deployment.yaml
@@ -56,7 +56,7 @@ spec:
         - --client-cert=/client/tls.crt
         - --server-address=:9090
         - --leader-elect
-        - --log-level={{ .Values.logLevel | default "debug" }}
+        - --log-level={{ .Values.logLevel | default "info" }}
         {{- range .Values.additionalArgs }}
         - {{ . }}
         {{- end }}

--- a/charts/plugin-barman-cloud/templates/deployment.yaml
+++ b/charts/plugin-barman-cloud/templates/deployment.yaml
@@ -56,7 +56,7 @@ spec:
         - --client-cert=/client/tls.crt
         - --server-address=:9090
         - --leader-elect
-        - --log-level=debug
+        - --log-level={{ .Values.logLevel }}
         {{- range .Values.additionalArgs }}
         - {{ . }}
         {{- end }}

--- a/charts/plugin-barman-cloud/test/simple-deployment/01-simple_deployment-assert.yaml
+++ b/charts/plugin-barman-cloud/test/simple-deployment/01-simple_deployment-assert.yaml
@@ -15,7 +15,7 @@ spec:
           - --client-cert=/client/tls.crt
           - --server-address=:9090
           - --leader-elect
-          - --log-level=debug
+          - --log-level=info
         ports:
         - containerPort: 9090
           protocol: TCP

--- a/charts/plugin-barman-cloud/test/simple-deployment/02-loglevel_override-assert.yaml
+++ b/charts/plugin-barman-cloud/test/simple-deployment/02-loglevel_override-assert.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: plugin-barman-cloud
+spec:
+  template:
+    spec:
+      containers:
+        - name: barman-cloud
+          args:
+            - operator
+            - --server-cert=/server/tls.crt
+            - --server-key=/server/tls.key
+            - --client-cert=/client/tls.crt
+            - --server-address=:9090
+            - --leader-elect
+            - --log-level=trace

--- a/charts/plugin-barman-cloud/test/simple-deployment/02-loglevel_override.yaml
+++ b/charts/plugin-barman-cloud/test/simple-deployment/02-loglevel_override.yaml
@@ -1,0 +1,8 @@
+logLevel: trace
+resources:
+  limits:
+    cpu: 100m
+    memory: 200Mi
+  requests:
+    cpu: 100m
+    memory: 100Mi

--- a/charts/plugin-barman-cloud/test/simple-deployment/chainsaw-test.yaml
+++ b/charts/plugin-barman-cloud/test/simple-deployment/chainsaw-test.yaml
@@ -23,6 +23,18 @@ spec:
                 plugin-barman-cloud ../../
         - assert:
             file: ./01-simple_deployment-assert.yaml
+    - name: Override log level
+      try:
+        - script:
+            content: |
+              helm upgrade \
+              --install \
+              --namespace $NAMESPACE \
+              --values ./02-loglevel_override.yaml \
+              --wait \
+              plugin-barman-cloud ../../
+        - assert:
+            file: ./02-loglevel_override-assert.yaml
     - name: Cleanup
       try:
         - script:

--- a/charts/plugin-barman-cloud/values.schema.json
+++ b/charts/plugin-barman-cloud/values.schema.json
@@ -173,7 +173,14 @@
     },
     "logLevel": {
       "default": "debug",
-      "description": "Log verbosity level for the plugin operator.",
+      "description": "Log verbosity level for the plugin barman cloud with values: [error, warning, info, debug, trace].",
+      "enum": [
+        "error",
+        "warning",
+        "info",
+        "debug",
+        "trace"
+      ],
       "type": "string"
     },
     "nameOverride": {

--- a/charts/plugin-barman-cloud/values.schema.json
+++ b/charts/plugin-barman-cloud/values.schema.json
@@ -171,6 +171,11 @@
       },
       "required": []
     },
+    "logLevel": {
+      "default": "debug",
+      "description": "Log verbosity level for the plugin operator.",
+      "type": "string"
+    },
     "nameOverride": {
       "default": "",
       "type": "string"

--- a/charts/plugin-barman-cloud/values.schema.json
+++ b/charts/plugin-barman-cloud/values.schema.json
@@ -172,7 +172,7 @@
       "required": []
     },
     "logLevel": {
-      "default": "debug",
+      "default": "info",
       "description": "Log verbosity level for the plugin barman cloud with values: [error, warning, info, debug, trace].",
       "enum": [
         "error",

--- a/charts/plugin-barman-cloud/values.yaml
+++ b/charts/plugin-barman-cloud/values.yaml
@@ -22,6 +22,8 @@
 
 replicaCount: 1
 
+logLevel: debug
+
 image:
   registry: ghcr.io
   repository: cloudnative-pg/plugin-barman-cloud

--- a/charts/plugin-barman-cloud/values.yaml
+++ b/charts/plugin-barman-cloud/values.yaml
@@ -25,10 +25,10 @@ replicaCount: 1
 # @schema
 # type: string
 # enum: [error, warning, info, debug, trace]
-# default: debug
+# default: info
 # @schema
 # -- Log verbosity level for the plugin barman cloud with values: [error, warning, info, debug, trace].
-logLevel: debug
+logLevel: info
 
 image:
   registry: ghcr.io

--- a/charts/plugin-barman-cloud/values.yaml
+++ b/charts/plugin-barman-cloud/values.yaml
@@ -22,6 +22,12 @@
 
 replicaCount: 1
 
+# @schema
+# type: string
+# enum: [error, warning, info, debug, trace]
+# default: debug
+# @schema
+# -- Log verbosity level for the plugin barman cloud with values: [error, warning, info, debug, trace].
 logLevel: debug
 
 image:


### PR DESCRIPTION
The plugin deployment previously hardcoded --log-level=debug. The log level is now configurable through the logLevel value, which also changes the default from debug to info for installations that do not set it explicitly.

Closes #982