### PR TITLE
fix(cluster):  align  plugin ObjectStore name to  barmanObjectName

### DIFF
--- a/charts/cluster/templates/_helpers.tpl
+++ b/charts/cluster/templates/_helpers.tpl
@@ -243,3 +243,12 @@ Given a list of objects, returns the first item that matches the key value pairs
   {{- end -}}
   {{- $required -}}
 {{- end -}}
+
+{{/*
+Name of the plugin's barmanObject Nameparameter when set, otherwise defaults to "<fullname>-backups".
+*/}}
+{{- define "cluster.barmanObjectName" -}}
+  {{- $barmanPlugin := include "helpers.fetchKeyValue" (list .Values.cluster.plugins (list (list "name" "barman-cloud.cloudnative-pg.io"))) | fromYaml -}}
+  {{- $parameters := coalesce $barmanPlugin.parameters dict -}}
+  {{- $parameters.barmanObjectName | default (printf "%s-backups" (include "cluster.fullname" .)) -}}
+{{- end -}}

--- a/charts/cluster/templates/backup-objectstore.yaml
+++ b/charts/cluster/templates/backup-objectstore.yaml
@@ -2,7 +2,9 @@
 apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore
 metadata:
-  name: {{ include "cluster.fullname" . }}-backups
+  {{- $barmanPlugin := include "helpers.fetchKeyValue" (list .Values.cluster.plugins (list (list "name" "barman-cloud.cloudnative-pg.io"))) | fromYaml }}
+  {{- $parameters := coalesce $barmanPlugin.parameters dict }}
+  name: {{ $parameters.barmanObjectName | default (printf "%s-backups" (include "cluster.fullname" .)) | quote }}
   namespace: {{ include "cluster.namespace" . }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,pre-rollback

--- a/charts/cluster/templates/backup-objectstore.yaml
+++ b/charts/cluster/templates/backup-objectstore.yaml
@@ -2,9 +2,7 @@
 apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore
 metadata:
-  {{- $barmanPlugin := include "helpers.fetchKeyValue" (list .Values.cluster.plugins (list (list "name" "barman-cloud.cloudnative-pg.io"))) | fromYaml }}
-  {{- $parameters := coalesce $barmanPlugin.parameters dict }}
-  name: {{ $parameters.barmanObjectName | default (printf "%s-backups" (include "cluster.fullname" .)) | quote }}
+  name: {{ include "cluster.barmanObjectName" . | quote }}
   namespace: {{ include "cluster.namespace" . }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,pre-rollback

--- a/charts/cluster/templates/cluster.yaml
+++ b/charts/cluster/templates/cluster.yaml
@@ -175,6 +175,6 @@ spec:
         {{ with $parametersWithoutObjectName }}
           {{- toYaml . | indent 8 | trim }}
         {{- end }}
-        barmanObjectName: {{ $parameters.barmanObjectName | default (printf "%s-backups" (include "cluster.fullname" .)) }}
+        barmanObjectName: {{ $parameters.barmanObjectName | default (printf "%s-backups" (include "cluster.fullname" .)) | quote }}
     {{- end }}
   {{- end }}

--- a/charts/cluster/templates/cluster.yaml
+++ b/charts/cluster/templates/cluster.yaml
@@ -175,6 +175,6 @@ spec:
         {{ with $parametersWithoutObjectName }}
           {{- toYaml . | indent 8 | trim }}
         {{- end }}
-        barmanObjectName: {{ $parameters.barmanObjectName | default (printf "%s-backups" (include "cluster.fullname" .)) | quote }}
+        barmanObjectName: {{ include "cluster.barmanObjectName" . | quote }}
     {{- end }}
   {{- end }}

--- a/charts/cluster/test/barman-plugin-explicit/02-barman_plugin_config_override_cluster-assert.yaml
+++ b/charts/cluster/test/barman-plugin-explicit/02-barman_plugin_config_override_cluster-assert.yaml
@@ -15,3 +15,20 @@ spec:
     parameters:
       foo: bar
       barmanObjectName: asd
+---
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: asd
+spec:
+  retentionPolicy: 30d
+  configuration:
+    destinationPath: s3://mybucket/barman-plugin-scheduledbackups/v1
+    endpointURL: https://minio.minio.svc.cluster.local
+    s3Credentials:
+      accessKeyId:
+        key: ACCESS_KEY_ID
+        name: barman-plugin-config-override-cluster-backup-s3-creds
+      secretAccessKey:
+        key: ACCESS_SECRET_KEY
+        name: barman-plugin-config-override-cluster-backup-s3-creds


### PR DESCRIPTION
The pr fixes the name  name: {{ include "cluster.fullname" . }}-backups  in barman plugin object store to match the cluster 
barmanObjectName,

closes #975 
Signed-off-by: danishedb <danish.khan@enterprisedb.com>