### PR TITLE
ci: adding workflow dispatch to charts ci test

### DIFF
--- a/.github/workflows/tests-cluster-chainsaw.yaml
+++ b/.github/workflows/tests-cluster-chainsaw.yaml
@@ -4,13 +4,17 @@ on:
   pull_request:
     branches-ignore:
       - 'gh-pages'
-  workflow_dispatch:
+  push:
+    branches-ignore:
+      - 'main'
+      - 'gh-pages'
 
 permissions: read-all
 
 jobs:
   test-list:
     runs-on: ubuntu-24.04
+    if: github.event_name != 'push' || github.repository_owner != 'cloudnative-pg'
     outputs:
       tests: ${{ steps.listTests.outputs.tests }}
     steps:

--- a/.github/workflows/tests-cluster-chainsaw.yaml
+++ b/.github/workflows/tests-cluster-chainsaw.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches-ignore:
       - 'gh-pages'
+  workflow_dispatch:
 
 permissions: read-all
 

--- a/.github/workflows/tests-operator.yml
+++ b/.github/workflows/tests-operator.yml
@@ -4,13 +4,17 @@ on:
   pull_request:
     branches-ignore:
       - 'gh-pages'
-  workflow_dispatch:
+  push:
+    branches-ignore:
+      - 'main'
+      - 'gh-pages'
 
 permissions: read-all
 
 jobs:
   deploy_operator:
     name: Deploy the operator in cluster-wide mode
+    if: github.event_name != 'push' || github.repository_owner != 'cloudnative-pg'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -35,6 +39,7 @@ jobs:
 
   deploy_operator_single_namespace:
     name: Deploy the operator in single-namespace mode
+    if: github.event_name != 'push' || github.repository_owner != 'cloudnative-pg'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout

--- a/.github/workflows/tests-operator.yml
+++ b/.github/workflows/tests-operator.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches-ignore:
       - 'gh-pages'
+  workflow_dispatch:
 
 permissions: read-all
 

--- a/.github/workflows/tests-plugin-barman-cloud.yaml
+++ b/.github/workflows/tests-plugin-barman-cloud.yaml
@@ -4,13 +4,17 @@ on:
   pull_request:
     branches-ignore:
       - 'gh-pages'
-  workflow_dispatch:
+  push:
+    branches-ignore:
+      - 'main'
+      - 'gh-pages'
 
 permissions: read-all
 
 jobs:
   test-list:
     runs-on: ubuntu-24.04
+    if: github.event_name != 'push' || github.repository_owner != 'cloudnative-pg'
     outputs:
       tests: ${{ steps.listTests.outputs.tests }}
     steps:

--- a/.github/workflows/tests-plugin-barman-cloud.yaml
+++ b/.github/workflows/tests-plugin-barman-cloud.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches-ignore:
       - 'gh-pages'
+  workflow_dispatch:
 
 permissions: read-all
 


### PR DESCRIPTION
Currently the test on CI is running only on pull request.
Updated it to run on push only on forks.

https://github.com/danishedb/charts/actions
closes #992 
Signed-off-by: danishedb <danish.khan@enterprisedb.com>