### PR TITLE
cnpg: attach customQueriesConfigMap for instrumentations

### DIFF
--- a/charts/cluster/templates/cluster.yaml
+++ b/charts/cluster/templates/cluster.yaml
@@ -140,10 +140,19 @@ spec:
 
   monitoring:
     disableDefaultQueries: {{ .Values.cluster.monitoring.disableDefaultQueries }}
-    {{- if not (empty .Values.cluster.monitoring.customQueries) }}
+    {{- if or (not (empty .Values.cluster.monitoring.customQueries)) (or .Values.cluster.monitoring.instrumentation.pgStatStatements .Values.cluster.monitoring.instrumentation.logicalReplication) }}
     customQueriesConfigMap:
+    {{- if not (empty .Values.cluster.monitoring.customQueries) }}
       - name: {{ include "cluster.fullname" . }}-monitoring
         key: custom-queries
+    {{- end }}
+    {{- if not (not .Values.cluster.monitoring.instrumentation.pgStatStatements) }}
+      - name: {{ include "cluster.fullname" . }}-monitoring-pg-stat-statements
+        key: custom-queries
+    {{- end }}
+    {{- if .Values.cluster.monitoring.instrumentation.logicalReplication }}
+    - name: {{ include "cluster.fullname" . }}-monitoring-logical-replication
+      key: custom-queries
     {{- end }}
     {{- if not (empty .Values.cluster.monitoring.customQueriesSecret) }}
     {{- with .Values.cluster.monitoring.customQueriesSecret }}


### PR DESCRIPTION
Solves https://github.com/cloudnative-pg/charts/issues/994

If any of the instrumentations is enabled the metrics configmaps are automatically added. 
I would understand that the CNPG will add the default queries as one more in the list when mutated, have not checked.