### PR TITLE
feat(cluster): add ephemeralVolumeSource support

### DIFF
--- a/charts/cluster/README.md
+++ b/charts/cluster/README.md
@@ -202,6 +202,7 @@ Kubernetes: `>=1.29.0-0`
 | cluster.enableSuperuserAccess | bool | `true` | When this option is enabled, the operator will use the SuperuserSecret to update the postgres user password. If the secret is not present, the operator will automatically create one. When this option is disabled, the operator will ignore the SuperuserSecret content, delete it when automatically created, and then blank the password of the postgres user by setting it to NULL. |
 | cluster.env | list | `[]` | Env follows the Env format to pass environment variables to the pods created in the cluster |
 | cluster.envFrom | list | `[]` | EnvFrom follows the EnvFrom format to pass environment variables sources to the pods to be used by Env |
+| cluster.ephemeralVolumeSource | object | `{}` | Override the default emptyDir used by CNPG for temporary storage. See: https://cloudnative-pg.io/documentation/current/cluster_conf/#ephemeral-volumes |
 | cluster.imageCatalogRef | object | `{}` | Reference to `ImageCatalog` of `ClusterImageCatalog`, if specified takes precedence over `cluster.imageName` |
 | cluster.imageName | string | `""` | Name of the container image, supporting both tags (<image>:<tag>) and digests for deterministic and repeatable deployments: <image>:<tag>@sha256:<digestValue> |
 | cluster.imagePullPolicy | string | `"IfNotPresent"` | Image pull policy. One of Always, Never or IfNotPresent. If not defined, it defaults to IfNotPresent. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images |

--- a/charts/cluster/templates/cluster.yaml
+++ b/charts/cluster/templates/cluster.yaml
@@ -31,6 +31,10 @@ spec:
     storageClass: {{ .Values.cluster.walStorage.storageClass }}
     {{- end }}
   {{- end }}
+  {{- with .Values.cluster.ephemeralVolumeSource }}
+  ephemeralVolumeSource:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.cluster.resources }}
   resources:
     {{- toYaml . | nindent 4 }}

--- a/charts/cluster/test/postgresql-cluster-configuration/01-non_default_configuration_cluster-assert.yaml
+++ b/charts/cluster/test/postgresql-cluster-configuration/01-non_default_configuration_cluster-assert.yaml
@@ -70,6 +70,15 @@ spec:
   walStorage:
     size: 256Mi
     storageClass: standard
+  ephemeralVolumeSource:
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: scratch-storage-class
+        resources:
+          requests:
+            storage: 1Gi
   affinity:
     topologyKey: kubernetes.io/hostname
     nodeAffinity:

--- a/charts/cluster/test/postgresql-cluster-configuration/01-non_default_configuration_cluster.yaml
+++ b/charts/cluster/test/postgresql-cluster-configuration/01-non_default_configuration_cluster.yaml
@@ -13,6 +13,15 @@ cluster:
     enabled: true
     size: 256Mi
     storageClass: standard
+  ephemeralVolumeSource:
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: scratch-storage-class
+        resources:
+          requests:
+            storage: 1Gi
   postgresUID: 1001
   postgresGID: 1002
   resources:

--- a/charts/cluster/values.schema.json
+++ b/charts/cluster/values.schema.json
@@ -318,6 +318,11 @@
           },
           "type": "array"
         },
+        "ephemeralVolumeSource": {
+          "description": "Override the default emptyDir used by CNPG for temporary storage.\nSee: https://cloudnative-pg.io/documentation/current/cluster_conf/#ephemeral-volumes",
+          "required": [],
+          "type": "object"
+        },
         "imageCatalogRef": {
           "description": "Reference to `ImageCatalog` of `ClusterImageCatalog`, if specified takes precedence over `cluster.imageName`",
           "required": [],

--- a/charts/cluster/values.yaml
+++ b/charts/cluster/values.yaml
@@ -222,6 +222,17 @@ cluster:
     size: 1Gi
     storageClass: ""
 
+  # -- Override the default emptyDir used by CNPG for temporary storage.
+  # See: https://cloudnative-pg.io/documentation/current/cluster_conf/#ephemeral-volumes
+  ephemeralVolumeSource: {}
+    # volumeClaimTemplate:
+    #   spec:
+    #     accessModes: ["ReadWriteOnce"]
+    #     storageClassName: "scratch-storage-class"
+    #     resources:
+    #       requests:
+    #         storage: 1Gi
+
   # -- The UID of the postgres user inside the image, defaults to 26
   postgresUID: -1
 


### PR DESCRIPTION
**Summary**
---
- Add cluster.ephemeralVolumeSource to default values and schema.
- Render the value into the CNPG Cluster resource.
- Document the new value in the chart README.
- Add rendering coverage to the non-default cluster configuration test.

**Testing**
---
- helm lint charts/cluster
- ct lint --check-version-increment=false