### PR TITLE
feat(cloudnative-pg): add operator pod disruption budget

### DIFF
--- a/charts/cloudnative-pg/README.md
+++ b/charts/cloudnative-pg/README.md
@@ -151,6 +151,11 @@ Kubernetes: `>=1.29.0-0`
 | namespaceOverride | string | `""` |  |
 | nodeSelector | object | `{}` | Nodeselector for the operator to be installed. |
 | podAnnotations | object | `{}` | Annotations to be added to the pod. |
+| podDisruptionBudget | object | `{"enabled":false,"maxUnavailable":null,"minAvailable":1,"unhealthyPodEvictionPolicy":""}` | Pod disruption budget for the operator. Exactly one of `minAvailable` or `maxUnavailable` must be set when enabled. This does not configure the disruption budgets managed by CloudNativePG for database clusters. |
+| podDisruptionBudget.enabled | bool | `false` | Specifies whether the pod disruption budget should be created. |
+| podDisruptionBudget.maxUnavailable | string | `nil` | Maximum number or percentage of operator pods that may be unavailable. Mutually exclusive with `minAvailable`. |
+| podDisruptionBudget.minAvailable | int | `1` | Minimum number or percentage of operator pods that must remain available. Mutually exclusive with `maxUnavailable`. |
+| podDisruptionBudget.unhealthyPodEvictionPolicy | string | `""` | Policy for evicting unhealthy operator pods. An empty value uses the Kubernetes default (`IfHealthyBudget`). |
 | podLabels | object | `{}` | Labels to be added to the pod. |
 | podSecurityContext | object | `{"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Security Context for the whole pod. |
 | priorityClassName | string | `""` | Priority indicates the importance of a Pod relative to other Pods. |

--- a/charts/cloudnative-pg/templates/poddisruptionbudget.yaml
+++ b/charts/cloudnative-pg/templates/poddisruptionbudget.yaml
@@ -1,0 +1,51 @@
+#
+# Copyright © contributors to CloudNativePG, established as
+# CloudNativePG a Series of LF Projects, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+{{- if .Values.podDisruptionBudget.enabled }}
+{{- if and (ne .Values.podDisruptionBudget.minAvailable nil) (ne .Values.podDisruptionBudget.maxUnavailable nil) }}
+{{- fail "podDisruptionBudget.minAvailable and podDisruptionBudget.maxUnavailable are mutually exclusive" }}
+{{- end }}
+{{- if and (eq .Values.podDisruptionBudget.minAvailable nil) (eq .Values.podDisruptionBudget.maxUnavailable nil) }}
+{{- fail "one of podDisruptionBudget.minAvailable or podDisruptionBudget.maxUnavailable must be configured" }}
+{{- end }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "cloudnative-pg.fullname" . }}
+  namespace: {{ include "cloudnative-pg.namespace" . }}
+  labels:
+    {{- include "cloudnative-pg.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if ne .Values.podDisruptionBudget.minAvailable nil }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if ne .Values.podDisruptionBudget.maxUnavailable nil }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  {{- with .Values.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "cloudnative-pg.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/cloudnative-pg/values.schema.json
+++ b/charts/cloudnative-pg/values.schema.json
@@ -270,6 +270,74 @@
       "required": [],
       "type": "object"
     },
+    "podDisruptionBudget": {
+      "description": "Pod disruption budget for the operator. Exactly one of `minAvailable` or\n`maxUnavailable` must be set when enabled. This does not configure the\ndisruption budgets managed by CloudNativePG for database clusters.",
+      "not": {
+        "properties": {
+          "maxUnavailable": {
+            "required": [],
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "minAvailable": {
+            "required": [],
+            "type": [
+              "integer",
+              "string"
+            ]
+          }
+        },
+        "required": [
+          "minAvailable",
+          "maxUnavailable"
+        ]
+      },
+      "properties": {
+        "enabled": {
+          "default": false,
+          "description": "Specifies whether the pod disruption budget should be created.",
+          "type": "boolean"
+        },
+        "maxUnavailable": {
+          "default": "null",
+          "description": "Maximum number or percentage of operator pods that may be unavailable.\nMutually exclusive with `minAvailable`.",
+          "minimum": 0,
+          "pattern": "^([0-9]|[1-9][0-9]|100)%$",
+          "required": [],
+          "type": [
+            "integer",
+            "string",
+            "null"
+          ]
+        },
+        "minAvailable": {
+          "default": 1,
+          "description": "Minimum number or percentage of operator pods that must remain available.\nMutually exclusive with `maxUnavailable`.",
+          "minimum": 0,
+          "pattern": "^([0-9]|[1-9][0-9]|100)%$",
+          "required": [],
+          "type": [
+            "integer",
+            "string",
+            "null"
+          ]
+        },
+        "unhealthyPodEvictionPolicy": {
+          "default": "",
+          "description": "Policy for evicting unhealthy operator pods. An empty value uses the\nKubernetes default (`IfHealthyBudget`).",
+          "enum": [
+            "",
+            "IfHealthyBudget",
+            "AlwaysAllow"
+          ],
+          "required": []
+        }
+      },
+      "required": [],
+      "type": "object"
+    },
     "podLabels": {
       "description": "Labels to be added to the pod.",
       "required": [],

--- a/charts/cloudnative-pg/values.yaml
+++ b/charts/cloudnative-pg/values.yaml
@@ -179,6 +179,45 @@ tolerations: []
 # -- Affinity for the operator to be installed.
 affinity: {}
 
+# @schema
+# type: object
+# not:
+#   properties:
+#     minAvailable:
+#       type: [integer, string]
+#     maxUnavailable:
+#       type: [integer, string]
+#   required: [minAvailable, maxUnavailable]
+# @schema
+# -- Pod disruption budget for the operator. Exactly one of `minAvailable` or
+# `maxUnavailable` must be set when enabled. This does not configure the
+# disruption budgets managed by CloudNativePG for database clusters.
+podDisruptionBudget:
+  # -- Specifies whether the pod disruption budget should be created.
+  enabled: false
+  # @schema
+  # type: [integer, string, null]
+  # minimum: 0
+  # pattern: ^([0-9]|[1-9][0-9]|100)%$
+  # @schema
+  # -- Minimum number or percentage of operator pods that must remain available.
+  # Mutually exclusive with `maxUnavailable`.
+  minAvailable: 1
+  # @schema
+  # type: [integer, string, null]
+  # minimum: 0
+  # pattern: ^([0-9]|[1-9][0-9]|100)%$
+  # @schema
+  # -- Maximum number or percentage of operator pods that may be unavailable.
+  # Mutually exclusive with `minAvailable`.
+  maxUnavailable: null
+  # @schema
+  # enum: ["", IfHealthyBudget, AlwaysAllow]
+  # @schema
+  # -- Policy for evicting unhealthy operator pods. An empty value uses the
+  # Kubernetes default (`IfHealthyBudget`).
+  unhealthyPodEvictionPolicy: ""
+
 monitoring:
 
   # -- Specifies whether the monitoring should be enabled. Requires Prometheus Operator CRDs.


### PR DESCRIPTION
## Summary

- add an opt-in `policy/v1` PodDisruptionBudget for the CloudNativePG operator Deployment
- support either `minAvailable` or `maxUnavailable` as a count or percentage, including zero
- expose `unhealthyPodEvictionPolicy` and validate its supported values
- preserve `namespaceOverride`, standard chart labels, and `commonAnnotations`
- regenerate the values schema and chart documentation

The chart currently does not create a disruption budget for the operator itself. This leaves operator replicas unprotected during voluntary disruptions such as node drains. The feature remains disabled by default for backward compatibility. When enabled, the default `minAvailable: 1` protects the default single-replica operator; users can scale the Deployment and tune the budget for their availability requirements.

This setting applies only to the operator Deployment. PodDisruptionBudgets for PostgreSQL clusters continue to be managed by CloudNativePG through the Cluster spec.

Closes #1003.
Supersedes #639 after its author invited a clean replacement based on current `main`.

## Validation

- `ct lint` 3.14.0 with Helm 4.2.4 and the repository CI arguments
- `helm lint` with Helm 4.2.4
- `helm-schema` 0.23.4 and `helm-docs` 1.14.2 regeneration
- `codespell`
- render coverage for disabled defaults, count and percentage budgets, `maxUnavailable: 0`, namespace and annotation overrides, and unhealthy-pod policy
- failure coverage for conflicting or missing availability fields, negative counts, invalid percentages, and invalid eviction policies

## AI assistance

OpenAI Codex assisted with this contribution. The commit includes the corresponding `Assisted-by` trailer in accordance with the project AI policy.