### PR TITLE
ci: add cert manager to renovate

### DIFF
--- a/.github/actions/deploy-cert-manager/action.yml
+++ b/.github/actions/deploy-cert-manager/action.yml
@@ -12,6 +12,8 @@ runs:
       shell: bash
       env:
         NAMESPACE: ${{ inputs.namespace }}
+        # renovate: datasource=helm depName=cert-manager registryUrl=https://charts.jetstack.io
+        CERT_MANAGER_VERSION: v1.21.1
       run: |
         helm repo add jetstack https://charts.jetstack.io
 
@@ -19,5 +21,5 @@ runs:
           cert-manager jetstack/cert-manager \
           --namespace $NAMESPACE \
           --create-namespace \
-          --version v1.18.2 \
+          --version $CERT_MANAGER_VERSION \
           --set crds.enabled=true

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -27,6 +27,20 @@
         '# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s+[A-Za-z0-9_]+?_VERSION\\s*\\??=\\s*["\']?(?<currentValue>.+?)["\']?\\s',
       ],
     },
+    {
+      customType: 'regex',
+      managerFilePatterns: [
+        '/^\\.github\\/actions\\/deploy-cert-manager\\/action\\.yml$/',
+        '/^charts\\/cluster\\/TESTING\\.md$/',
+      ],
+      matchStrings: [
+        '# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?) registryUrl=(?<registryUrl>[^\\s]+?)\\s+[A-Za-z0-9_]+?_VERSION: ["\']?(?<currentValue>[^"\'\\s]+)',
+        'jetstack\\/cert-manager[\\s\\S]*?--version (?<currentValue>v?\\d\\S*)'
+      ],
+      datasourceTemplate: 'helm',
+      depNameTemplate: 'cert-manager',
+      registryUrlTemplate: 'https://charts.jetstack.io',
+    },
   ],
   packageRules: [
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -22,24 +22,12 @@
       customType: 'regex',
       managerFilePatterns: [
         '/^Makefile$/',
-      ],
-      matchStrings: [
-        '# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s+[A-Za-z0-9_]+?_VERSION\\s*\\??=\\s*["\']?(?<currentValue>.+?)["\']?\\s',
-      ],
-    },
-    {
-      customType: 'regex',
-      managerFilePatterns: [
         '/^\\.github\\/actions\\/deploy-cert-manager\\/action\\.yml$/',
         '/^charts\\/cluster\\/TESTING\\.md$/',
       ],
       matchStrings: [
-        '# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?) registryUrl=(?<registryUrl>[^\\s]+?)\\s+[A-Za-z0-9_]+?_VERSION: ["\']?(?<currentValue>[^"\'\\s]+)',
-        'jetstack\\/cert-manager[\\s\\S]*?--version (?<currentValue>v?\\d\\S*)'
+        '# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s+[A-Za-z0-9_]+?_VERSION\\s*\\??[:=]\\s*["\']?(?<currentValue>[^"\'\\s]+)',
       ],
-      datasourceTemplate: 'helm',
-      depNameTemplate: 'cert-manager',
-      registryUrlTemplate: 'https://charts.jetstack.io',
     },
   ],
   packageRules: [

--- a/charts/cluster/TESTING.md
+++ b/charts/cluster/TESTING.md
@@ -35,12 +35,14 @@ We use a local kind cluster (minikube also works) and provision prerequisites su
 4. Install Cert-Manager and Barman plugin (optional, but required for backup/recovery tests).
 
     ```bash
+    # renovate: datasource=helm depName=cert-manager registryUrl=https://charts.jetstack.io
+    CERT_MANAGER_VERSION=v1.21.1
     helm repo add jetstack https://charts.jetstack.io
     helm install \
        cert-manager jetstack/cert-manager \
        --namespace cert-manager \
        --create-namespace \
-       --version v1.21.1 \
+       --version $CERT_MANAGER_VERSION \
        --set crds.enabled=true
     ```
     ```bash


### PR DESCRIPTION
`action.yml` had cert-manager pinned at `v1.18.2`, untracked by Renovate.
`charts/cluster/TESTING.md` was already bumped to `v1.21.1` by #1007, so the
two had drifted.

This syncs `action.yml` to `v1.21.1` and adds a Renovate custom manager for
both files, so future bumps stay in sync.

Closes #1009